### PR TITLE
Roles self-assignment component handlers

### DIFF
--- a/.active_record_doctor.rb
+++ b/.active_record_doctor.rb
@@ -39,11 +39,9 @@ ActiveRecordDoctor.configure do
   detector :missing_presence_validation,
     ignore_columns_with_default: true,
     ignore_attributes: [
-      "Plugin.default_enabled",
       "PluginActivation.enabled",
       "Reminders::Reminder.deliver_via_dm",
       "Roles::Settings.log_on_assign",
-      "Roles::Settings.notify_on_assign",
       "ServerConfiguration.force_dm_reminders"
     ]
 end

--- a/app/bot/base_event.rb
+++ b/app/bot/base_event.rb
@@ -2,13 +2,20 @@ class BaseEvent
   include WithConnection
 
   class << self
-    def on(*values)
-      @discord_events = values if values.any?
+    def on(*values, **attributes)
+      if values.any?
+        @discord_events = values
+        @event_attributes = attributes
+      end
       @discord_events ||= []
     end
 
     def discord_events
       on
+    end
+
+    def event_attributes
+      @event_attributes ||= {}
     end
 
     def dispatch(event)

--- a/app/bot/event_registrar.rb
+++ b/app/bot/event_registrar.rb
@@ -9,7 +9,11 @@ class EventRegistrar
   def register_all
     events.each do |klass|
       klass.discord_events.each do |discord_event|
-        bot.public_send(discord_event) { |event| klass.dispatch(event) }
+        if klass.event_attributes.empty?
+          bot.public_send(discord_event) { |event| klass.dispatch(event) }
+        else
+          bot.public_send(discord_event, klass.event_attributes) { |event| klass.dispatch(event) }
+        end
       end
     end
   end

--- a/app/operations/roles/assignable_roles/add.rb
+++ b/app/operations/roles/assignable_roles/add.rb
@@ -2,14 +2,13 @@ module Ops
   module Roles
     module AssignableRoles
       class Add < ApplicationOperation
