### PR TITLE
Onboard every server once with a welcome DM

### DIFF
--- a/app/bot/guild_metadata.rb
+++ b/app/bot/guild_metadata.rb
@@ -6,6 +6,7 @@ module GuildMetadata
     Ops::ServerConfiguration::ServerChannels::Sync.call(server_configuration: config, channels: channels(server))
     Ops::ServerConfiguration::ServerRoles::Sync.call(server_configuration: config, roles: roles(server))
     Ops::ServerConfiguration::Channels::Reconcile.call(server_configuration: config, bot: bot)
+    ServerOnboarder.notify(bot, server, config)
     config
   end
 

--- a/app/bot/server_onboarder.rb
+++ b/app/bot/server_onboarder.rb
@@ -1,0 +1,18 @@
+module ServerOnboarder
+  WELCOME_MESSAGE = <<~MSG.strip
+    👋 Thanks for adding shrkbot!
+
+    shrkbot is configured through a web dashboard — setup details are on the way.
+  MSG
+
+  module_function
+
+  def notify(bot, server, config)
+    return if config.onboarded_at?
+
+    bot.pm_channel(server.owner.id).send_message(WELCOME_MESSAGE)
+    config.update!(onboarded_at: Time.current)
+  rescue => e
+    Rails.logger.error("[ServerOnboarder] could not onboard server #{server.id}: #{e.class}: #{e.message}")
+  end
+end

--- a/app/models/plugin_catalog.rb
+++ b/app/models/plugin_catalog.rb
@@ -1,5 +1,5 @@
 class PluginCatalog
-  Definition = Data.define(:key, :name, :description, :default_enabled, :channel_setting) do
+  Definition = Data.define(:key, :name, :description, :channel_setting) do
     def channel_backed?
       !channel_setting.nil?
     end
@@ -12,9 +12,9 @@ class PluginCatalog
   end
 
   DEFINITIONS = [
-    Definition.new(key: :logging, name: "Logging", description: "Writes moderation actions to a log channel.", default_enabled: true, channel_setting: :logging_setting),
-    Definition.new(key: :roles, name: "Roles", description: "Self-assignable roles.", default_enabled: false, channel_setting: :role_setting),
-    Definition.new(key: :welcomes, name: "Welcomes", description: "Join and leave messages.", default_enabled: false, channel_setting: :welcome_settings)
+    Definition.new(key: :logging, name: "Logging", description: "Writes moderation actions to a log channel.", channel_setting: :logging_setting),
+    Definition.new(key: :roles, name: "Roles", description: "Self-assignable roles.", channel_setting: :role_setting),
+    Definition.new(key: :welcomes, name: "Welcomes", description: "Join and leave messages.", channel_setting: :welcome_settings)
   ].freeze
 
   def self.all

--- a/db/migrate/20260619120000_remove_plugin_default_enabled.rb
+++ b/db/migrate/20260619120000_remove_plugin_default_enabled.rb
@@ -1,0 +1,5 @@
+class RemovePluginDefaultEnabled < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :plugins, :default_enabled, :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20260619120001_add_onboarded_at_to_server_configurations.rb
+++ b/db/migrate/20260619120001_add_onboarded_at_to_server_configurations.rb
@@ -1,0 +1,5 @@
+class AddOnboardedAtToServerConfigurations < ActiveRecord::Migration[8.1]
+  def change
+    add_column :server_configurations, :onboarded_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_17_210000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_19_120001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -66,7 +66,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_17_210000) do
 
   create_table "plugins", id: :string, default: -> { "('plg_'::text || gen_random_uuid())" }, force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.boolean "default_enabled", default: false, null: false
     t.text "description"
     t.string "key", null: false
     t.string "name", null: false
@@ -124,6 +123,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_17_210000) do
     t.datetime "created_at", null: false
     t.bigint "discord_id", null: false
     t.boolean "force_dm_reminders", default: false, null: false
+    t.datetime "onboarded_at"
     t.datetime "updated_at", null: false
     t.index ["discord_id"], name: "index_server_configurations_on_discord_id", unique: true
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,4 @@
 PluginCatalog.all.each do |definition|
   plugin = Plugin.find_or_initialize_by(key: definition.key)
