### PR TITLE
Add Discord::Truncate word-boundary helper

### DIFF
--- a/app/bot/discord/truncate.rb
+++ b/app/bot/discord/truncate.rb
@@ -1,0 +1,9 @@
+module Discord
+  module Truncate
+    module_function
+
+    def call(text, limit)
+      text.to_s.truncate(limit, separator: " ", omission: "…")
+    end
+  end
+end

--- a/app/bot/owner_notifier.rb
+++ b/app/bot/owner_notifier.rb
@@ -29,6 +29,6 @@ module OwnerNotifier
       #{backtrace}
       ```
     MSG
-    (msg.length > MAX_LENGTH) ? "#{msg[0, MAX_LENGTH]}…" : msg
+    Discord::Truncate.call(msg, MAX_LENGTH)
   end
 end

--- a/app/plugins/reminders/commands/list.rb
+++ b/app/plugins/reminders/commands/list.rb
@@ -10,7 +10,7 @@ module Reminders
       if reminders.empty?
         event.respond(content: "You have no active reminders.", ephemeral: true)
       else
-        lines = reminders.map { |r| "• <t:#{r.remind_at.to_i}:R> — #{r.message.truncate(80)}" }
+        lines = reminders.map { |r| "• <t:#{r.remind_at.to_i}:R> — #{Discord::Truncate.call(r.message, 80)}" }
         event.respond(content: lines.join("\n"), ephemeral: true)
       end
     end

--- a/app/plugins/reminders/commands/unremind.rb
+++ b/app/plugins/reminders/commands/unremind.rb
@@ -25,7 +25,7 @@ module Reminders
     private
 
     def choice_label(reminder)
-      "#{reminder.message.truncate(75)} (#{reminder.remind_at.strftime("%b %-d %H:%M %Z")})"
+      "#{Discord::Truncate.call(reminder.message, 75)} (#{reminder.remind_at.strftime("%b %-d %H:%M %Z")})"
     end
   end
 end

--- a/spec/bot/discord/truncate_spec.rb
+++ b/spec/bot/discord/truncate_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe Discord::Truncate do
+  describe ".call" do
+    subject(:truncated) { described_class.call(text, limit) }
+
+    context "when the text fits within the limit" do
+      let(:text) { "hello world" }
+      let(:limit) { 50 }
+
+      it { is_expected.to eq("hello world") }
+    end
+
+    context "when the text exactly fills the limit" do
+      let(:text) { "hello" }
+      let(:limit) { 5 }
+
+      it { is_expected.to eq("hello") }
+    end
+
+    context "when the text exceeds the limit" do
+      let(:text) { "hello world foo bar baz" }
+      let(:limit) { 12 }
+
+      it "breaks at a word boundary and ends with an ellipsis" do
+        expect(truncated).to eq("hello world…")
+      end
+
+      it "never exceeds the limit" do
+        expect(truncated.length).to be <= limit
+      end
+    end
+
+    context "when a single word is longer than the limit" do
+      let(:text) { "supercalifragilistic" }
+      let(:limit) { 10 }
+
+      it "hard-cuts and still ends with an ellipsis within the limit" do
+        expect(truncated).to end_with("…")
+        expect(truncated.length).to eq(10)
+      end
+    end
+
+    context "with nil" do
+      let(:text) { nil }
+      let(:limit) { 10 }
+
+      it { is_expected.to eq("") }
+    end
+  end
+end


### PR DESCRIPTION
F1 from the review plan: a single `Discord::Truncate.call(text, limit)` helper that truncates to a Discord length limit, breaking at a word boundary and appending an ellipsis.

Thin wrapper over ActiveSupport's `String#truncate` with the Discord defaults (`separator: " "`, `omission: "…"`) baked in, so call sites stop repeating them and stop hand-rolling hard cuts. Lives at `app/bot/discord/truncate.rb` (`app/bot` is a Zeitwerk root, so the `discord/` subdir gives the `Discord::` namespace with zero config).

Wired into:
- `OwnerNotifier` — replaces the hard cut at 1900
- reminders `/reminders` list + `/unremind` autocomplete labels — replaces the `.truncate(75/80)` hard cuts

Test-first; 6 unit examples covering fits/exact-fit/word-boundary/single-long-word/nil. Full suite 308 green, standardrb + zeitwerk:check clean.