-        receives :role_set, :role_id, :label
+        receives :role_set, :role_id
         receives :description, optional: true
         receives :emoji, optional: true
 
         def call
           role = role_set.assignable_roles.create!(
             role_id: role_id,
-            label: label,
             description: description,
             emoji: emoji,
             position: next_position

--- a/app/operations/roles/settings/update.rb
+++ b/app/operations/roles/settings/update.rb
@@ -2,11 +2,11 @@ module Ops
   module Roles
     module Settings
       class Update < ApplicationOperation
-        receives :server_configuration, :channel_id, :notify_on_assign, :log_on_assign
+        receives :server_configuration, :channel_id, :log_on_assign
 
         def call
           setting = server_configuration.role_setting
-          setting.update!(channel_id: channel_id, notify_on_assign: notify_on_assign, log_on_assign: log_on_assign)
+          setting.update!(channel_id: channel_id, log_on_assign: log_on_assign)
           ok(setting)
         end
       end

--- a/app/plugins/roles/assignment.rb
+++ b/app/plugins/roles/assignment.rb
@@ -1,0 +1,14 @@
+module Roles
+  module Assignment
+    module_function
+
+    def single(set_role_ids, picked_id)
+      {add: [picked_id], remove: set_role_ids - [picked_id]}
+    end
+
+    def multi(set_role_ids, selected_ids)
+      desired = selected_ids & set_role_ids
+      {add: desired, remove: set_role_ids - desired}
+    end
+  end
+end

--- a/app/plugins/roles/events/component_handler.rb
+++ b/app/plugins/roles/events/component_handler.rb
@@ -21,7 +21,7 @@ module Roles
     end
 
     def update(picker)
-      event.update_message(content: picker[:content], components: picker[:components])
+      event.update_message(components: picker[:components], has_components: true)
     end
   end
 end

--- a/app/plugins/roles/events/component_handler.rb
+++ b/app/plugins/roles/events/component_handler.rb
@@ -1,0 +1,36 @@
+module Roles
+  class ComponentHandler < BaseEvent
+    private
+
+    def set
+      @set ||= Set.find_by(id: CustomId.parse(event.custom_id)[:set_id])
+    end
+
+    def member
+      return @member if defined?(@member)
+
+      @member = event.server&.member(event.user.id)
+    end
+
+    def set_role_ids
+      set.assignable_roles.map(&:role_id)
+    end
+
+    def apply(diff, active)
+      member.modify_roles(diff[:add], diff[:remove])
+      notify(active)
+    end
+
+    def notify(active)
+      return unless set.role_setting.notify_on_assign
+
+      event.user.pm(Message.selection_summary(set, active))
+    rescue
+      nil
+    end
+
+    def update(picker)
+      event.update_message(content: picker[:content], components: picker[:components])
+    end
+  end
+end

--- a/app/plugins/roles/events/component_handler.rb
+++ b/app/plugins/roles/events/component_handler.rb
@@ -16,17 +16,8 @@ module Roles
       set.assignable_roles.map(&:role_id)
     end
 
-    def apply(diff, active)
+    def apply(diff)
       member.modify_roles(diff[:add], diff[:remove])
-      notify(active)
-    end
-
-    def notify(active)
-      return unless set.role_setting.notify_on_assign
-
-      event.user.pm(Message.selection_summary(set, active))
-    rescue
-      nil
     end
 
     def update(picker)

--- a/app/plugins/roles/events/manage.rb
+++ b/app/plugins/roles/events/manage.rb
@@ -1,0 +1,13 @@
+module Roles
+  class Manage < ComponentHandler
+    on :button, custom_id: /\Aroles:manage:/
+
+    def handle
+      return unless set && member
+
+      active = member.roles.map(&:id) & set_role_ids
+      picker = (set.selection_mode == "single") ? Message.single_picker(set, active) : Message.multi_picker(set, active)
+      event.respond(content: picker[:content], components: picker[:components], ephemeral: true)
+    end
+  end
+end

--- a/app/plugins/roles/events/manage.rb
+++ b/app/plugins/roles/events/manage.rb
@@ -6,7 +6,7 @@ module Roles
       return unless set && member
 
       active = member.roles.map(&:id) & set_role_ids
-      picker = (set.selection_mode == "single") ? Message.single_picker(set, active) : Message.multi_picker(set, active)
+      picker = Message.multi_picker(set, active)
       event.respond(content: picker[:content], components: picker[:components], ephemeral: true)
     end
   end

--- a/app/plugins/roles/events/manage.rb
+++ b/app/plugins/roles/events/manage.rb
@@ -7,7 +7,7 @@ module Roles
 
       active = member.roles.map(&:id) & set_role_ids
       picker = Message.multi_picker(set, active)
-      event.respond(content: picker[:content], components: picker[:components], ephemeral: true)
+      event.respond(components: picker[:components], ephemeral: true, has_components: true)
     end
   end
 end

--- a/app/plugins/roles/events/pick.rb
+++ b/app/plugins/roles/events/pick.rb
@@ -8,9 +8,8 @@ module Roles
       picked = CustomId.parse(event.custom_id)[:role_id]
       return unless set_role_ids.include?(picked)
 
-      active = [picked]
-      apply(Assignment.single(set_role_ids, picked), active)
-      event.respond(content: Message.selection_summary(set, active), ephemeral: true)
+      apply(Assignment.single(set_role_ids, picked))
+      event.respond(content: Message.selection_summary(set, [picked]), ephemeral: true)
     end
   end
 end

--- a/app/plugins/roles/events/pick.rb
+++ b/app/plugins/roles/events/pick.rb
@@ -10,7 +10,7 @@ module Roles
 
       active = [picked]
       apply(Assignment.single(set_role_ids, picked), active)
-      update(Message.single_picker(set, active))
+      event.respond(content: Message.selection_summary(set, active), ephemeral: true)
     end
   end
 end

--- a/app/plugins/roles/events/pick.rb
+++ b/app/plugins/roles/events/pick.rb
@@ -1,0 +1,16 @@
+module Roles
+  class Pick < ComponentHandler
+    on :button, custom_id: /\Aroles:pick:/
+
+    def handle
+      return unless set && member
+
+      picked = CustomId.parse(event.custom_id)[:role_id]
+      return unless set_role_ids.include?(picked)
+
+      active = [picked]
+      apply(Assignment.single(set_role_ids, picked), active)
+      update(Message.single_picker(set, active))
+    end
+  end
+end

--- a/app/plugins/roles/events/select.rb
+++ b/app/plugins/roles/events/select.rb
@@ -6,9 +6,8 @@ module Roles
       return unless set && member
 
       selected = event.values.map(&:to_i)
-      active = selected & set_role_ids
-      apply(Assignment.multi(set_role_ids, selected), active)
-      update(Message.multi_picker(set, active))
+      apply(Assignment.multi(set_role_ids, selected))
+      update(Message.multi_picker(set, selected & set_role_ids))
     end
   end
 end

--- a/app/plugins/roles/events/select.rb
+++ b/app/plugins/roles/events/select.rb
@@ -1,0 +1,14 @@
+module Roles
+  class Select < ComponentHandler
+    on :string_select, custom_id: /\Aroles:select:/
+
+    def handle
+      return unless set && member
+
+      selected = event.values.map(&:to_i)
+      active = selected & set_role_ids
+      apply(Assignment.multi(set_role_ids, selected), active)
+      update(Message.multi_picker(set, active))
+    end
+  end
+end

--- a/app/plugins/roles/message.rb
+++ b/app/plugins/roles/message.rb
@@ -1,80 +1,109 @@
 module Roles
   module Message
+    CONTAINER = 17
+    TEXT_DISPLAY = 10
     ACTION_ROW = 1
     BUTTON = 2
     STRING_SELECT = 3
     PRIMARY = 1
     SECONDARY = 2
     BUTTONS_PER_ROW = 5
+    COMPONENTS_V2 = 1 << 15
+    UNKNOWN_ROLE = "Unknown role"
 
     module_function
 
     def public_message(set)
-      if set.selection_mode == "single"
-        {content: single_content(set), components: button_rows(role_buttons(set))}
-      else
-        {content: content(set), components: [manage_row(set)]}
-      end
+      blocks =
+        if set.selection_mode == "single"
+          [text(single_content(set)), *button_rows(role_buttons(set))]
+        else
+          [text(content(set)), action_row([manage_button(set)])]
+        end
+      container(blocks)
+    end
+
+    def multi_picker(set, active_role_ids)
+      container([text(picker_content(set)), action_row([role_select(set, active_role_ids)])])
+    end
+
+    def selection_summary(set, active_role_ids)
+      names = role_names(set)
+      chosen = set.assignable_roles
+        .select { |role| active_role_ids.include?(role.role_id) }
+        .map { |role| names[role.role_id] || UNKNOWN_ROLE }
+      "**#{set.name}**: #{chosen.any? ? chosen.join(", ") : "none"}"
+    end
+
+    def container(blocks)
+      {components: [{type: CONTAINER, components: blocks}], flags: COMPONENTS_V2}
+    end
+
+    def text(body)
+      {type: TEXT_DISPLAY, content: body}
+    end
+
+    def action_row(components)
+      {type: ACTION_ROW, components: components}
     end
 
     def content(set)
-      header = "**#{set.name}**"
-      roles = set.assignable_roles.map { |role| label(role) }
-      [header, *roles].join("\n")
+      names = role_names(set)
+      [["**#{set.name}**"], set.assignable_roles.map { |role| role_label(role, names) }].flatten.join("\n")
     end
 
     def single_content(set)
       "**#{set.name}**\nPick a role below. You can only have one, so choosing a role replaces your current one."
     end
 
+    def picker_content(set)
+      "**#{set.name}** — choose your roles."
+    end
+
     def role_buttons(set)
+      names = role_names(set)
       set.assignable_roles.map do |role|
-        {type: BUTTON, style: SECONDARY, label: label(role), custom_id: CustomId.pick(set, role)}
+        {type: BUTTON, style: SECONDARY, label: role_label(role, names), custom_id: CustomId.pick(set, role)}
       end
     end
 
-    def multi_picker(set, active_role_ids)
+    def role_select(set, active_role_ids)
+      names = role_names(set)
       options = set.assignable_roles.map do |role|
-        option = {label: role.label, value: role.role_id.to_s}
+        option = {label: names[role.role_id] || UNKNOWN_ROLE, value: role.role_id.to_s}
         option[:description] = role.description if role.description.present?
         option[:default] = true if active_role_ids.include?(role.role_id)
         option
       end
-      select = {
+      {
         type: STRING_SELECT,
         custom_id: CustomId.select(set),
         min_values: 0,
         max_values: options.size,
         options: options
       }
-      {content: picker_content(set), components: [{type: ACTION_ROW, components: [select]}]}
     end
 
-    def selection_summary(set, active_role_ids)
-      chosen = set.assignable_roles
-        .select { |role| active_role_ids.include?(role.role_id) }
-        .map(&:label)
-      "**#{set.name}**: #{chosen.any? ? chosen.join(", ") : "none"}"
-    end
-
-    def manage_row(set)
-      {type: ACTION_ROW, components: [
-        {type: BUTTON, style: PRIMARY, label: "Manage Roles", custom_id: CustomId.manage(set)}
-      ]}
-    end
-
-    def label(role)
-      [role.emoji, role.label].compact.join(" ")
-    end
-
-    def picker_content(set)
-      "**#{set.name}** — choose your roles."
+    def manage_button(set)
+      {type: BUTTON, style: PRIMARY, label: "Manage Roles", custom_id: CustomId.manage(set)}
     end
 
     def button_rows(buttons)
-      buttons.each_slice(BUTTONS_PER_ROW).map { |row| {type: ACTION_ROW, components: row} }
+      buttons.each_slice(BUTTONS_PER_ROW).map { |row| action_row(row) }
     end
 
-    private_class_method :content, :single_content, :role_buttons, :manage_row, :label, :picker_content, :button_rows
+    def role_names(set)
+      set.role_setting.server_configuration.server_roles
+        .where(discord_id: set.assignable_roles.map(&:role_id))
+        .pluck(:discord_id, :name)
+        .to_h
+    end
+
+    def role_label(role, names)
+      [role.emoji, names[role.role_id] || UNKNOWN_ROLE].compact.join(" ")
+    end
+
+    private_class_method :container, :text, :action_row, :content, :single_content, :picker_content,
+      :role_buttons, :role_select, :manage_button, :button_rows, :role_names, :role_label
   end
 end

--- a/app/plugins/roles/message.rb
+++ b/app/plugins/roles/message.rb
@@ -1,7 +1,9 @@
 module Roles
   module Message
     CONTAINER = 17
+    SECTION = 9
     TEXT_DISPLAY = 10
+    SEPARATOR = 14
     ACTION_ROW = 1
     BUTTON = 2
     STRING_SELECT = 3
@@ -9,6 +11,7 @@ module Roles
     SECONDARY = 2
     BUTTONS_PER_ROW = 5
     COMPONENTS_V2 = 1 << 15
+    ACCENT_COLOR = 0x39afe5
     UNKNOWN_ROLE = "Unknown role"
 
     module_function
@@ -16,9 +19,9 @@ module Roles
     def public_message(set)
       blocks =
         if set.selection_mode == "single"
-          [text(single_content(set)), *button_rows(role_buttons(set))]
+          [text(single_content(set)), separator, *button_rows(role_buttons(set))]
         else
-          [text(content(set)), action_row([manage_button(set)])]
+          [text(multi_content(set)), separator, manage_section(set)]
         end
       container(blocks)
     end
@@ -36,28 +39,41 @@ module Roles
     end
 
     def container(blocks)
-      {components: [{type: CONTAINER, components: blocks}], flags: COMPONENTS_V2}
+      {components: [{type: CONTAINER, accent_color: ACCENT_COLOR, components: blocks}], flags: COMPONENTS_V2}
     end
 
     def text(body)
       {type: TEXT_DISPLAY, content: body}
     end
 
+    def separator
+      {type: SEPARATOR, divider: true}
+    end
+
+    def manage_section(set)
+      {
+        type: SECTION,
+        components: [text("Click the button to the right to edit your roles.")],
+        accessory: manage_button(set)
+      }
+    end
+
     def action_row(components)
       {type: ACTION_ROW, components: components}
     end
 
-    def content(set)
-      names = role_names(set)
-      [["**#{set.name}**"], set.assignable_roles.map { |role| role_label(role, names) }].flatten.join("\n")
+    def single_content(set)
+      "### #{set.name}\nPick a role below — you can only have one, so choosing a role replaces your current one."
     end
 
-    def single_content(set)
-      "**#{set.name}**\nPick a role below. You can only have one, so choosing a role replaces your current one."
+    def multi_content(set)
+      names = role_names(set)
+      roles = set.assignable_roles.map { |role| role_label(role, names) }.join(" • ")
+      "### #{set.name}\nSelect all roles that apply from the options below.\n\n#{roles}"
     end
 
     def picker_content(set)
-      "**#{set.name}** — choose your roles."
+      "### #{set.name}\nSelect all roles that apply."
     end
 
     def role_buttons(set)
@@ -103,7 +119,8 @@ module Roles
       [role.emoji, names[role.role_id] || UNKNOWN_ROLE].compact.join(" ")
     end
 
-    private_class_method :container, :text, :action_row, :content, :single_content, :picker_content,
+    private_class_method :container, :text, :separator, :manage_section, :action_row,
+      :single_content, :multi_content, :picker_content,
       :role_buttons, :role_select, :manage_button, :button_rows, :role_names, :role_label
   end
 end

--- a/app/plugins/roles/message.rb
+++ b/app/plugins/roles/message.rb
@@ -2,7 +2,10 @@ module Roles
   module Message
     ACTION_ROW = 1
     BUTTON = 2
+    STRING_SELECT = 3
     PRIMARY = 1
+    SECONDARY = 2
+    BUTTONS_PER_ROW = 5
 
     module_function
 
@@ -12,14 +15,62 @@ module Roles
 
     def content(set)
       header = "**#{set.name}**"
-      roles = set.assignable_roles.map { |role| [role.emoji, role.label].compact.join(" ") }
+      roles = set.assignable_roles.map { |role| label(role) }
       [header, *roles].join("\n")
+    end
+
+    def single_picker(set, active_role_ids)
+      buttons = set.assignable_roles.map do |role|
+        {
+          type: BUTTON,
+          style: active_role_ids.include?(role.role_id) ? PRIMARY : SECONDARY,
+          label: label(role),
+          custom_id: CustomId.pick(set, role)
+        }
+      end
+      {content: picker_content(set), components: button_rows(buttons)}
+    end
+
+    def multi_picker(set, active_role_ids)
+      options = set.assignable_roles.map do |role|
+        option = {label: role.label, value: role.role_id.to_s}
+        option[:description] = role.description if role.description.present?
+        option[:default] = true if active_role_ids.include?(role.role_id)
+        option
+      end
+      select = {
+        type: STRING_SELECT,
+        custom_id: CustomId.select(set),
+        min_values: 0,
+        max_values: options.size,
+        options: options
+      }
+      {content: picker_content(set), components: [{type: ACTION_ROW, components: [select]}]}
+    end
+
+    def selection_summary(set, active_role_ids)
+      chosen = set.assignable_roles
+        .select { |role| active_role_ids.include?(role.role_id) }
+        .map(&:label)
+      "**#{set.name}**: #{chosen.any? ? chosen.join(", ") : "none"}"
     end
 
     def manage_row(set)
       {type: ACTION_ROW, components: [
         {type: BUTTON, style: PRIMARY, label: "Manage Roles", custom_id: CustomId.manage(set)}
       ]}
+    end
+
+    def label(role)
+      [role.emoji, role.label].compact.join(" ")
+    end
+
+    def picker_content(set)
+      "**#{set.name}** — choose your roles."
+    end
+
+    def button_rows(buttons)
+      buttons.each_slice(BUTTONS_PER_ROW).map { |row| {type: ACTION_ROW, components: row} }
     end
   end
 end

--- a/app/plugins/roles/message.rb
+++ b/app/plugins/roles/message.rb
@@ -53,7 +53,7 @@ module Roles
     def manage_section(set)
       {
         type: SECTION,
-        components: [text("Click the button to the right to edit your roles.")],
+        components: [text("-# Click this button to edit your roles ->")],
         accessory: manage_button(set)
       }
     end
@@ -68,8 +68,8 @@ module Roles
 
     def multi_content(set)
       names = role_names(set)
-      roles = set.assignable_roles.map { |role| role_label(role, names) }.join(" • ")
-      "### #{set.name}\nSelect all roles that apply from the options below.\n\n#{roles}"
+      roles = set.assignable_roles.map { |role| "- **#{role_label(role, names)}**" }.join("\n")
+      "### #{set.name}\nSelect all roles that apply. You will have the following options:\n#{roles}"
     end
 
     def picker_content(set)

--- a/app/plugins/roles/message.rb
+++ b/app/plugins/roles/message.rb
@@ -74,5 +74,7 @@ module Roles
     def button_rows(buttons)
       buttons.each_slice(BUTTONS_PER_ROW).map { |row| {type: ACTION_ROW, components: row} }
     end
+
+    private_class_method :content, :single_content, :role_buttons, :manage_row, :label, :picker_content, :button_rows
   end
 end

--- a/app/plugins/roles/message.rb
+++ b/app/plugins/roles/message.rb
@@ -10,7 +10,11 @@ module Roles
     module_function
 
     def public_message(set)
-      {content: content(set), components: [manage_row(set)]}
+      if set.selection_mode == "single"
+        {content: single_content(set), components: button_rows(role_buttons(set))}
+      else
+        {content: content(set), components: [manage_row(set)]}
+      end
     end
 
     def content(set)
@@ -19,16 +23,14 @@ module Roles
       [header, *roles].join("\n")
     end
 
-    def single_picker(set, active_role_ids)
-      buttons = set.assignable_roles.map do |role|
-        {
-          type: BUTTON,
-          style: active_role_ids.include?(role.role_id) ? PRIMARY : SECONDARY,
-          label: label(role),
-          custom_id: CustomId.pick(set, role)
-        }
+    def single_content(set)
+      "**#{set.name}**\nPick a role below. You can only have one, so choosing a role replaces your current one."
+    end
+
+    def role_buttons(set)
+      set.assignable_roles.map do |role|
+        {type: BUTTON, style: SECONDARY, label: label(role), custom_id: CustomId.pick(set, role)}
       end
-      {content: picker_content(set), components: button_rows(buttons)}
     end
 
     def multi_picker(set, active_role_ids)

--- a/app/plugins/roles/message_poster.rb
+++ b/app/plugins/roles/message_poster.rb
@@ -23,12 +23,12 @@ module Roles
     private
 
     def create(channel, rendered)
-      message = channel.send_message(rendered[:content], false, nil, nil, nil, nil, rendered[:components])
+      message = channel.send_message(nil, false, nil, nil, nil, nil, rendered[:components], rendered[:flags])
       @set.update!(message_id: message.id)
     end
 
     def edit(channel, rendered)
-      channel.load_message(@set.message_id)&.edit(rendered[:content], nil, rendered[:components])
+      channel.load_message(@set.message_id)&.edit(nil, nil, rendered[:components], rendered[:flags])
     end
   end
 end

--- a/bin/bot
+++ b/bin/bot
@@ -3,6 +3,7 @@ require_relative "../config/environment"
 require "discordrb"
 
 Rails.application.eager_load!
+Rails.logger.broadcast_to(ActiveSupport::Logger.new($stdout))
 
 shard_count = BotConfig.shard_count
 

--- a/db/migrate/20260619214046_remove_notify_on_assign_from_role_settings.rb
+++ b/db/migrate/20260619214046_remove_notify_on_assign_from_role_settings.rb
@@ -1,0 +1,5 @@
+class RemoveNotifyOnAssignFromRoleSettings < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :role_settings, :notify_on_assign, :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20260619220209_remove_label_from_assignable_roles.rb
+++ b/db/migrate/20260619220209_remove_label_from_assignable_roles.rb
@@ -1,0 +1,5 @@
+class RemoveLabelFromAssignableRoles < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :assignable_roles, :label, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_19_120001) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_19_214046) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -103,7 +103,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_19_120001) do
     t.bigint "channel_id"
     t.datetime "created_at", null: false
     t.boolean "log_on_assign", default: false, null: false