-  plugin.update!(name: definition.name, description: definition.description, default_enabled: definition.default_enabled)
+  plugin.update!(name: definition.name, description: definition.description)
 end

--- a/docs/adding-a-plugin.md
+++ b/docs/adding-a-plugin.md
@@ -60,7 +60,6 @@ Definition.new(
   key: :welcomes,
   name: "Welcomes",
   description: "Join and leave messages.",   # user-facing; reused on the website
-  default_enabled: false,
   channel_setting: :welcome_settings          # the assoc holding channel_id; nil if not channel-backed
 )
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,8 +89,8 @@ and validations (e.g. the @everyone-visibility check on a logging channel).
 ### Plugin catalog and activation
 
 `PluginCatalog` (`app/models/plugin_catalog.rb`) is the single source of plugin
-metadata — a frozen list of `Definition`s (key, name, description, default_enabled,
-channel_setting). Don't hardcode the plugin list anywhere else. It drives the
+metadata — a frozen list of `Definition`s (key, name, description, channel_setting).
+Don't hardcode the plugin list anywhere else. It drives the
 `db:seed` of the `Plugin` table, prerequisite checks, and the channel-backed registry.
 
 `Plugin#key` is exposed as a **symbol** (stored as text); call sites read `:welcomes`.
@@ -207,6 +207,15 @@ defaulted). This establishes the invariant that **a server's config and its plug
 settings rows always exist**, so settings operations can update the row directly
 instead of build-or-update. (Event handlers reading config for an arbitrary guild
 still guard against a nil config — a server seen before its Ensure has run.)
+
+`GuildMetadata.sync` then calls `ServerOnboarder.notify`, which DMs the guild owner a
+welcome once and stamps `ServerConfiguration#onboarded_at`. Because it runs inside the
+shared sync path, it fires from both triggers — so every server is onboarded exactly
+once, including servers that were already present when the rewrite first goes live
+(the `:ready` sweep). The `onboarded_at` stamp is what keeps it once-per-server rather
+than once-per-boot, and a send failure (owner blocks DMs) is swallowed and left
+un-stamped so a later boot retries. The welcome copy is a placeholder until the config
+website ships, when it gains the real setup link.
 
 ## Sharding
 

--- a/spec/bot/guild_metadata_spec.rb
+++ b/spec/bot/guild_metadata_spec.rb
@@ -42,12 +42,21 @@ RSpec.describe GuildMetadata do
     before do
       allow(Ops::ServerConfiguration::Ensure).to receive(:call)
         .with(discord_id: 77).and_return(double(value: config))
+      allow(ServerOnboarder).to receive(:notify)
     end
 
     it "ensures the config, then syncs channels and roles, then reconciles deletions" do
       expect(Ops::ServerConfiguration::ServerChannels::Sync).to receive(:call).with(server_configuration: config, channels: [])
       expect(Ops::ServerConfiguration::ServerRoles::Sync).to receive(:call).with(server_configuration: config, roles: [])
       expect(Ops::ServerConfiguration::Channels::Reconcile).to receive(:call).with(server_configuration: config, bot:)
+      sync
+    end
+
+    it "onboards the server" do
+      allow(Ops::ServerConfiguration::ServerChannels::Sync).to receive(:call)
+      allow(Ops::ServerConfiguration::ServerRoles::Sync).to receive(:call)
+      allow(Ops::ServerConfiguration::Channels::Reconcile).to receive(:call)
+      expect(ServerOnboarder).to receive(:notify).with(bot, server, config)
       sync
     end
 

