### PR TITLE
Add specs for undercover-flagged coverage gaps

### DIFF
--- a/spec/bot/base_command_spec.rb
+++ b/spec/bot/base_command_spec.rb
@@ -43,6 +43,27 @@ RSpec.describe BaseCommand do
         expect(anonymous.registrable).to be(false)
       end
     end
+
+    context "owner-only commands" do
+      let(:klass) do
+        Class.new(described_class) do
+          command_name :secret
+          owner_only
+        end
+      end
+
+      it "carries the flag through to the registration" do
+        expect(klass.owner_only?).to be(true)
+        expect(klass.registration.owner_only).to be(true)
+      end
+    end
+  end
+
+  describe "#execute" do
+    it "is abstract" do
+      klass = Class.new(described_class) { command_name :probe }
+      expect { klass.new(double("event")).execute }.to raise_error(AbstractMethodError)
+    end
   end
 
   describe "#dispatch template" do
@@ -107,6 +128,61 @@ RSpec.describe BaseCommand do
         expect(OwnerNotifier).to receive(:report).with(hash_including(source: "command /probe"))
         expect(event).to receive(:respond).with(hash_including(ephemeral: true))
         expect { dispatch }.not_to raise_error
+      end
+    end
+
+    context "when the error reply itself fails (interaction expired)" do
+      subject(:dispatch) { klass.dispatch(event) }
+
+      let(:klass) { command_class { raise "boom" } }
+
+      it "swallows the secondary failure" do
+        allow(OwnerNotifier).to receive(:report)
+        allow(event).to receive(:respond).and_raise("interaction expired")
+        expect { dispatch }.not_to raise_error
+      end
+    end
+  end
+
+  describe "autocomplete dispatch" do
+    let(:event) { double("event", respond: nil, bot: double("bot")) }
+
+    context "when the command defines #autocomplete" do
+      let(:klass) do
+        Class.new(described_class) do
+          command_name :probe
+
+          def autocomplete
+            event.respond(choices: [{name: "a", value: "a"}])
+          end
+        end
+      end
+
+      it "runs it via .dispatch_autocomplete" do
+        expect(event).to receive(:respond).with(choices: [{name: "a", value: "a"}])
+        klass.dispatch_autocomplete(event)
+      end
+    end
+
+    context "when #autocomplete raises" do
+      let(:klass) do
+        Class.new(described_class) do
+          command_name :probe
+
+          def autocomplete
+            raise "boom"
+          end
+        end
+      end
+
+      it "clears the picker with empty choices instead of leaving it hanging" do
+        expect(event).to receive(:respond).with(choices: [])
+        expect { klass.dispatch_autocomplete(event) }.not_to raise_error
+      end
+
+      it "swallows a secondary failure while clearing the picker" do
+        allow(event).to receive(:respond).and_raise("interaction expired")
+        expect { klass.dispatch_autocomplete(event) }.not_to raise_error
       end
     end
   end

--- a/spec/bot/base_event_spec.rb
+++ b/spec/bot/base_event_spec.rb
@@ -32,4 +32,24 @@ RSpec.describe BaseEvent do
       expect(call).to be_nil
     end
   end
+
+  describe ".dispatch" do
+    let(:handled) { double("handle spy") }
+    let(:klass) do
+      spy = handled
+      event_class { spy.run }
+    end
+
+    it "instantiates the event class and runs #handle" do
+      expect(handled).to receive(:run)
+      klass.dispatch(event)
+    end
+  end
+
+  describe "#handle" do
+    it "is abstract" do
+      klass = Class.new(described_class)
+      expect { klass.new(event).handle }.to raise_error(AbstractMethodError)
+    end
+  end
 end

--- a/spec/bot/bot_config_spec.rb
+++ b/spec/bot/bot_config_spec.rb
@@ -1,6 +1,33 @@
 require "rails_helper"
 
 RSpec.describe BotConfig do
+  # Each reads straight from ENV; swap and restore so the suite stays isolated.
+  def with_env(key, value)
+    original = ENV[key]
+    ENV[key] = value
+    yield
+  ensure
+    ENV[key] = original
+  end
+
+  describe ".token" do
+    it "reads DISCORD_TOKEN from the environment" do
+      with_env("DISCORD_TOKEN", "tok-123") { expect(described_class.token).to eq("tok-123") }
+    end
+  end
+
+  describe ".owner_id" do
+    it "reads OWNER_ID from the environment" do
+      with_env("OWNER_ID", "9001") { expect(described_class.owner_id).to eq("9001") }
+    end
+  end
+
+  describe ".test_server_id" do
+    it "reads TEST_SERVER_ID from the environment" do
+      with_env("TEST_SERVER_ID", "42") { expect(described_class.test_server_id).to eq("42") }
+    end
+  end
+
   describe ".rest_token" do
     subject(:rest_token) { described_class.rest_token }
 