-    t.boolean "notify_on_assign", default: false, null: false
     t.string "server_configuration_id", null: false
     t.datetime "updated_at", null: false
     t.index ["server_configuration_id"], name: "index_role_settings_on_server_configuration_id", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_19_214046) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_19_220209) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -18,7 +18,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_19_214046) do
     t.datetime "created_at", null: false
     t.string "description"
     t.string "emoji"
-    t.string "label"
     t.integer "position", default: 0, null: false
     t.bigint "role_id", null: false
     t.string "role_set_id", null: false

--- a/docs/adding-an-event.md
+++ b/docs/adding-an-event.md
@@ -48,7 +48,8 @@ several handler classes. The event exposes `custom_id`, `values` (selects), `use
 `server`, and `respond`/`update_message` (acknowledge the interaction — `respond` for a
 new ephemeral reply, `update_message` to edit the message the component is on). See
 `app/plugins/roles/events/`, where a thin `Roles::ComponentHandler` base shares the
-set lookup, member resolution, and notify across the manage/pick/select handlers.
+set lookup, member resolution, and role-diff application across the manage/pick/select
+handlers.
 
 ## Spec it
 

--- a/docs/adding-an-event.md
+++ b/docs/adding-an-event.md
@@ -38,6 +38,18 @@ end
 - For plugins gated by an enable flag, check it at the top of `#handle` (a DB read) —
   event handlers aren't hidden the way guild commands are. See `Settings.active_for`.
 
+## Component interactions (buttons, selects)
+
+`on` forwards keyword attributes to the discordrb handler, so component events filter
+by `custom_id`: `on :button, custom_id: /\Aroles:pick:/` or
+`on :string_select, custom_id: /\Aroles:select:/`. discordrb routes each interaction to
+the handler whose `custom_id` regexp matches, so one custom-id namespace can fan out to
+several handler classes. The event exposes `custom_id`, `values` (selects), `user`,
+`server`, and `respond`/`update_message` (acknowledge the interaction — `respond` for a
+new ephemeral reply, `update_message` to edit the message the component is on). See
+`app/plugins/roles/events/`, where a thin `Roles::ComponentHandler` base shares the
+set lookup, member resolution, and notify across the manage/pick/select handlers.
+
 ## Spec it
 
 Drive `#handle` with a fake/`double` event and assert the effect (a send, a DB write).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -236,6 +236,15 @@ grant an arbitrary server role. The runtime toggle is bot-only (no DB write, no 
 caller), so it lives in the handlers, not in an operation; the testable unit is the
 pure `Roles::Assignment` diff with `member.modify_roles` as the seam.
 
+`Roles::Message` renders every message as a **Components V2** payload (a `Container`
+wrapping a text block plus the buttons/select), so `public_message`/`multi_picker`
+return `{components:, flags:}` with the `COMPONENTS_V2` flag and no `content` — senders
+pass `has_components: true` (or the flag positionally). Buttons and select options are
+**always labelled with the synced role name** (`ServerRole`, looked up by `role_id`),
+not a stored label — Discord exposes no way to colour a button by the role's colour, so
+the name is the only useful signal. A role missing from the sync falls back to a
+placeholder so a component is never empty.
+
 ## Sharding
 
 Static only (`SHARD_COUNT`, floored at 1). discordrb is one shard per `Bot` instance,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -236,10 +236,14 @@ grant an arbitrary server role. The runtime toggle is bot-only (no DB write, no 
 caller), so it lives in the handlers, not in an operation; the testable unit is the
 pure `Roles::Assignment` diff with `member.modify_roles` as the seam.
 
-`Roles::Message` renders every message as a **Components V2** payload (a `Container`
-wrapping a text block plus the buttons/select), so `public_message`/`multi_picker`
-return `{components:, flags:}` with the `COMPONENTS_V2` flag and no `content` — senders
-pass `has_components: true` (or the flag positionally). Buttons and select options are
+`Roles::Message` renders every message as a **Components V2** payload, so
+`public_message`/`multi_picker` return `{components:, flags:}` with the `COMPONENTS_V2`
+flag and no `content` — senders pass `has_components: true` (or the flag positionally).
+Each message is a `Container` carrying the brand `ACCENT_COLOR` sidebar, a markdown
+`### ` heading (Discord supports only h1–h3), a `Separator`, and then the controls.
+Single sets put the role buttons straight in the container; multi sets list the roles
+side by side (no markdown tables in Discord — an inline `•`-joined line) and expose the
+manage button as a `Section` accessory. Buttons and select options are
 **always labelled with the synced role name** (`ServerRole`, looked up by `role_id`),
 not a stored label — Discord exposes no way to colour a button by the role's colour, so
 the name is the only useful signal. A role missing from the sync falls back to a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -217,6 +217,25 @@ than once-per-boot, and a send failure (owner blocks DMs) is swallowed and left
 un-stamped so a later boot retries. The welcome copy is a placeholder until the config
 website ships, when it gains the real setup link.
 
