### PR TITLE
Per-message force-repost over a web->bot config bus

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,7 @@ DISCORD_CLIENT_SECRET=
 # If you instead run the app INSIDE the compose network, use the service host:
 #   postgres://root:password@db:5432/shrkbot_db
 DATABASE_URL=postgres://root:password@localhost:5678/shrkbot_db
-# Redis isn't wired up yet (Solid Queue uses Postgres). Needed in Phase 8 for
-# web->bot pub/sub; there's no redis service in docker-compose yet.
+# Web->bot config propagation: the bot subscribes, the web UI publishes.
+# Leave blank to disable the subscriber (the bot logs it's off and runs anyway).
+# Solid Queue itself is Postgres-backed and doesn't need this.
 REDIS_URL=redis://localhost:6379/0

--- a/app/bot/bot_config.rb
+++ b/app/bot/bot_config.rb
@@ -17,6 +17,10 @@ module BotConfig
     ENV["TEST_SERVER_ID"]
   end
 
+  def redis_url
+    ENV["REDIS_URL"]
+  end
+
   def shard_count
     [ENV.fetch("SHARD_COUNT", "1").to_i, 1].max
   end

--- a/app/bot/config_bus.rb
+++ b/app/bot/config_bus.rb
@@ -1,0 +1,13 @@
+module ConfigBus
+  CHANNEL = "shrkbot:config"
+
+  module_function
+
+  def repost_roles(role_set)
+    publish(type: "roles_repost", set_id: role_set.id)
+  end
+
+  def publish(payload)
+    Redis.new(url: BotConfig.redis_url).publish(CHANNEL, JSON.generate(payload))
+  end
+end

--- a/app/bot/config_subscriber.rb
+++ b/app/bot/config_subscriber.rb
@@ -1,0 +1,45 @@
+class ConfigSubscriber
+  include WithConnection
+
+  def initialize(bot)
+    @bot = bot
+  end
+
+  def start
+    Thread.new do
+      Redis.new(url: BotConfig.redis_url).subscribe(ConfigBus::CHANNEL) do |on|
+        on.message do |_channel, payload|
+          handle(payload)
+        end
+      end
+    end
+  end
+
+  def handle(payload)
+    event = JSON.parse(payload, symbolize_names: true)
+    with_connection do
+      route(event)
+    end
+  rescue => e
+    Rails.logger.error("[ConfigSubscriber] #{e.class}: #{e.message}")
+    OwnerNotifier.report(bot: @bot, error: e, source: "ConfigSubscriber")
+  end
+
+  private
+
+  attr_reader :bot
+
+  def route(event)
+    case event[:type]
+    when "roles_repost"
+      repost_roles(event[:set_id])
+    end
+  end
+
+  def repost_roles(set_id)
+    set = Roles::Set.find_by(id: set_id)
+    return unless set
+
+    Ops::Roles::Messages::Repost.call(bot: bot, role_set: set)
+  end
+end

--- a/app/operations/roles/messages/repost.rb
+++ b/app/operations/roles/messages/repost.rb
@@ -1,0 +1,31 @@
+module Ops
+  module Roles
+    module Messages
+      class Repost < ApplicationOperation
+        self.transactional = false
+
+        receives :bot, :role_set
+
+        def call
+          delete_stale_message
+          role_set.update!(message_id: nil)
+          ::Roles::MessagePoster.post(bot, role_set)
+
+          return failure("Could not post the role message — check the channel.") if role_set.message_id.nil?
+
+          ok(role_set)
+        end
+
+        private
+
+        def delete_stale_message
+          return if role_set.message_id.nil?
+
+          bot.channel(role_set.channel_id)&.load_message(role_set.message_id)&.delete
+        rescue
+          nil
+        end
+      end
+    end
+  end
+end

--- a/bin/bot
+++ b/bin/bot
@@ -44,6 +44,13 @@ bots.each_with_index do |bot, index|
   bot.server_delete { refresh_presence.call }
 end
 