--- a/spec/bot/server_onboarder_spec.rb
+++ b/spec/bot/server_onboarder_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe ServerOnboarder do
+  subject(:notify) { described_class.notify(bot, server, config) }
+
+  let(:config) { create(:server_configuration) }
+  let(:owner) { double("owner", id: 999) }
+  let(:server) { double("server", id: 77, owner:) }
+  let(:pm_channel) { double("pm_channel", send_message: nil) }
+  let(:bot) { double("bot", pm_channel: pm_channel) }
+
+  context "when the server has not been onboarded" do
+    it "DMs the guild owner the welcome message" do
+      expect(bot).to receive(:pm_channel).with(999).and_return(pm_channel)
+      expect(pm_channel).to receive(:send_message).with(described_class::WELCOME_MESSAGE)
+      notify
+    end
+
+    it "records when the server was onboarded" do
+      expect { notify }.to change { config.reload.onboarded_at }.from(nil)
+    end
+  end
+
+  context "when the server has already been onboarded" do
+    before do
+      config.update!(onboarded_at: 1.day.ago)
+    end
+
+    it "does not DM the owner again" do
+      expect(bot).not_to receive(:pm_channel)
+      notify
+    end
+
+    it "leaves the timestamp untouched" do
+      expect { notify }.not_to change { config.reload.onboarded_at }
+    end
+  end
+
+  context "when the owner cannot be DMed" do
+    before do
+      allow(bot).to receive(:pm_channel).and_raise(StandardError, "Cannot send messages to this user")
+    end
+
+    it "swallows the error and leaves the server un-onboarded" do
+      expect { notify }.not_to change { config.reload.onboarded_at }
+    end
+  end
+end

--- a/spec/models/plugin_catalog_spec.rb
+++ b/spec/models/plugin_catalog_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe PluginCatalog do
 
   describe PluginCatalog::Definition do
     def definition(channel_setting:)
-      described_class.new(key: :x, name: "X", description: "", default_enabled: false, channel_setting:)
+      described_class.new(key: :x, name: "X", description: "", channel_setting:)
     end
 
     context "when not channel-backed" do

--- a/spec/operations/server_configuration/ensure_spec.rb
+++ b/spec/operations/server_configuration/ensure_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe Ops::ServerConfiguration::Ensure do
   subject(:result) { described_class.call(discord_id:) }
 
   let(:discord_id) { 42 }
-  let!(:logging) { create(:plugin, key: "logging", name: "Logging", default_enabled: true) }
-  let!(:welcomes) { create(:plugin, key: "welcomes", name: "Welcomes", default_enabled: false) }
+  let!(:logging) { create(:plugin, key: "logging", name: "Logging") }
+  let!(:welcomes) { create(:plugin, key: "welcomes", name: "Welcomes") }
 
   it "creates a server configuration when none exists" do
     expect { result }.to change { ServerConfiguration.where(discord_id:).count }.from(0).to(1)
   end
 
-  it "seeds an activation per plugin, all disabled (regardless of default_enabled)" do
+  it "seeds an activation per plugin, all disabled" do
     activations = result.value.plugin_activations.joins(:plugin)
 
     expect(activations.find_by(plugins: {key: "logging"}).enabled).to be(false)


### PR DESCRIPTION
Continues review-plans item 3 (H4). Builds on #42 (settings always exist).

## What

- **Drop `default_enabled`** — vestigial since `Ops::ServerConfiguration::Ensure` seeds every activation disabled regardless. Removes the column, the `PluginCatalog::Definition` field, and the seed/spec references.
- **Onboarding DM infra** — new `ServerConfiguration#onboarded_at` + `ServerOnboarder` (bot-layer notifier, mirrors `OwnerNotifier`). `GuildMetadata.sync` DMs the guild owner a welcome once and stamps `onboarded_at`.

## Onboarding semantics

Fires from the shared sync path, so both `ServerSetup` (live `:server_create`) **and** `ServerBackfill` (`:ready` sweep) trigger it. Result: **every server is onboarded exactly once** — including servers already present when the rewrite first goes live (caught by the ready sweep). `onboarded_at` is what makes it once-per-server rather than once-per-boot; a send failure (owner blocks DMs) is swallowed and left un-stamped so a later boot retries.

The welcome copy is a **placeholder** — the bot won't deploy until the config website is ready, at which point Phase 7 swaps in the real setup link.

## Tests

`server_onboarder_spec` (DM-once / already-onboarded / send-failure), updated `guild_metadata_spec`, `server_setup_spec` unchanged. 264 examples green; standardrb + active_record_doctor clean.