+## Roles self-assignment
+
+Each role set posts a public message and assigns roles through component
+interactions (`app/plugins/roles/events/`). The flow differs by the set's
+`selection_mode`, because a public message renders identically to everyone and so
+can't show per-user state:
+
+- **single** (exclusive) — the public message renders the role buttons directly.
+  Clicking one assigns it and strips the set's other roles, with an ephemeral
+  confirmation. One step; current state doesn't matter for an exclusive overwrite.
+- **multi** — the public message carries one "Manage Roles" button. Clicking it opens
+  an ephemeral string-select with the user's current roles pre-checked, so they can
+  see and toggle what they have. Two steps, because the stateful view is the point.
+
+Selection is always constrained to the set's own roles, so a forged `custom_id` can't
+grant an arbitrary server role. The runtime toggle is bot-only (no DB write, no web
+caller), so it lives in the handlers, not in an operation; the testable unit is the
+pure `Roles::Assignment` diff with `member.modify_roles` as the seam.
+
 ## Sharding
 
 Static only (`SHARD_COUNT`, floored at 1). discordrb is one shard per `Bot` instance,

--- a/spec/bot/base_event_spec.rb
+++ b/spec/bot/base_event_spec.rb
@@ -52,4 +52,16 @@ RSpec.describe BaseEvent do
       expect { klass.new(event).handle }.to raise_error(AbstractMethodError)
     end
   end
+
+  describe ".event_attributes" do
+    it "defaults to empty" do
+      expect(Class.new(described_class).event_attributes).to eq({})
+    end
+
+    it "captures the attributes passed to `on` alongside the events" do
+      klass = Class.new(described_class) { on :button, custom_id: /x/ }
+      expect(klass.discord_events).to eq([:button])
+      expect(klass.event_attributes).to eq(custom_id: /x/)
+    end
+  end
 end

--- a/spec/bot/base_event_spec.rb
+++ b/spec/bot/base_event_spec.rb
@@ -47,21 +47,29 @@ RSpec.describe BaseEvent do
   end
 
   describe "#handle" do
+    subject(:klass) { Class.new(described_class) }
+
     it "is abstract" do
-      klass = Class.new(described_class)
       expect { klass.new(event).handle }.to raise_error(AbstractMethodError)
     end
   end
 
   describe ".event_attributes" do
-    it "defaults to empty" do
-      expect(Class.new(described_class).event_attributes).to eq({})
+    context "without an `on` declaration" do
+      let(:klass) { Class.new(described_class) }
+
+      it "defaults to empty" do
+        expect(klass.event_attributes).to eq({})
+      end
     end
 
-    it "captures the attributes passed to `on` alongside the events" do
-      klass = Class.new(described_class) { on :button, custom_id: /x/ }
-      expect(klass.discord_events).to eq([:button])
-      expect(klass.event_attributes).to eq(custom_id: /x/)
+    context "with attributes on the `on` declaration" do
+      let(:klass) { Class.new(described_class) { on :button, custom_id: /x/ } }
+
+      it "captures them alongside the events" do
+        expect(klass.discord_events).to eq([:button])
+        expect(klass.event_attributes).to eq(custom_id: /x/)
+      end
     end
   end
 end

--- a/spec/bot/event_registrar_spec.rb
+++ b/spec/bot/event_registrar_spec.rb
@@ -23,6 +23,10 @@ RSpec.describe EventRegistrar do
       def channel_delete(&block)
         @handlers[:channel_delete] = block
       end
+
+      def button(attributes = {}, &block)
+        @handlers[:button] = {attributes: attributes, block: block}
+      end
     end.new
   end
 
@@ -59,6 +63,26 @@ RSpec.describe EventRegistrar do
     it "binds the class to each declared handler" do
       register_all
       expect(fake_bot.handlers.keys).to contain_exactly(:channel_create, :channel_delete)
+    end
+  end
+
+  context "with an event declaring handler attributes" do
+    let(:event_class) do
+      Class.new(BaseEvent) do
+        on :button, custom_id: /\Aroles:/
+        def handle
+        end
+      end
+    end
+    let(:events) { [event_class] }
+
+    it "passes the attributes through to the discordrb handler" do
+      register_all
+      expect(fake_bot.handlers[:button][:attributes]).to eq(custom_id: /\Aroles:/)
+
+      incoming = double("event")
+      expect(event_class).to receive(:dispatch).with(incoming)
+      fake_bot.handlers[:button][:block].call(incoming)
     end
   end
 

--- a/spec/bot/event_registrar_spec.rb
+++ b/spec/bot/event_registrar_spec.rb
@@ -39,12 +39,11 @@ RSpec.describe EventRegistrar do
       end
     end
     let(:events) { [event_class] }
+    let(:incoming) { double("event") }
 
     it "binds it to its discordrb handler and dispatches to the class" do
       register_all
       expect(fake_bot.handlers.key?(:member_join)).to be(true)
-
-      incoming = double("event")
       expect(event_class).to receive(:dispatch).with(incoming)
       fake_bot.handlers[:member_join].call(incoming)
     end
@@ -75,12 +74,11 @@ RSpec.describe EventRegistrar do
       end
     end
     let(:events) { [event_class] }
+    let(:incoming) { double("event") }
 
     it "passes the attributes through to the discordrb handler" do
       register_all
       expect(fake_bot.handlers[:button][:attributes]).to eq(custom_id: /\Aroles:/)
-
-      incoming = double("event")
       expect(event_class).to receive(:dispatch).with(incoming)
       fake_bot.handlers[:button][:block].call(incoming)
     end

--- a/spec/factories/assignable_roles.rb
+++ b/spec/factories/assignable_roles.rb
@@ -2,6 +2,5 @@ FactoryBot.define do
   factory :assignable_role, class: "Roles::AssignableRole" do
     association :role_set
     sequence(:role_id) { |n| 400_000 + n }
-    label { "Role" }
   end
 end

--- a/spec/operations/roles/assignable_roles/add_spec.rb
+++ b/spec/operations/roles/assignable_roles/add_spec.rb
@@ -1,13 +1,13 @@
 require "rails_helper"
 
 RSpec.describe Ops::Roles::AssignableRoles::Add do
-  subject(:result) { described_class.call(role_set: set, role_id: 42, label: "Gamer") }
+  subject(:result) { described_class.call(role_set: set, role_id: 42) }
 
   let(:set) { create(:role_set) }
 
   it "adds the role at the first position" do
     expect(result.success?).to be(true)
-    expect(result.value).to have_attributes(role_id: 42, label: "Gamer", position: 0)
+    expect(result.value).to have_attributes(role_id: 42, position: 0)
   end
 
   context "when a role already exists" do

--- a/spec/operations/roles/settings/update_spec.rb
+++ b/spec/operations/roles/settings/update_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Ops::Roles::Settings::Update do
   subject(:result) do
-    described_class.call(server_configuration: server, channel_id:, notify_on_assign: true, log_on_assign: false)
+    described_class.call(server_configuration: server, channel_id:, log_on_assign: false)
   end
 
   let(:server) { create(:server_configuration) }
@@ -11,12 +11,12 @@ RSpec.describe Ops::Roles::Settings::Update do
 
   it "sets the role settings" do
     expect(result.success?).to be(true)
-    expect(setting.reload).to have_attributes(channel_id: 99, notify_on_assign: true, log_on_assign: false)
+    expect(setting.reload).to have_attributes(channel_id: 99, log_on_assign: false)
   end
 
   context "updating existing values" do
     before do
-      setting.update!(channel_id: 1, notify_on_assign: false)
+      setting.update!(channel_id: 1)
     end
 
     it "updates them in place" do

--- a/spec/plugins/roles/assignment_spec.rb
+++ b/spec/plugins/roles/assignment_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.describe Roles::Assignment do
+  describe ".single" do
+    subject(:diff) { described_class.single(set_role_ids, picked) }
+
+    let(:set_role_ids) { [1, 2, 3] }
+    let(:picked) { 2 }
+
+    it "adds the picked role" do
+      expect(diff[:add]).to eq([2])
+    end
+
+    it "removes every other role in the set (exclusive selection)" do
+      expect(diff[:remove]).to contain_exactly(1, 3)
+    end
+  end
+
+  describe ".multi" do
+    subject(:diff) { described_class.multi(set_role_ids, selected) }
+
+    let(:set_role_ids) { [1, 2, 3] }
+
+    context "with a subset selected" do
+      let(:selected) { [1, 3] }
+
+      it "adds the selected set roles" do
+        expect(diff[:add]).to contain_exactly(1, 3)
+      end
+
+      it "removes the unselected set roles" do
+        expect(diff[:remove]).to eq([2])
+      end
+    end
+
+    context "when the selection includes ids outside the set" do
+      let(:selected) { [1, 999] }
+
+      it "ignores them" do
+        expect(diff[:add]).to eq([1])
+        expect(diff[:remove]).to contain_exactly(2, 3)
+      end
+    end
+
+    context "with nothing selected" do
+      let(:selected) { [] }
+
+      it "removes the whole set" do
+        expect(diff[:add]).to be_empty
+        expect(diff[:remove]).to contain_exactly(1, 2, 3)
+      end
+    end
+  end
+end

--- a/spec/plugins/roles/events/manage_spec.rb
+++ b/spec/plugins/roles/events/manage_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe Roles::Manage do
+  subject(:handle) { described_class.new(event).handle }
+
+  let(:user) { double("user", id: 42) }
+  let(:member) { double("member", roles: [double("role", id: 200)]) }
+  let(:server) { double("server") }
+  let(:event) { double("event", custom_id: Roles::CustomId.manage(set), server:, user:) }
+
+  before do
+    allow(server).to receive(:member).with(42).and_return(member)
+  end
+
+  context "for a single-selection set" do
+    let(:set) { create(:role_set, selection_mode: "single") }
+
+    before do
+      create(:assignable_role, role_set: set, role_id: 100, label: "Red", position: 0)
+      create(:assignable_role, role_set: set, role_id: 200, label: "Blue", position: 1)
+    end
+
+    it "responds with an ephemeral button picker" do
+      expect(event).to receive(:respond) do |args|
+        expect(args[:ephemeral]).to be(true)
+        types = args[:components].flat_map { |row| row[:components] }.map { |component| component[:type] }
+        expect(types).to all(eq(Roles::Message::BUTTON))
+      end
+      handle
+    end
+  end
+
+  context "for a multi-selection set" do
+    let(:set) { create(:role_set, selection_mode: "multi") }
+
+    before do
+      create(:assignable_role, role_set: set, role_id: 200, label: "Blue", position: 0)
+    end
+
+    it "responds with an ephemeral string-select picker" do
+      expect(event).to receive(:respond) do |args|
+        expect(args[:ephemeral]).to be(true)
+        expect(args[:components].first[:components].first[:type]).to eq(Roles::Message::STRING_SELECT)
+      end
+      handle
+    end
+  end
+
+  context "when the set no longer exists" do
+    let(:event) { double("event", custom_id: "roles:manage:rst_gone", server:, user:) }
+    let(:set) { nil }
+
+    it "does nothing" do
+      expect(event).not_to receive(:respond)
+      handle
+    end
+  end
+end