+if BotConfig.redis_url
+  ConfigSubscriber.new(bots.first).start
+  Rails.logger.info("[bot] config subscriber listening on #{ConfigBus::CHANNEL}")
+else
+  Rails.logger.warn("[bot] REDIS_URL not set — config subscriber disabled")
+end
+
 bots.each_with_index do |bot, index|
   sleep(5) unless index.zero?
   Rails.logger.info("[bot] shard #{index + 1}/#{shard_count} connecting…")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,15 @@ services:
       timeout: 3s
       retries: 10
 
+  redis:
+    image: redis:7
+    restart: always
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
   # The app processes. Same image, different command. RAILS_ENV=development for
   # now; DATABASE_URL here points at the in-network db host (overrides the
   # localhost value in .env — compose `environment` wins, and dotenv won't
@@ -28,12 +37,15 @@ services:
     environment:
       RAILS_ENV: development
       DATABASE_URL: postgres://root:password@db:5432/shrkbot_db
+      REDIS_URL: redis://redis:6379/0
     ports:
       - 3000:3000
     volumes:
       - ./:/app
     depends_on:
       db:
+        condition: service_healthy
+      redis:
         condition: service_healthy
 
   bot:
@@ -43,10 +55,13 @@ services:
     environment:
       RAILS_ENV: development
       DATABASE_URL: postgres://root:password@db:5432/shrkbot_db
+      REDIS_URL: redis://redis:6379/0
     volumes:
       - ./:/app
     depends_on:
       db:
+        condition: service_healthy
+      redis:
         condition: service_healthy
 
   jobs:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,7 +13,7 @@ One Docker image, multiple services off it:
 - **bot** (`bin/bot`) — the discordrb gateway connection. Long-lived, blocking. Must be its own process: discordrb is gateway-based, and booting it from a Puma worker would open one gateway connection per cluster worker (duplicate events).
 - **jobs** (`bin/jobs`) — Solid Queue worker for background and scheduled work (reminder delivery).
 - **postgres** — source of truth.