--- a/spec/bot/commands/ping_spec.rb
+++ b/spec/bot/commands/ping_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe Commands::Ping do
+  it "replies with an ephemeral pong" do
+    event = double("event", respond: nil)
+    expect(event).to receive(:respond).with(hash_including(content: a_string_including("pong"), ephemeral: true))
+    described_class.new(event).execute
+  end
+end

--- a/spec/models/plugin_catalog_spec.rb
+++ b/spec/models/plugin_catalog_spec.rb
@@ -1,6 +1,12 @@
 require "rails_helper"
 
 RSpec.describe PluginCatalog do
+  describe ".all" do
+    it "returns every definition" do
+      expect(described_class.all).to eq(PluginCatalog::DEFINITIONS)
+    end
+  end
+
   describe ".find" do
     it "looks a definition up by key" do
       expect(described_class.find(:logging).name).to eq("Logging")

--- a/spec/models/plugin_spec.rb
+++ b/spec/models/plugin_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe Plugin do
+  describe "#key" do
+    it "exposes the stored key as a symbol" do
+      expect(create(:plugin, key: "logging").key).to eq(:logging)
+    end
+
+    it "is nil when the key is unset" do
+      expect(described_class.new.key).to be_nil
+    end
+  end
+end

--- a/spec/operations/server_configuration/ensure_spec.rb
+++ b/spec/operations/server_configuration/ensure_spec.rb
@@ -18,6 +18,15 @@ RSpec.describe Ops::ServerConfiguration::Ensure do
     expect(activations.find_by(plugins: {key: "welcomes"}).enabled).to be(false)
   end
 
+  context "when a concurrent insert wins the race" do
+    it "returns the already-created configuration instead of raising" do
+      existing = create(:server_configuration, discord_id:)
+      allow(ServerConfiguration).to receive(:find_or_create_by!).and_raise(ActiveRecord::RecordNotUnique)
+
+      expect(result.value).to eq(existing)
+    end
+  end
+
   context "when the configuration already exists with a manually toggled activation" do
     let(:config) { described_class.call(discord_id:).value }
 

--- a/spec/plugins/reminders/commands/remind_spec.rb
+++ b/spec/plugins/reminders/commands/remind_spec.rb
@@ -39,4 +39,17 @@ RSpec.describe Reminders::Remind do
       execute
     end
   end
+
+  describe "command options" do
+    it "declares the duration, message, and deliver inputs" do
+      opts = double("options")
+      allow(opts).to receive(:string)
+
+      described_class.registration.options_block.call(opts)
+
+      expect(opts).to have_received(:string).with("duration", anything, hash_including(required: true))
+      expect(opts).to have_received(:string).with("message", anything, hash_including(required: true))
+      expect(opts).to have_received(:string).with("deliver", anything, hash_including(required: false, choices: anything))
+    end
+  end
 end

--- a/spec/plugins/reminders/commands/unremind_spec.rb
+++ b/spec/plugins/reminders/commands/unremind_spec.rb
@@ -12,6 +12,24 @@ RSpec.describe Reminders::Unremind do
       expect(event).to receive(:respond).with(hash_including(content: a_string_including("cancelled")))
       execute
     end
+
+    it "surfaces the failure message when the cancellation is rejected" do
+      allow(Ops::Reminders::Delete).to receive(:call)
+        .and_return(Ops::ApplicationOperation::Result.new(false, nil, ["not your reminder"]))
+      expect(event).to receive(:respond).with(hash_including(content: a_string_including("not your reminder")))
+      execute
+    end
+  end
+
+  describe "command options" do
+    it "declares an autocompleted reminder input" do
+      opts = double("options")
+      allow(opts).to receive(:string)
+
+      described_class.registration.options_block.call(opts)
+
+      expect(opts).to have_received(:string).with("reminder", anything, hash_including(required: true, autocomplete: true))
+    end
   end
 
   describe "#autocomplete" do