--- a/spec/plugins/roles/events/manage_spec.rb
+++ b/spec/plugins/roles/events/manage_spec.rb
@@ -12,24 +12,6 @@ RSpec.describe Roles::Manage do
     allow(server).to receive(:member).with(42).and_return(member)
   end
 
-  context "for a single-selection set" do
-    let(:set) { create(:role_set, selection_mode: "single") }
-
-    before do
-      create(:assignable_role, role_set: set, role_id: 100, label: "Red", position: 0)
-      create(:assignable_role, role_set: set, role_id: 200, label: "Blue", position: 1)
-    end
-
-    it "responds with an ephemeral button picker" do
-      expect(event).to receive(:respond) do |args|
-        expect(args[:ephemeral]).to be(true)
-        types = args[:components].flat_map { |row| row[:components] }.map { |component| component[:type] }
-        expect(types).to all(eq(Roles::Message::BUTTON))
-      end
-      handle
-    end
-  end
-
   context "for a multi-selection set" do
     let(:set) { create(:role_set, selection_mode: "multi") }
 

--- a/spec/plugins/roles/events/manage_spec.rb
+++ b/spec/plugins/roles/events/manage_spec.rb
@@ -16,13 +16,16 @@ RSpec.describe Roles::Manage do
     let(:set) { create(:role_set, selection_mode: "multi") }
 
     before do
-      create(:assignable_role, role_set: set, role_id: 200, label: "Blue", position: 0)
+      create(:assignable_role, role_set: set, role_id: 200, position: 0)
     end
 
-    it "responds with an ephemeral string-select picker" do
+    it "responds with an ephemeral, components-v2 string-select picker" do
       expect(event).to receive(:respond) do |args|
         expect(args[:ephemeral]).to be(true)
-        expect(args[:components].first[:components].first[:type]).to eq(Roles::Message::STRING_SELECT)
+        expect(args[:has_components]).to be(true)
+        container = args[:components].first
+        select = container[:components].find { |block| block[:type] == Roles::Message::ACTION_ROW }[:components].first
+        expect(select[:type]).to eq(Roles::Message::STRING_SELECT)
       end
       handle
     end

--- a/spec/plugins/roles/events/pick_spec.rb
+++ b/spec/plugins/roles/events/pick_spec.rb
@@ -3,9 +3,16 @@ require "rails_helper"
 RSpec.describe Roles::Pick do
   subject(:handle) { described_class.new(event).handle }
 
-  let(:set) { create(:role_set, selection_mode: "single") }
-  let!(:red) { create(:assignable_role, role_set: set, role_id: 100, label: "Red", position: 0) }
-  let!(:blue) { create(:assignable_role, role_set: set, role_id: 200, label: "Blue", position: 1) }
+  let(:server_config) { create(:server_configuration) }
+  let(:setting) { create(:role_setting, server_configuration: server_config) }
+  let(:set) { create(:role_set, role_setting: setting, selection_mode: "single") }
+  let!(:red) { create(:assignable_role, role_set: set, role_id: 100, position: 0) }
+  let!(:blue) { create(:assignable_role, role_set: set, role_id: 200, position: 1) }
+
+  before do
+    create(:server_role, server_configuration: server_config, discord_id: 100, name: "Red")
+    create(:server_role, server_configuration: server_config, discord_id: 200, name: "Blue")
+  end
 
   let(:user) { double("user", id: 42) }
   let(:member) { double("member", roles: [], modify_roles: nil) }

--- a/spec/plugins/roles/events/pick_spec.rb
+++ b/spec/plugins/roles/events/pick_spec.rb
@@ -10,13 +10,9 @@ RSpec.describe Roles::Pick do
 
   let(:user) { double("user", id: 42) }
   let(:member) { double("member", roles: [], modify_roles: nil) }
-  let(:server) { double("server") }
+  let(:server) { double("server", member: member) }
   let(:event) do
-    double("event", custom_id: Roles::CustomId.pick(set, blue), server:, user:, update_message: nil)
-  end
-
-  before do
-    allow(server).to receive(:member).with(42).and_return(member)
+    double("event", custom_id: Roles::CustomId.pick(set, blue), server:, user:, respond: nil)
   end
 
   it "adds the picked role and removes the other roles in the set" do
@@ -24,18 +20,27 @@ RSpec.describe Roles::Pick do
     handle
   end
 
-  it "re-renders the picker via update_message" do
-    expect(event).to receive(:update_message)
+  it "confirms the new selection ephemerally" do
+    expect(event).to receive(:respond).with(content: "**#{set.name}**: Blue", ephemeral: true)
     handle
   end
 
   context "when the custom id references a role outside the set" do
     let(:event) do
-      double("event", custom_id: "roles:pick:#{set.id}:999", server:, user:, update_message: nil)
+      double("event", custom_id: "roles:pick:#{set.id}:999", server:, user:, respond: nil)
     end
 
     it "makes no change" do
       expect(member).not_to receive(:modify_roles)
+      handle
+    end
+  end
+
+  context "outside a server (no member to assign)" do
+    let(:server) { nil }
+
+    it "does nothing" do
+      expect(event).not_to receive(:respond)
       handle
     end
   end
@@ -45,6 +50,12 @@ RSpec.describe Roles::Pick do
 
     it "DMs the user their selection" do
       expect(user).to receive(:pm).with("**#{set.name}**: Blue")
+      handle
+    end
+
+    it "still confirms even if the DM cannot be delivered" do
+      allow(user).to receive(:pm).and_raise(StandardError, "Cannot send messages to this user")
+      expect(event).to receive(:respond).with(content: "**#{set.name}**: Blue", ephemeral: true)
       handle
     end
   end

--- a/spec/plugins/roles/events/pick_spec.rb
+++ b/spec/plugins/roles/events/pick_spec.rb
@@ -3,8 +3,7 @@ require "rails_helper"
 RSpec.describe Roles::Pick do
   subject(:handle) { described_class.new(event).handle }
 
-  let(:setting) { create(:role_setting, notify_on_assign: false) }
-  let(:set) { create(:role_set, role_setting: setting, selection_mode: "single") }
+  let(:set) { create(:role_set, selection_mode: "single") }
   let!(:red) { create(:assignable_role, role_set: set, role_id: 100, label: "Red", position: 0) }
   let!(:blue) { create(:assignable_role, role_set: set, role_id: 200, label: "Blue", position: 1) }
 
@@ -45,25 +44,8 @@ RSpec.describe Roles::Pick do
     end
   end
 
-  context "when notify_on_assign is on" do
-    let(:setting) { create(:role_setting, notify_on_assign: true) }
-
-    it "DMs the user their selection" do
-      expect(user).to receive(:pm).with("**#{set.name}**: Blue")
-      handle
-    end
-
-    it "still confirms even if the DM cannot be delivered" do
-      allow(user).to receive(:pm).and_raise(StandardError, "Cannot send messages to this user")
-      expect(event).to receive(:respond).with(content: "**#{set.name}**: Blue", ephemeral: true)
-      handle
-    end
-  end
-
-  context "when notify_on_assign is off" do
-    it "does not DM the user" do
-      expect(user).not_to receive(:pm)
-      handle
-    end
+  it "never DMs the user" do
+    expect(user).not_to receive(:pm)
+    handle
   end
 end

--- a/spec/plugins/roles/events/pick_spec.rb
+++ b/spec/plugins/roles/events/pick_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe Roles::Pick do
+  subject(:handle) { described_class.new(event).handle }
+
+  let(:setting) { create(:role_setting, notify_on_assign: false) }
+  let(:set) { create(:role_set, role_setting: setting, selection_mode: "single") }
+  let!(:red) { create(:assignable_role, role_set: set, role_id: 100, label: "Red", position: 0) }
+  let!(:blue) { create(:assignable_role, role_set: set, role_id: 200, label: "Blue", position: 1) }
+
+  let(:user) { double("user", id: 42) }
+  let(:member) { double("member", roles: [], modify_roles: nil) }
+  let(:server) { double("server") }
+  let(:event) do
+    double("event", custom_id: Roles::CustomId.pick(set, blue), server:, user:, update_message: nil)
+  end
+
+  before do
+    allow(server).to receive(:member).with(42).and_return(member)
+  end
+
+  it "adds the picked role and removes the other roles in the set" do
+    expect(member).to receive(:modify_roles).with([200], [100])
+    handle
+  end
+
+  it "re-renders the picker via update_message" do
+    expect(event).to receive(:update_message)
+    handle
+  end
+
+  context "when the custom id references a role outside the set" do
+    let(:event) do
+      double("event", custom_id: "roles:pick:#{set.id}:999", server:, user:, update_message: nil)
+    end
+
+    it "makes no change" do
+      expect(member).not_to receive(:modify_roles)
+      handle
+    end
+  end
+
+  context "when notify_on_assign is on" do
+    let(:setting) { create(:role_setting, notify_on_assign: true) }
+
+    it "DMs the user their selection" do
+      expect(user).to receive(:pm).with("**#{set.name}**: Blue")
+      handle
+    end
+  end
+
+  context "when notify_on_assign is off" do
+    it "does not DM the user" do
+      expect(user).not_to receive(:pm)
+      handle
+    end
+  end
+end