-- **redis** — config-change pub/sub (web → bot), Phase 8.
+- **redis** — config-change pub/sub (web → bot); see [Config propagation](#config-propagation).
 
 discordrb dispatches each handler on its own thread, so any DB work in the bot
 process must check out and return its own connection from the AR pool — see
@@ -263,6 +263,31 @@ drops later shards into reconnect backoff.
 The gateway `Bot` prefixes the auth header itself, but direct `Discordrb::API` calls
 (e.g. reminder delivery from the jobs process) need the header as `Bot <token>` or
 Discord returns 401. `BotConfig.rest_token` provides the prefixed form.
+
+## Config propagation
+
+Config is written on the web side, but anything that touches Discord (posting a
+role message, re-registering commands) can only run in the bot process, which
+holds the gateway and token. The two are bridged by a one-way Redis pub/sub bus:
+the web UI publishes, the bot subscribes.
+
+`ConfigBus` (`app/bot/config_bus.rb`) publishes typed JSON events on a single
+channel (`shrkbot:config`); `ConfigSubscriber` (`app/bot/config_subscriber.rb`)
+runs a listener thread on the first shard's bot, routes each event by `type`, and
+hands off to an operation inside a `with_connection` block (its own AR
+connection, like every other bot thread). A malformed or failing event is logged
+and reported to the owner rather than killing the listener.
+
+The first event type is `roles_repost` (`ConfigBus.repost_roles(set)`), the
+force-repost recovery path: it runs `Ops::Roles::Messages::Repost`, which deletes
+the set's stale message (best-effort — a 404 is the expected case) and posts a
+fresh one. The op runs bot-side because both steps need the token; it fails if the
+channel can't be resolved rather than silently doing nothing. Add a new event by
+publishing a new `type` and adding a branch to `ConfigSubscriber#route`.
+
+The bot starts the subscriber only when `REDIS_URL` is set; without it the bot
+logs that propagation is off and runs anyway (Solid Queue is Postgres-backed and
+doesn't depend on Redis).
 
 ## Bot settings vs server configuration
 

--- a/spec/bot/config_bus_spec.rb
+++ b/spec/bot/config_bus_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe ConfigBus do
+  let(:redis) { double("redis") }
+
+  before do
+    allow(Redis).to receive(:new).and_return(redis)
+    allow(redis).to receive(:publish)
+  end
+
+  describe ".repost_roles" do
+    let(:set) { create(:role_set) }
+
+    it "publishes a roles_repost event carrying the set id" do
+      described_class.repost_roles(set)
+
+      expect(redis).to have_received(:publish).with(
+        described_class::CHANNEL,
+        JSON.generate(type: "roles_repost", set_id: set.id)
+      )
+    end
+  end
+end

--- a/spec/bot/config_subscriber_spec.rb
+++ b/spec/bot/config_subscriber_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe ConfigSubscriber do
+  subject(:subscriber) { described_class.new(bot) }
+
+  let(:bot) { double("bot") }
+
+  describe "#handle" do
+    context "with a roles_repost event for an existing set" do
+      let(:set) { create(:role_set) }
+      let(:payload) { JSON.generate(type: "roles_repost", set_id: set.id) }
+
+      it "runs the repost operation for that set with the bot" do
+        expect(Ops::Roles::Messages::Repost).to receive(:call).with(bot: bot, role_set: set)
+
+        subscriber.handle(payload)
+      end
+    end
+
+    context "when the set no longer exists" do
+      let(:payload) { JSON.generate(type: "roles_repost", set_id: "rls_missing") }
+
+      it "does not run the operation" do
+        expect(Ops::Roles::Messages::Repost).not_to receive(:call)
+        subscriber.handle(payload)
+      end
+    end
+
+    context "with an unknown event type" do
+      let(:payload) { JSON.generate(type: "something_else", set_id: "x") }
+
+      it "ignores it without raising" do
+        expect { subscriber.handle(payload) }.not_to raise_error
+      end
+    end
+
+    context "with malformed JSON" do
+      let(:payload) { "not json" }
+
+      it "reports the error instead of crashing the listener" do
+        allow(OwnerNotifier).to receive(:report)
+        expect { subscriber.handle(payload) }.not_to raise_error
+        expect(OwnerNotifier).to have_received(:report)
+      end
+    end
+  end
+end

--- a/spec/bot/config_subscriber_spec.rb
+++ b/spec/bot/config_subscriber_spec.rb
@@ -5,6 +5,22 @@ RSpec.describe ConfigSubscriber do
 
   let(:bot) { double("bot") }
 
+  describe "#start" do
+    let(:redis) { double("redis") }
+    let(:on) { double("on") }
+
+    it "subscribes on the config channel and routes each message to #handle" do
+      allow(Thread).to receive(:new).and_yield
+      allow(Redis).to receive(:new).with(url: BotConfig.redis_url).and_return(redis)
+      allow(redis).to receive(:subscribe).with(ConfigBus::CHANNEL).and_yield(on)
+      allow(on).to receive(:message).and_yield("shrkbot:config", "payload")
+
+      expect(subscriber).to receive(:handle).with("payload")
+
+      subscriber.start
+    end
+  end
+
   describe "#handle" do
     context "with a roles_repost event for an existing set" do
       let(:set) { create(:role_set) }

--- a/spec/operations/roles/messages/repost_spec.rb
+++ b/spec/operations/roles/messages/repost_spec.rb
@@ -1,0 +1,95 @@
+require "rails_helper"
+
+RSpec.describe Ops::Roles::Messages::Repost do
+  subject(:result) { described_class.call(bot: bot, role_set: set) }
+
+  let(:bot) { double("bot") }
+  let(:channel) { double("channel") }
+  let(:setting) { create(:role_setting, channel_id: 555) }
+
+  context "when the set already has a posted message" do
+    let(:set) { create(:role_set, role_setting: setting, message_id: 111) }
+    let(:old_message) { double("old_message") }
+
+    before do
+      allow(bot).to receive(:channel).with(555).and_return(channel)
+      allow(channel).to receive(:load_message).with(111).and_return(old_message)
+      allow(old_message).to receive(:delete)
+      allow(channel).to receive(:send_message).and_return(double(id: 222))
+    end
+
+    it "deletes the stale message" do
+      expect(old_message).to receive(:delete)
+      result
+    end
+
+    it "posts a fresh message and stores its id" do
+      result
+      expect(set.reload.message_id).to eq(222)
+    end
+
+    it "succeeds" do
+      expect(result).to be_success
+    end
+  end
+
+  context "when the stale message is already gone" do
+    let(:set) { create(:role_set, role_setting: setting, message_id: 111) }
+
+    before do
+      allow(bot).to receive(:channel).with(555).and_return(channel)
+      allow(channel).to receive(:load_message).with(111).and_return(nil)
+      allow(channel).to receive(:send_message).and_return(double(id: 222))
+    end
+
+    it "reposts without raising" do
+      expect { result }.not_to raise_error
+      expect(set.reload.message_id).to eq(222)
+    end
+  end
+
+  context "when deleting the stale message raises" do
+    let(:set) { create(:role_set, role_setting: setting, message_id: 111) }
+    let(:old_message) { double("old_message") }
+
+    before do
+      allow(bot).to receive(:channel).with(555).and_return(channel)
+      allow(channel).to receive(:load_message).with(111).and_return(old_message)
+      allow(old_message).to receive(:delete).and_raise("404")
+      allow(channel).to receive(:send_message).and_return(double(id: 222))
+    end
+
+    it "swallows the delete failure and still reposts" do
+      result
+      expect(set.reload.message_id).to eq(222)
+    end
+  end
+
+  context "when the set has no message yet" do
+    let(:set) { create(:role_set, role_setting: setting, message_id: nil) }
+
+    before do
+      allow(bot).to receive(:channel).with(555).and_return(channel)
+      allow(channel).to receive(:send_message).and_return(double(id: 222))
+    end
+
+    it "posts without trying to load a stale message" do
+      expect(channel).not_to receive(:load_message)
+      result
+      expect(set.reload.message_id).to eq(222)
+    end
+  end
+
+  context "when the channel can't be resolved" do
+    let(:set) { create(:role_set, role_setting: setting, message_id: 111) }
+
+    before do
+      allow(bot).to receive(:channel).with(555).and_return(nil)
+    end
+
+    it "fails and leaves no message id" do
+      expect(result).to be_failure
+      expect(set.reload.message_id).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
F2 from the review plan: a per-message force-repost for role sets, plus the thin slice of the web->bot Redis bus that triggers it.

## Why
A role set's posted message can outlive itself — the message gets deleted, or its channel does. There was no recovery path; the set just points at a dead message id.

## What
- **`Ops::Roles::Messages::Repost(bot:, role_set:)`** — deletes the set's stale message (best-effort; a 404 is the expected case), clears `message_id`, and posts fresh via `Roles::MessagePoster`. Runs bot-side because both steps need the gateway/token. Non-transactional (external IO). **Fails** with an error if the channel can't be resolved, rather than silently no-op'ing.
- **Web->bot config bus** (minimal, the long-deferred Phase-8 pub/sub seam):
  - `ConfigBus` (`app/bot/config_bus.rb`) — publishes typed JSON events on one Redis channel (`shrkbot:config`). First event: `ConfigBus.repost_roles(set)`, the method the Phase-7 web "repost" button will call.
  - `ConfigSubscriber` (`app/bot/config_subscriber.rb`) — listener thread on the first shard's bot; routes each event by `type` and runs the op inside `with_connection`. Malformed/failing events are logged + owner-reported, never crash the listener.
  - `bin/bot` starts the subscriber only when `REDIS_URL` is set; logs that it's disabled and runs anyway otherwise.
  - `BotConfig.redis_url`; `.env.example` comment refreshed; new `docs/architecture.md` "Config propagation" section.

## Decisions baked in (per your answers)
- Dead/invalid channel → **fail with an error** (not silent skip; not the F3 channel-delete rework).
- Trigger built now = **minimal Redis subscriber**, not a config command (keeps config web-only, design #10) and not full Phase-8 propagation.

## Tests
New: repost op (delete/repost/already-gone/no-prior-message/dead-channel), ConfigBus publish payload, ConfigSubscriber routing (dispatch / missing set / unknown type / malformed JSON). Full suite **320 green**, standardrb + zeitwerk:check + active_record_doctor clean.

## Not in this PR
- The web "repost" button (Phase 7 web UI) — `ConfigBus.repost_roles` is the seam it will call.
- A `redis` service in docker-compose + `REDIS_URL` in the bot/web service env — needs adding when you next touch the (read-only-in-sandbox) compose file; until then the subscriber self-disables.