### PR TITLE
Pre-create plugin settings rows so they always exist

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -47,6 +47,8 @@ USER dev
 RUN mkdir -p /home/dev/.claude /home/dev/.local/state/claude /home/dev/.local/share/claude \
   && rtk init -g
 
+RUN bundle install
+
 RUN ruby --version \
   && gh --version \
   && claude --version \

--- a/app/operations/logging/settings/update.rb
+++ b/app/operations/logging/settings/update.rb
@@ -7,7 +7,7 @@ module Ops
         def call
           return failure("A channel is required.") if channel_id.blank?
 
-          setting = server_configuration.logging_setting || server_configuration.build_logging_setting
+          setting = server_configuration.logging_setting
           setting.update!(channel_id: channel_id)
           ok(setting, warnings: visibility_warnings)
         end

--- a/app/operations/roles/sets/create.rb
+++ b/app/operations/roles/sets/create.rb
@@ -6,7 +6,7 @@ module Ops
         receives :channel_override, optional: true
 
         def call
-          setting = server_configuration.role_setting || server_configuration.create_role_setting!
+          setting = server_configuration.role_setting
           set = setting.role_sets.create!(
             name: name,
             selection_mode: selection_mode,

--- a/app/operations/roles/settings/update.rb
+++ b/app/operations/roles/settings/update.rb
@@ -5,7 +5,7 @@ module Ops
         receives :server_configuration, :channel_id, :notify_on_assign, :log_on_assign
 
         def call
-          setting = server_configuration.role_setting || server_configuration.build_role_setting
+          setting = server_configuration.role_setting
           setting.update!(channel_id: channel_id, notify_on_assign: notify_on_assign, log_on_assign: log_on_assign)
           ok(setting)
         end

--- a/app/operations/server_configuration/ensure.rb
+++ b/app/operations/server_configuration/ensure.rb
@@ -9,6 +9,7 @@ module Ops
         config = transaction do
           sc = ::ServerConfiguration.find_or_create_by!(discord_id: discord_id)
           ensure_activations(sc)
+          ensure_settings(sc)
           sc
         end
         ok(config)
@@ -22,6 +23,12 @@ module Ops
         Plugin.find_each do |plugin|
           PluginActivation.find_or_create_by!(server_configuration: config, plugin:) { |a| a.enabled = false }
         end
+      end
+
+      def ensure_settings(config)
+        config.logging_setting || config.create_logging_setting!
+        config.role_setting || config.create_role_setting!
+        config.welcome_settings || config.create_welcome_settings!
       end
     end
   end

--- a/app/operations/welcomes/settings/update.rb
+++ b/app/operations/welcomes/settings/update.rb
@@ -5,7 +5,7 @@ module Ops
         receives :server_configuration, :channel_id, :join_message, :leave_message
 
         def call
-          setting = server_configuration.welcome_settings || server_configuration.build_welcome_settings
+          setting = server_configuration.welcome_settings
           setting.update!(channel_id: channel_id, join_message: join_message, leave_message: leave_message)
           ok(setting)
         end

--- a/docs/adding-a-plugin.md
+++ b/docs/adding-a-plugin.md
@@ -37,6 +37,19 @@ Wire the association on `ServerConfiguration` with explicit `class_name` (and
 default — see [architecture.md](architecture.md#primary-keys). Mirror model
 validations with DB constraints (CI enforces this via `active_record_doctor`).
 
+Keep every column nullable or defaulted, then add a line to
+`Ops::ServerConfiguration::Ensure#ensure_settings` so the row is pre-created for
+every server:
+
+```ruby
+config.welcome_settings || config.create_welcome_settings!
+```
+
+This upholds the invariant that a server's settings rows always exist (see
+[architecture.md](architecture.md#server-onboarding)), so operations update the row
+directly instead of build-or-update. Forgetting this line means the plugin's
+settings operations hit `nil` for servers onboarded before the line was added.
+
 ## 3. Register in the catalog
 
 Add a `Definition` to `PluginCatalog` (`app/models/plugin_catalog.rb`) — the single

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -202,6 +202,12 @@ GUILD_CREATE handler returns before raising the event when `unavailable` is `fal
 unique `discord_id` index), so both triggers can call it freely. Activation rows seed
 disabled; the admin enables plugins via the web UI, which enforces prerequisites.
 
+Ensure also creates each plugin's settings row (empty — all columns are nullable or
+defaulted). This establishes the invariant that **a server's config and its plugin
+settings rows always exist**, so settings operations can update the row directly
+instead of build-or-update. (Event handlers reading config for an arbitrary guild
+still guard against a nil config — a server seen before its Ensure has run.)
+
 ## Sharding
 
 Static only (`SHARD_COUNT`, floored at 1). discordrb is one shard per `Bot` instance,

--- a/spec/operations/logging/settings/update_spec.rb
+++ b/spec/operations/logging/settings/update_spec.rb
@@ -4,21 +4,35 @@ RSpec.describe Ops::Logging::Settings::Update do
   subject(:result) { described_class.call(server_configuration: server, channel_id:) }
 
   let(:server) { create(:server_configuration, discord_id: 1) }
+  let!(:setting) { server.create_logging_setting! }
   let(:channel_id) { 555 }
+
+  context "with a channel" do
+    it "sets the channel" do
+      expect(result.success?).to be(true)
+      expect(setting.reload.channel_id).to eq(555)
+    end
+  end
 
   context "without a channel" do
     let(:channel_id) { nil }
 
-    it "fails and creates no setting" do
+    it "fails and leaves the channel unset" do
       expect(result.failure?).to be(true)
-      expect(server.reload.logging_setting).to be_nil
+      expect(setting.reload.channel_id).to be_nil
     end
   end
 
-  context "with a channel" do
-    it "creates the logging setting" do
-      expect(result.success?).to be(true)
-      expect(server.reload.logging_setting.channel_id).to eq(555)
+  context "updating an already-set channel" do
+    before do
+      setting.update!(channel_id: 111)
+    end
+
+    let(:channel_id) { 222 }
+
+    it "updates it" do
+      result
+      expect(setting.reload.channel_id).to eq(222)
     end
   end
 
@@ -42,19 +56,6 @@ RSpec.describe Ops::Logging::Settings::Update do
 
     it "saves with no warning" do
       expect(result.warnings).to be_empty
-    end
-  end
-
-  context "with an existing setting" do
-    before do
-      server.create_logging_setting!(channel_id: 111)
-    end
-
-    let(:channel_id) { 222 }
-
-    it "updates it" do
-      result
-      expect(server.reload.logging_setting.channel_id).to eq(222)
     end
   end
 end

--- a/spec/operations/roles/sets/create_spec.rb
+++ b/spec/operations/roles/sets/create_spec.rb
@@ -4,16 +4,15 @@ RSpec.describe Ops::Roles::Sets::Create do
   subject(:result) { described_class.call(server_configuration: server, name: "Games", selection_mode: "multi") }
 
   let(:server) { create(:server_configuration) }
+  let!(:setting) { server.create_role_setting! }
 
-  it "creates a set, auto-creating the role settings if absent" do
+  it "creates a set under the role settings" do
     expect(result.success?).to be(true)
     expect(result.value).to have_attributes(name: "Games", selection_mode: "multi", position: 0)
-    expect(server.reload.role_setting.role_sets.count).to eq(1)
+    expect(setting.reload.role_sets.count).to eq(1)
   end
 
   context "when a set already exists" do
-    let(:setting) { create(:role_setting, server_configuration: server) }
-
     before do
       create(:role_set, role_setting: setting, position: 0)
     end

--- a/spec/operations/roles/settings/update_spec.rb
+++ b/spec/operations/roles/settings/update_spec.rb
@@ -6,21 +6,22 @@ RSpec.describe Ops::Roles::Settings::Update do
   end
 
   let(:server) { create(:server_configuration) }
+  let!(:setting) { server.create_role_setting! }
   let(:channel_id) { 99 }
 
-  it "creates the role settings" do
+  it "sets the role settings" do
     expect(result.success?).to be(true)
-    expect(server.reload.role_setting).to have_attributes(channel_id: 99, notify_on_assign: true, log_on_assign: false)
+    expect(setting.reload).to have_attributes(channel_id: 99, notify_on_assign: true, log_on_assign: false)
   end
 
-  context "with existing settings" do
+  context "updating existing values" do
     before do
-      server.create_role_setting!(channel_id: 1, notify_on_assign: false)
+      setting.update!(channel_id: 1, notify_on_assign: false)
     end
 
     it "updates them in place" do
       result
-      expect(server.reload.role_setting.channel_id).to eq(99)
+      expect(setting.reload.channel_id).to eq(99)
     end
   end
 end

--- a/spec/operations/server_configuration/ensure_spec.rb
+++ b/spec/operations/server_configuration/ensure_spec.rb
@@ -18,6 +18,14 @@ RSpec.describe Ops::ServerConfiguration::Ensure do
     expect(activations.find_by(plugins: {key: "welcomes"}).enabled).to be(false)
   end
 
+  it "creates the plugin settings rows so they always exist" do
+    config = result.value
+
+    expect(config.logging_setting).to be_present
+    expect(config.role_setting).to be_present
+    expect(config.welcome_settings).to be_present
+  end
+
   context "when a concurrent insert wins the race" do
     it "returns the already-created configuration instead of raising" do
       existing = create(:server_configuration, discord_id:)
@@ -31,7 +39,7 @@ RSpec.describe Ops::ServerConfiguration::Ensure do
     let(:config) { described_class.call(discord_id:).value }
 
     before do
-      config.create_welcome_settings!(channel_id: 42)
+      config.welcome_settings.update!(channel_id: 42)
       config.plugin_activations.find_by(plugin: welcomes).update!(enabled: true)
     end
 

--- a/spec/operations/welcomes/settings/update_spec.rb
+++ b/spec/operations/welcomes/settings/update_spec.rb
@@ -6,30 +6,31 @@ RSpec.describe Ops::Welcomes::Settings::Update do
   end
 
   let(:server) { create(:server_configuration, discord_id: 1) }
+  let!(:setting) { server.create_welcome_settings! }
   let(:channel_id) { 99 }
   let(:join_message) { "hi" }
   let(:leave_message) { "bye" }
 
-  it "creates the welcome settings with channel and messages" do
+  it "sets the channel and messages" do
     expect(result.success?).to be(true)
-    setting = server.reload.welcome_settings
+    setting.reload
     expect(setting.channel_id).to eq(99)
     expect(setting.join_message).to eq("hi")
     expect(setting.leave_message).to eq("bye")
   end
 
-  context "with existing settings" do
+  context "updating existing values" do
     before do
-      server.create_welcome_settings!(channel_id: 1, join_message: "old")
+      setting.update!(channel_id: 1, join_message: "old")
     end
 
     let(:channel_id) { 2 }
     let(:join_message) { "new" }
     let(:leave_message) { nil }
 
-    it "updates them" do
+    it "overwrites them" do
       result
-      setting = server.reload.welcome_settings
+      setting.reload
       expect(setting.channel_id).to eq(2)
       expect(setting.join_message).to eq("new")
       expect(setting.leave_message).to be_nil
@@ -42,7 +43,7 @@ RSpec.describe Ops::Welcomes::Settings::Update do
 
     it "still saves (a channel is required only to enable)" do
       expect(result.success?).to be(true)
-      expect(server.reload.welcome_settings.channel_id).to be_nil
+      expect(setting.reload.channel_id).to be_nil
     end
   end
 end


### PR DESCRIPTION
First half of the settings/onboarding chunk (review plan item 3, **A3**). Establishes the invariant that a server's config **and** its plugin settings rows always exist, so operations stop doing build-or-update.

### Change
- `Ops::ServerConfiguration::Ensure` now creates each plugin's settings row (`logging_setting`, `role_setting`, `welcome_settings`) alongside the activation rows. The rows are empty — every column is nullable or defaulted, so an empty row is valid — and creation is idempotent (skips rows that already exist).
- The settings operations drop their `|| build_*` / `|| create_*` fallbacks and update the row directly: `Ops::Logging::Settings::Update`, `Ops::Welcomes::Settings::Update`, `Ops::Roles::Settings::Update`, `Ops::Roles::Sets::Create`.
- Invariant documented in `docs/architecture.md`.

### Notes
- Event handlers reading config for an arbitrary guild still guard against a nil **config** (a server seen before its Ensure has run) — that guard stays; only the redundant settings-row build is removed. `Welcomes::Settings.active_for` already accesses `welcome_settings` without a nil-guard, so it needs no change.
- The `default_enabled` removal + the onboarding-DM flow (the **H4** half) are a separate chunk — the onboarding DM has an open question (it points at a website that doesn't exist until the web phases) I'll raise before building it.

### Checks
`bundle exec rspec` → 258 examples, 0 failures. `zeitwerk:check`, `standardrb`, `active_record_doctor` all clean.