--- a/spec/plugins/roles/events/select_spec.rb
+++ b/spec/plugins/roles/events/select_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe Roles::Select do
   subject(:handle) { described_class.new(event).handle }
 
   let(:set) { create(:role_set, selection_mode: "multi") }
-  let!(:news) { create(:assignable_role, role_set: set, role_id: 100, label: "News", position: 0) }
-  let!(:events_role) { create(:assignable_role, role_set: set, role_id: 200, label: "Events", position: 1) }
+  let!(:news) { create(:assignable_role, role_set: set, role_id: 100, position: 0) }
+  let!(:events_role) { create(:assignable_role, role_set: set, role_id: 200, position: 1) }
 
   let(:user) { double("user", id: 42) }
   let(:member) { double("member", modify_roles: nil) }

--- a/spec/plugins/roles/events/select_spec.rb
+++ b/spec/plugins/roles/events/select_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe Roles::Select do
+  subject(:handle) { described_class.new(event).handle }
+
+  let(:setting) { create(:role_setting, notify_on_assign: false) }
+  let(:set) { create(:role_set, role_setting: setting, selection_mode: "multi") }
+  let!(:news) { create(:assignable_role, role_set: set, role_id: 100, label: "News", position: 0) }
+  let!(:events_role) { create(:assignable_role, role_set: set, role_id: 200, label: "Events", position: 1) }
+
+  let(:user) { double("user", id: 42) }
+  let(:member) { double("member", modify_roles: nil) }
+  let(:server) { double("server") }
+  let(:event) do
+    double("event", custom_id: Roles::CustomId.select(set), server:, user:, values: ["100"], update_message: nil)
+  end
+
+  before do
+    allow(server).to receive(:member).with(42).and_return(member)
+  end
+
+  it "adds the selected set roles and removes the unselected ones" do
+    expect(member).to receive(:modify_roles).with([100], [200])
+    handle
+  end
+
+  it "re-renders the picker via update_message" do
+    expect(event).to receive(:update_message)
+    handle
+  end
+
+  context "when notify_on_assign is on" do
+    let(:setting) { create(:role_setting, notify_on_assign: true) }
+
+    it "DMs the user their resulting selection" do
+      expect(user).to receive(:pm).with("**#{set.name}**: News")
+      handle
+    end
+  end
+end

--- a/spec/plugins/roles/events/select_spec.rb
+++ b/spec/plugins/roles/events/select_spec.rb
@@ -10,18 +10,23 @@ RSpec.describe Roles::Select do
 
   let(:user) { double("user", id: 42) }
   let(:member) { double("member", modify_roles: nil) }
-  let(:server) { double("server") }
+  let(:server) { double("server", member: member) }
   let(:event) do
     double("event", custom_id: Roles::CustomId.select(set), server:, user:, values: ["100"], update_message: nil)
-  end
-
-  before do
-    allow(server).to receive(:member).with(42).and_return(member)
   end
 
   it "adds the selected set roles and removes the unselected ones" do
     expect(member).to receive(:modify_roles).with([100], [200])
     handle
+  end
+
+  context "outside a server (no member to assign)" do
+    let(:server) { nil }
+
+    it "does nothing" do
+      expect(event).not_to receive(:update_message)
+      handle
+    end
   end
 
   it "re-renders the picker via update_message" do

--- a/spec/plugins/roles/events/select_spec.rb
+++ b/spec/plugins/roles/events/select_spec.rb
@@ -3,8 +3,7 @@ require "rails_helper"
 RSpec.describe Roles::Select do
   subject(:handle) { described_class.new(event).handle }
 
-  let(:setting) { create(:role_setting, notify_on_assign: false) }
-  let(:set) { create(:role_set, role_setting: setting, selection_mode: "multi") }
+  let(:set) { create(:role_set, selection_mode: "multi") }
   let!(:news) { create(:assignable_role, role_set: set, role_id: 100, label: "News", position: 0) }
   let!(:events_role) { create(:assignable_role, role_set: set, role_id: 200, label: "Events", position: 1) }
 
@@ -34,12 +33,8 @@ RSpec.describe Roles::Select do
     handle
   end
 
-  context "when notify_on_assign is on" do
-    let(:setting) { create(:role_setting, notify_on_assign: true) }
-
-    it "DMs the user their resulting selection" do
-      expect(user).to receive(:pm).with("**#{set.name}**: News")
-      handle
-    end
+  it "never DMs the user" do
+    expect(user).not_to receive(:pm)
+    handle
   end
 end

--- a/spec/plugins/roles/message_poster_spec.rb
+++ b/spec/plugins/roles/message_poster_spec.rb
@@ -19,6 +19,13 @@ RSpec.describe Roles::MessagePoster do
       post
       expect(set.reload.message_id).to eq(98765)
     end
+
+    it "sends with the components-v2 flag so the container is accepted" do
+      expect(channel).to receive(:send_message)
+        .with(nil, false, nil, nil, nil, nil, anything, Roles::Message::COMPONENTS_V2)
+        .and_return(double(id: 1))
+      post
+    end
   end
 
   context "when the set already has a message" do
@@ -32,6 +39,11 @@ RSpec.describe Roles::MessagePoster do
 
     it "edits the existing message rather than reposting" do
       expect(message).to receive(:edit)
+      post
+    end
+
+    it "edits with the components-v2 flag" do
+      expect(message).to receive(:edit).with(nil, nil, anything, Roles::Message::COMPONENTS_V2)
       post
     end
   end

--- a/spec/plugins/roles/message_spec.rb
+++ b/spec/plugins/roles/message_spec.rb
@@ -20,4 +20,86 @@ RSpec.describe Roles::Message do
       expect(button).to include(label: "Manage Roles", custom_id: Roles::CustomId.manage(set))
     end
   end
+
+  describe ".single_picker" do
+    subject(:picker) { described_class.single_picker(set, [200]) }
+
+    let(:set) { create(:role_set, name: "Color", selection_mode: "single") }
+    let!(:red) { create(:assignable_role, role_set: set, role_id: 100, label: "Red", position: 0) }
+    let!(:blue) { create(:assignable_role, role_set: set, role_id: 200, label: "Blue", position: 1) }
+
+    it "renders one button per role" do
+      buttons = picker[:components].flat_map { |row| row[:components] }
+      expect(buttons.map { |button| button[:custom_id] }).to eq([
+        Roles::CustomId.pick(set, red),
+        Roles::CustomId.pick(set, blue)
+      ])
+    end
+
+    it "styles the active role as primary and the rest as secondary" do
+      buttons = picker[:components].flat_map { |row| row[:components] }
+      expect(buttons.map { |button| button[:style] }).to eq([described_class::SECONDARY, described_class::PRIMARY])
+    end
+
+    it "chunks buttons into rows of five" do
+      6.times { |n| create(:assignable_role, role_set: set, role_id: 300 + n, position: 10 + n) }
+      expect(described_class.single_picker(set, [])[:components].size).to eq(2)
+    end
+  end
+
+  describe ".multi_picker" do
+    subject(:picker) { described_class.multi_picker(set, [200]) }
+
+    let(:set) { create(:role_set, name: "Pings", selection_mode: "multi") }
+    let!(:news) { create(:assignable_role, role_set: set, role_id: 100, label: "News", description: "Announcements", position: 0) }
+    let!(:events) { create(:assignable_role, role_set: set, role_id: 200, label: "Events", description: nil, position: 1) }
+
+    let(:select) { picker[:components].first[:components].first }
+
+    it "is a string select carrying the set's custom id" do
+      expect(select).to include(type: described_class::STRING_SELECT, custom_id: Roles::CustomId.select(set))
+    end
+
+    it "lets the user pick any number of roles in the set" do
+      expect(select).to include(min_values: 0, max_values: 2)
+    end
+
+    it "pre-checks the roles the user already has" do
+      defaults = select[:options].select { |option| option[:default] }
+      expect(defaults.map { |option| option[:value] }).to eq(["200"])
+    end
+
+    it "carries a description only when the role has one" do
+      news_option = select[:options].find { |option| option[:value] == "100" }
+      expect(news_option).to include(description: "Announcements")
+      expect(select[:options].find { |option| option[:value] == "200" }).not_to have_key(:description)
+    end
+  end
+
+  describe ".selection_summary" do
+    subject(:summary) { described_class.selection_summary(set, active) }
+
+    let(:set) { create(:role_set, name: "Color") }
+
+    before do
+      create(:assignable_role, role_set: set, role_id: 100, label: "Red", position: 0)
+      create(:assignable_role, role_set: set, role_id: 200, label: "Blue", position: 1)
+    end
+
+    context "with roles selected" do
+      let(:active) { [200] }
+
+      it "lists the chosen role labels" do
+        expect(summary).to eq("**Color**: Blue")
+      end
+    end
+
+    context "with nothing selected" do
+      let(:active) { [] }
+
+      it "says none" do
+        expect(summary).to eq("**Color**: none")
+      end
+    end
+  end
 end

--- a/spec/plugins/roles/message_spec.rb
+++ b/spec/plugins/roles/message_spec.rb
@@ -23,11 +23,14 @@ RSpec.describe Roles::Message do
   end
 
   describe ".public_message" do
-    it "wraps the message in a container and sets the components-v2 flag" do
+    it "wraps the message in an accented container and sets the components-v2 flag" do
       set = create(:role_set, role_setting: setting, selection_mode: "multi")
       rendered = described_class.public_message(set)
       expect(rendered[:flags]).to eq(described_class::COMPONENTS_V2)
-      expect(rendered[:components].first[:type]).to eq(described_class::CONTAINER)
+      expect(rendered[:components].first).to include(
+        type: described_class::CONTAINER,
+        accent_color: described_class::ACCENT_COLOR
+      )
     end
 
     context "for a multi-selection set" do