--- a/spec/plugins/reminders/deliver_job_spec.rb
+++ b/spec/plugins/reminders/deliver_job_spec.rb
@@ -29,6 +29,17 @@ RSpec.describe Reminders::DeliverJob do
     end
   end
 
+  context "when the reminder has no server (DM-origin) and no DM flag" do
+    let(:reminder) do
+      create(:reminder, user_id: 10, channel_id: 20, server_id: nil, remind_at: 1.minute.ago, message: "hello")
+    end
+
+    it "delivers to the original channel" do
+      expect(Discordrb::API::Channel).to receive(:create_message).with("Bot tok", 20, anything)
+      perform
+    end
+  end
+
   context "when the user requested DM delivery" do
     before do
       reminder.update!(deliver_via_dm: true)

--- a/spec/plugins/roles/custom_id_spec.rb
+++ b/spec/plugins/roles/custom_id_spec.rb
@@ -18,4 +18,8 @@ RSpec.describe Roles::CustomId do
     expect(described_class.parse(described_class.select(set)))
       .to eq(action: :select, set_id: "rst_abc123", role_id: nil)
   end
+
+  it "yields a nil action for an id with no action segment" do
+    expect(described_class.parse("roles")).to eq(action: nil, set_id: nil, role_id: nil)
+  end
 end

--- a/spec/plugins/roles/message_poster_spec.rb
+++ b/spec/plugins/roles/message_poster_spec.rb
@@ -50,6 +50,30 @@ RSpec.describe Roles::MessagePoster do
     end
   end
 
+  context "when the stored message has since been deleted" do
+    let(:set) { create(:role_set, role_setting: setting, message_id: 111) }
+
+    before do
+      allow(bot).to receive(:channel).with(555).and_return(channel)
+      allow(channel).to receive(:load_message).with(111).and_return(nil)
+    end
+
+    it "skips the edit without raising" do
+      expect { post }.not_to raise_error
+    end
+  end
+
+  context "when the bot can't resolve the channel" do
+    let(:set) { create(:role_set, role_setting: setting, channel_override: nil, message_id: nil) }
+
+    before { allow(bot).to receive(:channel).with(555).and_return(nil) }
+
+    it "does nothing" do
+      post
+      expect(set.reload.message_id).to be_nil
+    end
+  end
+
   context "when there is no channel to post in" do
     let(:setting) { create(:role_setting, channel_id: nil) }
     let(:set) { create(:role_set, role_setting: setting, channel_override: nil) }

--- a/spec/plugins/welcomes/events/member_leave_spec.rb
+++ b/spec/plugins/welcomes/events/member_leave_spec.rb
@@ -27,4 +27,13 @@ RSpec.describe Welcomes::MemberLeave do
       handle
     end
   end
+
+  context "when the plugin isn't configured for the server" do
+    let(:setting) { nil }
+
+    it "does nothing" do
+      expect(bot).not_to receive(:send_message)
+      handle
+    end
+  end
 end


### PR DESCRIPTION
## What

Closes the changed-line coverage gaps `undercover` reports on #35. The gate compares against `main`, but `rewrite/ruby-rails` is a full rewrite, so every untested method shows up as flagged. This adds the missing specs so the gate passes against the rewrite.

Targets `rewrite/ruby-rails`, not `main`.

## Coverage added

- **`BaseCommand`** — abstract `#execute`, `owner_only` macro, `.dispatch_autocomplete` (success + raise + secondary-failure), and the `respond_error` rescue when the interaction has expired.
- **`BaseEvent`** — `.dispatch` and abstract `#handle`.
- **`BotConfig`** — `.token`, `.owner_id`, `.test_server_id` env readers.
- **`Commands::Ping`** — new spec.
- **`Plugin#key`** — nil-key branch (new spec).
- **`PluginCatalog.all`**.
- **`Ops::ServerConfiguration::Ensure`** — the `RecordNotUnique` concurrent-insert rescue.
- **Reminders** — `remind`/`unremind` option blocks, `unremind` failure branch, `DeliverJob` no-server (DM-origin) delivery branch.
- **`Roles::CustomId`** — nil-action parse.
- **`Roles::MessagePoster`** — unresolved channel and stale-message (`load_message` nil) paths.
- **`Welcomes::MemberLeave`** — unconfigured server (nil setting).

## Verification

Reproduced the coverage report locally from SimpleCov's resultset: all 13 flagged files now have zero uncovered lines/branches. Suite: 248 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)