@@ -42,14 +45,23 @@ RSpec.describe Roles::Message do
         sync_role(200, "Artist")
       end
 
-      it "lists the set name and synced role names in order" do
-        expect(text_block(rendered)[:content]).to eq("**Game Roles**\n🎮 Gamer\nArtist")
+      it "heads with the set name and lists the synced roles side by side" do
+        content = text_block(rendered)[:content]
+        expect(content).to include("### Game Roles")
+        expect(content).to include("🎮 Gamer • Artist")
       end
 
-      it "offers a single manage button" do
-        expect(row_components(rendered)).to contain_exactly(
-          hash_including(label: "Manage Roles", custom_id: Roles::CustomId.manage(set))
-        )
+      it "explains the multi-select" do
+        expect(text_block(rendered)[:content]).to include("Select all roles that apply")
+      end
+
+      it "separates the text from the controls" do
+        expect(container_blocks(rendered).map { |block| block[:type] }).to include(described_class::SEPARATOR)
+      end
+
+      it "offers a manage button as a section accessory" do
+        section = container_blocks(rendered).find { |block| block[:type] == described_class::SECTION }
+        expect(section[:accessory]).to include(label: "Manage Roles", custom_id: Roles::CustomId.manage(set))
       end
     end
 
@@ -74,8 +86,14 @@ RSpec.describe Roles::Message do
         ])
       end
 
-      it "warns that picking replaces the current role" do
-        expect(text_block(rendered)[:content]).to include("replaces your current one")
+      it "heads with the set name and warns that picking replaces the current role" do
+        content = text_block(rendered)[:content]
+        expect(content).to include("### Color")
+        expect(content).to include("replaces your current one")
+      end
+
+      it "separates the text from the buttons" do
+        expect(container_blocks(rendered).map { |block| block[:type] }).to include(described_class::SEPARATOR)
       end
 
       it "chunks the buttons into rows of five" do

--- a/spec/plugins/roles/message_spec.rb
+++ b/spec/plugins/roles/message_spec.rb
@@ -23,9 +23,11 @@ RSpec.describe Roles::Message do
   end
 
   describe ".public_message" do
+    subject(:rendered) { described_class.public_message(set) }
+
+    let(:set) { create(:role_set, role_setting: setting, selection_mode: "multi") }
+
     it "wraps the message in an accented container and sets the components-v2 flag" do
-      set = create(:role_set, role_setting: setting, selection_mode: "multi")
-      rendered = described_class.public_message(set)
       expect(rendered[:flags]).to eq(described_class::COMPONENTS_V2)
       expect(rendered[:components].first).to include(
         type: described_class::CONTAINER,
@@ -34,8 +36,6 @@ RSpec.describe Roles::Message do
     end
 
     context "for a multi-selection set" do
-      subject(:rendered) { described_class.public_message(set) }
-
       let(:set) { create(:role_set, role_setting: setting, name: "Game Roles", selection_mode: "multi") }
 
       before do
@@ -66,8 +66,6 @@ RSpec.describe Roles::Message do
     end
 
     context "for a single-selection set" do
-      subject(:rendered) { described_class.public_message(set) }
-
       let(:set) { create(:role_set, role_setting: setting, name: "Color", selection_mode: "single") }
       let!(:red) { create(:assignable_role, role_set: set, role_id: 100, position: 0) }
       let!(:blue) { create(:assignable_role, role_set: set, role_id: 200, position: 1) }
@@ -96,19 +94,22 @@ RSpec.describe Roles::Message do
         expect(container_blocks(rendered).map { |block| block[:type] }).to include(described_class::SEPARATOR)
       end
 
-      it "chunks the buttons into rows of five" do
-        6.times do |n|
-          create(:assignable_role, role_set: set, role_id: 300 + n, position: 10 + n)
-          sync_role(300 + n, "extra-#{n}")
+      context "with more than five roles" do
+        before do
+          6.times do |n|
+            create(:assignable_role, role_set: set, role_id: 300 + n, position: 10 + n)
+            sync_role(300 + n, "extra-#{n}")
+          end
         end
-        rows = container_blocks(rendered).select { |block| block[:type] == described_class::ACTION_ROW }
-        expect(rows.size).to eq(2)
+
+        it "chunks the buttons into rows of five" do
+          rows = container_blocks(rendered).select { |block| block[:type] == described_class::ACTION_ROW }
+          expect(rows.size).to eq(2)
+        end
       end
     end
 
     context "with a role that has not been synced" do
-      subject(:rendered) { described_class.public_message(set) }
-
       let(:set) { create(:role_set, role_setting: setting, selection_mode: "single") }
 
       before do

--- a/spec/plugins/roles/message_spec.rb
+++ b/spec/plugins/roles/message_spec.rb
@@ -1,36 +1,73 @@
 require "rails_helper"
 
 RSpec.describe Roles::Message do
-  describe ".public_message" do
-    context "for a multi-selection set" do
-      subject(:message) { described_class.public_message(set) }
+  let(:server_config) { create(:server_configuration) }
+  let(:setting) { create(:role_setting, server_configuration: server_config) }
 
-      let(:set) { create(:role_set, name: "Game Roles", selection_mode: "multi") }
+  def sync_role(discord_id, name)
+    create(:server_role, server_configuration: server_config, discord_id: discord_id, name: name)
+  end
+
+  def container_blocks(rendered)
+    rendered[:components].first[:components]
+  end
+
+  def text_block(rendered)
+    container_blocks(rendered).find { |block| block[:type] == described_class::TEXT_DISPLAY }
+  end
+
+  def row_components(rendered)
+    container_blocks(rendered)
+      .select { |block| block[:type] == described_class::ACTION_ROW }
+      .flat_map { |row| row[:components] }
+  end
+
+  describe ".public_message" do
+    it "wraps the message in a container and sets the components-v2 flag" do
+      set = create(:role_set, role_setting: setting, selection_mode: "multi")
+      rendered = described_class.public_message(set)
+      expect(rendered[:flags]).to eq(described_class::COMPONENTS_V2)
+      expect(rendered[:components].first[:type]).to eq(described_class::CONTAINER)
+    end
+
+    context "for a multi-selection set" do
+      subject(:rendered) { described_class.public_message(set) }
+
+      let(:set) { create(:role_set, role_setting: setting, name: "Game Roles", selection_mode: "multi") }
 
       before do
-        create(:assignable_role, role_set: set, label: "Gamer", emoji: "🎮", position: 0)
-        create(:assignable_role, role_set: set, label: "Artist", emoji: nil, position: 1)
+        create(:assignable_role, role_set: set, role_id: 100, emoji: "🎮", position: 0)
+        create(:assignable_role, role_set: set, role_id: 200, emoji: nil, position: 1)
+        sync_role(100, "Gamer")
+        sync_role(200, "Artist")
       end
 
-      it "lists the set name and its roles in order" do
-        expect(message[:content]).to eq("**Game Roles**\n🎮 Gamer\nArtist")
+      it "lists the set name and synced role names in order" do
+        expect(text_block(rendered)[:content]).to eq("**Game Roles**\n🎮 Gamer\nArtist")
       end
 
-      it "includes a manage button carrying the set's custom id" do
-        button = message[:components].first[:components].first
-        expect(button).to include(label: "Manage Roles", custom_id: Roles::CustomId.manage(set))
+      it "offers a single manage button" do
+        expect(row_components(rendered)).to contain_exactly(
+          hash_including(label: "Manage Roles", custom_id: Roles::CustomId.manage(set))
+        )
       end
     end
 
     context "for a single-selection set" do
-      subject(:message) { described_class.public_message(set) }
+      subject(:rendered) { described_class.public_message(set) }
 
-      let(:set) { create(:role_set, name: "Color", selection_mode: "single") }
-      let!(:red) { create(:assignable_role, role_set: set, role_id: 100, label: "Red", position: 0) }
-      let!(:blue) { create(:assignable_role, role_set: set, role_id: 200, label: "Blue", position: 1) }
+      let(:set) { create(:role_set, role_setting: setting, name: "Color", selection_mode: "single") }
+      let!(:red) { create(:assignable_role, role_set: set, role_id: 100, position: 0) }
+      let!(:blue) { create(:assignable_role, role_set: set, role_id: 200, position: 1) }
 
-      it "renders the role buttons directly, no manage step" do
-        buttons = message[:components].flat_map { |row| row[:components] }
+      before do
+        sync_role(100, "Red")
+        sync_role(200, "Blue")
+      end
+
+      it "renders a button per role, labelled with the synced role name" do
+        buttons = row_components(rendered)
+        expect(buttons.map { |button| button[:label] }).to eq(["Red", "Blue"])
         expect(buttons.map { |button| button[:custom_id] }).to eq([
           Roles::CustomId.pick(set, red),
           Roles::CustomId.pick(set, blue)
@@ -38,24 +75,51 @@ RSpec.describe Roles::Message do
       end
 
       it "warns that picking replaces the current role" do
-        expect(message[:content]).to include("replaces your current one")
+        expect(text_block(rendered)[:content]).to include("replaces your current one")
       end
 
       it "chunks the buttons into rows of five" do
-        6.times { |n| create(:assignable_role, role_set: set, role_id: 300 + n, position: 10 + n) }
-        expect(message[:components].size).to eq(2)
+        6.times do |n|
+          create(:assignable_role, role_set: set, role_id: 300 + n, position: 10 + n)
+          sync_role(300 + n, "extra-#{n}")
+        end
+        rows = container_blocks(rendered).select { |block| block[:type] == described_class::ACTION_ROW }
+        expect(rows.size).to eq(2)
+      end
+    end
+
+    context "with a role that has not been synced" do
+      subject(:rendered) { described_class.public_message(set) }
+
+      let(:set) { create(:role_set, role_setting: setting, selection_mode: "single") }
+
+      before do
+        create(:assignable_role, role_set: set, role_id: 999, position: 0)
+      end
+
+      it "falls back to a placeholder so the button is never empty" do
+        expect(row_components(rendered).first[:label]).to eq(described_class::UNKNOWN_ROLE)
       end
     end
   end
 
   describe ".multi_picker" do
-    subject(:picker) { described_class.multi_picker(set, [200]) }
+    subject(:select) do
+      row_components(described_class.multi_picker(set, [200])).first
+    end
 
-    let(:set) { create(:role_set, name: "Pings", selection_mode: "multi") }
-    let!(:news) { create(:assignable_role, role_set: set, role_id: 100, label: "News", description: "Announcements", position: 0) }
-    let!(:events) { create(:assignable_role, role_set: set, role_id: 200, label: "Events", description: nil, position: 1) }
+    let(:set) { create(:role_set, role_setting: setting, name: "Pings", selection_mode: "multi") }
 
-    let(:select) { picker[:components].first[:components].first }
+    before do
+      create(:assignable_role, role_set: set, role_id: 100, description: "Announcements", position: 0)
+      create(:assignable_role, role_set: set, role_id: 200, description: nil, position: 1)
+      sync_role(100, "News")
+      sync_role(200, "Events")
+    end
+
+    it "sets the components-v2 flag" do
+      expect(described_class.multi_picker(set, [])[:flags]).to eq(described_class::COMPONENTS_V2)
+    end
 
     it "is a string select carrying the set's custom id" do
       expect(select).to include(type: described_class::STRING_SELECT, custom_id: Roles::CustomId.select(set))
@@ -65,32 +129,39 @@ RSpec.describe Roles::Message do
       expect(select).to include(min_values: 0, max_values: 2)
     end
 
+    it "labels options with the synced role names" do
+      expect(select[:options].map { |option| option[:label] }).to contain_exactly("News", "Events")
+    end
+
     it "pre-checks the roles the user already has" do
       defaults = select[:options].select { |option| option[:default] }
       expect(defaults.map { |option| option[:value] }).to eq(["200"])
     end
 
     it "carries a description only when the role has one" do
-      news_option = select[:options].find { |option| option[:value] == "100" }
-      expect(news_option).to include(description: "Announcements")
-      expect(select[:options].find { |option| option[:value] == "200" }).not_to have_key(:description)
+      news = select[:options].find { |option| option[:value] == "100" }
+      events = select[:options].find { |option| option[:value] == "200" }
+      expect(news).to include(description: "Announcements")
+      expect(events).not_to have_key(:description)
     end
   end
 
   describe ".selection_summary" do
     subject(:summary) { described_class.selection_summary(set, active) }
 
-    let(:set) { create(:role_set, name: "Color") }
+    let(:set) { create(:role_set, role_setting: setting, name: "Color") }
 
     before do
-      create(:assignable_role, role_set: set, role_id: 100, label: "Red", position: 0)
-      create(:assignable_role, role_set: set, role_id: 200, label: "Blue", position: 1)
+      create(:assignable_role, role_set: set, role_id: 100, position: 0)
+      create(:assignable_role, role_set: set, role_id: 200, position: 1)
+      sync_role(100, "Red")
+      sync_role(200, "Blue")
     end
 
     context "with roles selected" do
       let(:active) { [200] }
 
-      it "lists the chosen role labels" do
+      it "lists the chosen synced role names" do
         expect(summary).to eq("**Color**: Blue")
       end
     end

--- a/spec/plugins/roles/message_spec.rb
+++ b/spec/plugins/roles/message_spec.rb
@@ -2,48 +2,49 @@ require "rails_helper"
 
 RSpec.describe Roles::Message do
   describe ".public_message" do
-    subject(:message) { described_class.public_message(set) }
+    context "for a multi-selection set" do
+      subject(:message) { described_class.public_message(set) }
 
-    let(:set) { create(:role_set, name: "Game Roles") }
+      let(:set) { create(:role_set, name: "Game Roles", selection_mode: "multi") }
 
-    before do
-      create(:assignable_role, role_set: set, label: "Gamer", emoji: "🎮", position: 0)
-      create(:assignable_role, role_set: set, label: "Artist", emoji: nil, position: 1)
+      before do
+        create(:assignable_role, role_set: set, label: "Gamer", emoji: "🎮", position: 0)
+        create(:assignable_role, role_set: set, label: "Artist", emoji: nil, position: 1)
+      end
+
+      it "lists the set name and its roles in order" do
+        expect(message[:content]).to eq("**Game Roles**\n🎮 Gamer\nArtist")
+      end
+
+      it "includes a manage button carrying the set's custom id" do
+        button = message[:components].first[:components].first
+        expect(button).to include(label: "Manage Roles", custom_id: Roles::CustomId.manage(set))
+      end
     end
 
-    it "lists the set name and its roles in order" do
-      expect(message[:content]).to eq("**Game Roles**\n🎮 Gamer\nArtist")
-    end
+    context "for a single-selection set" do
+      subject(:message) { described_class.public_message(set) }
 
-    it "includes a manage button carrying the set's custom id" do
-      button = message[:components].first[:components].first
-      expect(button).to include(label: "Manage Roles", custom_id: Roles::CustomId.manage(set))
-    end
-  end
+      let(:set) { create(:role_set, name: "Color", selection_mode: "single") }
+      let!(:red) { create(:assignable_role, role_set: set, role_id: 100, label: "Red", position: 0) }
+      let!(:blue) { create(:assignable_role, role_set: set, role_id: 200, label: "Blue", position: 1) }
 
-  describe ".single_picker" do
-    subject(:picker) { described_class.single_picker(set, [200]) }
+      it "renders the role buttons directly, no manage step" do
+        buttons = message[:components].flat_map { |row| row[:components] }
+        expect(buttons.map { |button| button[:custom_id] }).to eq([
+          Roles::CustomId.pick(set, red),
+          Roles::CustomId.pick(set, blue)
+        ])
+      end
 
-    let(:set) { create(:role_set, name: "Color", selection_mode: "single") }
-    let!(:red) { create(:assignable_role, role_set: set, role_id: 100, label: "Red", position: 0) }
-    let!(:blue) { create(:assignable_role, role_set: set, role_id: 200, label: "Blue", position: 1) }
+      it "warns that picking replaces the current role" do
+        expect(message[:content]).to include("replaces your current one")
+      end
 
-    it "renders one button per role" do
-      buttons = picker[:components].flat_map { |row| row[:components] }
-      expect(buttons.map { |button| button[:custom_id] }).to eq([
-        Roles::CustomId.pick(set, red),
-        Roles::CustomId.pick(set, blue)
-      ])
-    end
-
-    it "styles the active role as primary and the rest as secondary" do
-      buttons = picker[:components].flat_map { |row| row[:components] }
-      expect(buttons.map { |button| button[:style] }).to eq([described_class::SECONDARY, described_class::PRIMARY])
-    end
-
-    it "chunks buttons into rows of five" do
-      6.times { |n| create(:assignable_role, role_set: set, role_id: 300 + n, position: 10 + n) }
-      expect(described_class.single_picker(set, [])[:components].size).to eq(2)
+      it "chunks the buttons into rows of five" do
+        6.times { |n| create(:assignable_role, role_set: set, role_id: 300 + n, position: 10 + n) }
+        expect(message[:components].size).to eq(2)
+      end
     end
   end
 

--- a/spec/plugins/roles/message_spec.rb
+++ b/spec/plugins/roles/message_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Roles::Message do
       it "heads with the set name and lists the synced roles side by side" do
         content = text_block(rendered)[:content]
         expect(content).to include("### Game Roles")
-        expect(content).to include("🎮 Gamer • Artist")
+        expect(content).to include("- **🎮 Gamer**\n- **Artist**")
       end
 
       it "explains the multi-select" do


### PR DESCRIPTION
Continues review-plans item 4 (finish Roles). The config CRUD, message rendering, and poster already landed; this wires up the **runtime** per-user flow.

## Flow

The public set message carries a **Manage Roles** button. Clicking it:

- **`Roles::Manage`** (`on :button, custom_id: /\Aroles:manage:/`) → responds with an **ephemeral** picker reflecting what the user already has:
  - single-selection set → one button per role, the current one styled primary (exclusive);
  - multi-selection set → a string select, current roles pre-checked, `min_values: 0`.
- **`Roles::Pick`** (single) → adds the picked role, removes the set's others, re-renders.
- **`Roles::Select`** (multi) → diffs the submitted values against the set, adds/removes, re-renders.

Pick/Select apply via `member.modify_roles(add, remove)` and **constrain selection to the set's own roles**, so a forged `custom_id` can't grant an arbitrary server role (anti-spoofing, C3 spirit). `notify_on_assign` DMs the user their resulting selection.

## Design notes

- **Not an op.** Toggling a Discord role is pure Discord API with no DB write and no web caller, so it doesn't fit the `Ops` seam (which is the shared bot+web/DB-write layer). It lives bot-side; the testable unit is the pure `Roles::Assignment` diff, with `member.modify_roles` as the mocked seam. (My earlier note had penciled in an `Ops::Roles::ToggleAssignableRole` — flagging the deliberate deviation.)
- **`on` now forwards keyword attributes** to the discordrb handler, so component events route by `custom_id` regexp. A thin `Roles::ComponentHandler` base shares set lookup / member resolution / notify.
- **Deferred:** `log_on_assign` → the logging/ModLog phase (F4); bot-can't-assign-above-its-top-role → Phase 7 web grey-out, with runtime failing gracefully via `BaseEvent`'s rescue.

## Tests

Pure diff (`assignment_spec`), picker rendering + summary (`message_spec`), all three handlers, plus the extended `on`/registrar attribute path. 293 examples green; standardrb + zeitwerk + active_record_doctor clean.

**Needs a live gate** (mine to flag, yours to run): post a set message, click through single + multi pickers on the test server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)