### PR TITLE
Add /info, /donate, and /announce always-on commands

### DIFF
--- a/app/bot/announce_modal.rb
+++ b/app/bot/announce_modal.rb
@@ -4,10 +4,10 @@ class AnnounceModal < BaseEvent
   def handle
     return reject unless owner?
 
+    event.defer(ephemeral: true)
     result = OwnerBroadcast.call(bots: BotRegistry.all, content: content)
-    event.respond(
-      content: "📣 Sent to #{result.sent}/#{result.owner_count} unique owner(s) across #{result.server_count} server(s).",
-      ephemeral: true
+    event.edit_response(
+      content: "📣 Sent to #{result.sent}/#{result.owner_count} unique owner(s) across #{result.server_count} server(s)."
     )
   end
 

--- a/app/bot/announce_modal.rb
+++ b/app/bot/announce_modal.rb
@@ -1,0 +1,27 @@
+class AnnounceModal < BaseEvent
+  on :modal_submit, custom_id: Commands::Announce::MODAL_ID
+
+  def handle
+    return reject unless owner?
+
+    result = OwnerBroadcast.call(bots: BotRegistry.all, content: content)
+    event.respond(
+      content: "📣 Sent to #{result.sent}/#{result.owner_count} unique owner(s) across #{result.server_count} server(s).",
+      ephemeral: true
+    )
+  end
+
+  private
+
+  def content
+    event.value(Commands::Announce::INPUT_ID).to_s
+  end
+
+  def owner?
+    CommandPermissions.permitted?(event: event, required: [], owner_only: true)
+  end
+
+  def reject
+    event.respond(content: "🚫 You don't have permission to do that.", ephemeral: true)
+  end
+end

--- a/app/bot/bot_config.rb
+++ b/app/bot/bot_config.rb
@@ -1,4 +1,6 @@
 module BotConfig
+  ACCENT_COLOR = 0x39afe5
+
   module_function
 
   def token

--- a/app/bot/bot_registry.rb
+++ b/app/bot/bot_registry.rb
@@ -1,0 +1,11 @@
+module BotRegistry
+  module_function
+
+  def register(bots)
+    @bots = Array(bots)
+  end
+
+  def all
+    @bots || []
+  end
+end

--- a/app/bot/commands/announce.rb
+++ b/app/bot/commands/announce.rb
@@ -1,0 +1,25 @@
+module Commands
+  class Announce < BaseCommand
+    command_name :announce
+    description "Broadcast a message to the owner of every server shrkbot is in. Bot owner only."
+    owner_only
+    register_in :global
+
+    MODAL_ID = "announce:compose"
+    INPUT_ID = "announce:content"
+
+    def execute
+      event.show_modal(title: "Owner announcement", custom_id: MODAL_ID) do |modal|
+        modal.label(label: "Announcement", description: "DM'd to every unique server owner.") do |row|
+          row.text_input(
+            style: :paragraph,
+            custom_id: INPUT_ID,
+            required: true,
+            max_length: 2000,
+            placeholder: "Write your announcement…"
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/bot/commands/donate.rb
+++ b/app/bot/commands/donate.rb
@@ -20,7 +20,7 @@ module Commands
     DONATE
 
     def execute
-      event.respond(content: MESSAGE)
+      event.respond(content: MESSAGE, ephemeral: true)
     end
   end
 end

--- a/app/bot/commands/donate.rb
+++ b/app/bot/commands/donate.rb
@@ -1,0 +1,26 @@
+module Commands
+  class Donate < BaseCommand
+    command_name :donate
+    description "Find out what it costs to run shrkbot and how you can support the project."
+    register_in :global
+
+    MESSAGE = <<~DONATE.freeze
+      Thank you for considering supporting the shrkbot project! For full transparency, here's what it currently costs to keep shrkbot running:
+      • Hosting: 10.60€ / month
+
+      That's the entire monthly cost as things stand. I'd love to keep growing the project — adding features and improving the ones that are there — and any support makes that easier.
+
+      To be clear: shrkbot is and always will be completely free and open source. You are never obligated to donate — just using shrkbot is more than enough :) And please only ever give money you don't otherwise need.
+
+      Thank you for using shrkbot! If you'd like to chip in:
+      • PayPal: https://paypal.me/trueblackshark
+      • Liberapay: https://liberapay.com/badBlackShark
+
+      All donations are non-refundable. Thanks for the support! <3
+    DONATE
+
+    def execute
+      event.respond(content: MESSAGE)
+    end
+  end
+end

--- a/app/bot/commands/info.rb
+++ b/app/bot/commands/info.rb
@@ -5,23 +5,29 @@ module Commands
     register_in :global
 
     INVITE_URL = "https://discord.com/oauth2/authorize?client_id=346043915142561793"
-    ACCENT_COLOR = 0x39afe5
 
     def execute
-      event.respond(embeds: [embed(event.bot.profile)])
+      event.respond(components: message[:components], ephemeral: true, has_components: true)
     end
 
     private
 
-    def embed(profile)
-      {
-        author: {name: profile.username, icon_url: profile.avatar_url},
-        description: "I was written in [Ruby](https://www.ruby-lang.org/) by [badBlackShark](https://github.com/badBlackShark/).\n" \
-          "My code lives [here](https://github.com/badBlackShark/shrkbot). Want me on your server? [Invite me!](#{INVITE_URL})",
-        fields: [{name: "Built with", value: credits}],
-        color: ACCENT_COLOR,
-        footer: {text: "Want to support the project? Use /donate."}
-      }
+    def message
+      Discord::Components.container(
+        [
+          Discord::Components.text(header),
+          Discord::Components.separator,
+          Discord::Components.text("**Built with**\n#{credits}"),
+          Discord::Components.separator,
+          Discord::Components.text("-# Want to support the project? Use /donate.")
+        ]
+      )
+    end
+
+    def header
+      "### #{event.bot.profile.username}\n" \
+        "I was written in [Ruby](https://www.ruby-lang.org/) by [badBlackShark](https://github.com/badBlackShark/).\n" \
+        "My code lives [here](https://github.com/badBlackShark/shrkbot). Want me on your server? [Invite me!](#{INVITE_URL})"
     end
 
     def credits

--- a/app/bot/commands/info.rb
+++ b/app/bot/commands/info.rb
@@ -1,0 +1,37 @@
+module Commands
+  class Info < BaseCommand
+    command_name :info
+    description "Show information about shrkbot — its code, stack, and how to add it to your server."
+    register_in :global
+
+    INVITE_URL = "https://discord.com/oauth2/authorize?client_id=346043915142561793"
+    ACCENT_COLOR = 0x39afe5
+
+    def execute
+      event.respond(embeds: [embed(event.bot.profile)])
+    end
+
+    private
+
+    def embed(profile)
+      {
+        author: {name: profile.username, icon_url: profile.avatar_url},
+        description: "I was written in [Ruby](https://www.ruby-lang.org/) by [badBlackShark](https://github.com/badBlackShark/).\n" \
+          "My code lives [here](https://github.com/badBlackShark/shrkbot). Want me on your server? [Invite me!](#{INVITE_URL})",
+        fields: [{name: "Built with", value: credits}],
+        color: ACCENT_COLOR,
+        footer: {text: "Want to support the project? Use /donate."}
+      }
+    end
+
+    def credits
+      [
+        "**[discordrb](https://github.com/shardlab/discordrb)** *by shardlab*",
+        "**[Ruby on Rails](https://rubyonrails.org/)** *by the Rails team*",
+        "**[Solid Queue](https://github.com/rails/solid_queue)** *by the Rails team*",
+        "**[pg](https://github.com/ged/ruby-pg)** *by Michael Granger et al.*",
+        "**[redis-rb](https://github.com/redis/redis-rb)** *by the redis-rb team*"
+      ].join("\n")
+    end
+  end
+end

--- a/app/bot/discord/components.rb
+++ b/app/bot/discord/components.rb
@@ -1,0 +1,22 @@
+module Discord
+  module Components
+    CONTAINER = 17
+    TEXT_DISPLAY = 10
+    SEPARATOR = 14
+    COMPONENTS_V2 = 1 << 15
+
+    module_function
+
+    def container(blocks, accent_color: BotConfig::ACCENT_COLOR)
+      {components: [{type: CONTAINER, accent_color: accent_color, components: blocks}], flags: COMPONENTS_V2}
+    end
+
+    def text(body)
+      {type: TEXT_DISPLAY, content: body}
+    end
+
+    def separator
+      {type: SEPARATOR, divider: true}
+    end
+  end
+end

--- a/app/bot/owner_broadcast.rb
+++ b/app/bot/owner_broadcast.rb
@@ -1,5 +1,5 @@
 module OwnerBroadcast
-  FOOTER = "\n\nYou're receiving this because you own at least one server that shrkbot is in."
+  FOOTER = "-# You're receiving this because you own at least one server that shrkbot is in."
   Result = Data.define(:owner_count, :sent, :server_count)
 
   module_function
@@ -14,10 +14,21 @@ module OwnerBroadcast
   end
 
   def deliver(bot, owner_id, content)
-    bot.pm_channel(owner_id).send_message(content + FOOTER)
+    rendered = message(content)
+    bot.pm_channel(owner_id).send_message(nil, false, nil, nil, nil, nil, rendered[:components], rendered[:flags])
     true
   rescue => e
     Rails.logger.warn("[OwnerBroadcast] could not DM owner #{owner_id}: #{e.class}: #{e.message}")
     false
+  end
+
+  def message(content)
+    Discord::Components.container(
+      [
+        Discord::Components.text(content),
+        Discord::Components.separator,
+        Discord::Components.text(FOOTER)
+      ]
+    )
   end
 end

--- a/app/bot/owner_broadcast.rb
+++ b/app/bot/owner_broadcast.rb
@@ -1,0 +1,23 @@
+module OwnerBroadcast
+  FOOTER = "\n\nYou're receiving this because you own at least one server that shrkbot is in."
+  Result = Data.define(:owner_count, :sent, :server_count)
+
+  module_function
+
+  def call(bots:, content:)
+    servers = bots.flat_map { |bot| bot.servers.values }
+    owner_ids = servers.filter_map { |server| server.owner&.id }.uniq
+    messenger = bots.first
+    sent = owner_ids.count { |owner_id| deliver(messenger, owner_id, content) }
+
+    Result.new(owner_count: owner_ids.size, sent: sent, server_count: servers.size)
+  end
+
+  def deliver(bot, owner_id, content)
+    bot.pm_channel(owner_id).send_message(content + FOOTER)
+    true
+  rescue => e
+    Rails.logger.warn("[OwnerBroadcast] could not DM owner #{owner_id}: #{e.class}: #{e.message}")
+    false
+  end
+end

--- a/app/plugins/roles/message.rb
+++ b/app/plugins/roles/message.rb
@@ -1,17 +1,12 @@
 module Roles
   module Message
-    CONTAINER = 17
     SECTION = 9
-    TEXT_DISPLAY = 10
-    SEPARATOR = 14
     ACTION_ROW = 1
     BUTTON = 2
     STRING_SELECT = 3
     PRIMARY = 1
     SECONDARY = 2
     BUTTONS_PER_ROW = 5
-    COMPONENTS_V2 = 1 << 15
-    ACCENT_COLOR = 0x39afe5
     UNKNOWN_ROLE = "Unknown role"
 
     module_function
@@ -19,15 +14,17 @@ module Roles
     def public_message(set)
       blocks =
         if set.selection_mode == "single"
-          [text(single_content(set)), separator, *button_rows(role_buttons(set))]
+          [Discord::Components.text(single_content(set)), Discord::Components.separator, *button_rows(role_buttons(set))]
         else
-          [text(multi_content(set)), separator, manage_section(set)]
+          [Discord::Components.text(multi_content(set)), Discord::Components.separator, manage_section(set)]
         end
-      container(blocks)
+      Discord::Components.container(blocks)
     end
 
     def multi_picker(set, active_role_ids)
-      container([text(picker_content(set)), action_row([role_select(set, active_role_ids)])])
+      Discord::Components.container(
+        [Discord::Components.text(picker_content(set)), action_row([role_select(set, active_role_ids)])]
+      )
     end
 
     def selection_summary(set, active_role_ids)
@@ -38,22 +35,10 @@ module Roles
       "**#{set.name}**: #{chosen.any? ? chosen.join(", ") : "none"}"
     end
 
-    def container(blocks)
-      {components: [{type: CONTAINER, accent_color: ACCENT_COLOR, components: blocks}], flags: COMPONENTS_V2}
-    end
-
-    def text(body)
-      {type: TEXT_DISPLAY, content: body}
-    end
-
-    def separator
-      {type: SEPARATOR, divider: true}
-    end
-
     def manage_section(set)
       {
         type: SECTION,
-        components: [text("-# Click this button to edit your roles ->")],
+        components: [Discord::Components.text("-# Click this button to edit your roles ->")],
         accessory: manage_button(set)
       }
     end
@@ -119,7 +104,7 @@ module Roles
       [role.emoji, names[role.role_id] || UNKNOWN_ROLE].compact.join(" ")
     end
 
-    private_class_method :container, :text, :separator, :manage_section, :action_row,
+    private_class_method :manage_section, :action_row,
       :single_content, :multi_content, :picker_content,
       :role_buttons, :role_select, :manage_button, :button_rows, :role_names, :role_label
   end

--- a/bin/bot
+++ b/bin/bot
@@ -15,6 +15,7 @@ bots = Array.new(shard_count) do |shard_id|
     num_shards: shard_count
   )
 end
+BotRegistry.register(bots)
 
 bots.each_with_index do |bot, index|
   CommandRegistrar.new(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -258,6 +258,14 @@ defines the application-global commands; every shard attaches handlers. Shard st
 are staggered by 5s — Discord rate-limits IDENTIFY to roughly one per 5s, and a burst
 drops later shards into reconnect backoff.
 
+Each `Bot` only knows the servers on its own shard, so anything that spans **all**
+servers (e.g. `/announce`, which DMs every unique server owner) must read every
+shard, not just `event.bot`. `bin/bot` registers the bot array with `BotRegistry`
+at boot; `OwnerBroadcast.call(bots:, …)` unions every shard's servers, dedupes owners
+across shards, and DMs through any one bot (DMs are REST, so the shard doesn't
+matter). This works because all shards share one process — no cross-process
+coordination needed.
+
 ## REST vs gateway token
 
 The gateway `Bot` prefixes the auth header itself, but direct `Discordrb::API` calls

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -236,10 +236,16 @@ grant an arbitrary server role. The runtime toggle is bot-only (no DB write, no 
 caller), so it lives in the handlers, not in an operation; the testable unit is the
 pure `Roles::Assignment` diff with `member.modify_roles` as the seam.
 
-`Roles::Message` renders every message as a **Components V2** payload, so
+`Discord::Components` (`app/bot/discord/`) holds the shared Components V2 primitives —
+the `CONTAINER`/`TEXT_DISPLAY`/`SEPARATOR` type ids, the `COMPONENTS_V2` flag, and the
+`container`/`text`/`separator` builders — so every sender (role messages, `/info`, the
+owner broadcast) renders the same way and the brand colour lives in one place
+(`BotConfig::ACCENT_COLOR`, the container default).
+
+`Roles::Message` composes those builders into a **Components V2** payload, so
 `public_message`/`multi_picker` return `{components:, flags:}` with the `COMPONENTS_V2`
 flag and no `content` — senders pass `has_components: true` (or the flag positionally).
-Each message is a `Container` carrying the brand `ACCENT_COLOR` sidebar, a markdown
+Each message is a `Container` carrying the brand accent sidebar, a markdown
 `### ` heading (Discord supports only h1–h3), a `Separator`, and then the controls.
 Single sets put the role buttons straight in the container; multi sets list the roles
 side by side (no markdown tables in Discord — an inline `•`-joined line) and expose the

--- a/spec/bot/announce_modal_spec.rb
+++ b/spec/bot/announce_modal_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe AnnounceModal do
+  subject(:handle) { described_class.new(event).handle }
+
+  let(:event) { double("event", bot: double("bot"), respond: nil) }
+
+  before do
+    allow(event).to receive(:value).with(Commands::Announce::INPUT_ID).and_return("the announcement")
+    allow(BotRegistry).to receive(:all).and_return([event.bot])
+  end
+
+  context "when the bot owner submits" do
+    before do
+      allow(CommandPermissions).to receive(:permitted?).and_return(true)
+    end
+
+    it "broadcasts the submitted text and reports a summary" do
+      expect(OwnerBroadcast).to receive(:call)
+        .with(bots: [event.bot], content: "the announcement")
+        .and_return(OwnerBroadcast::Result.new(owner_count: 3, sent: 3, server_count: 5))
+      expect(event).to receive(:respond).with(hash_including(content: a_string_including("3/3"), ephemeral: true))
+
+      handle
+    end
+  end
+
+  context "when someone other than the bot owner submits" do
+    before do
+      allow(CommandPermissions).to receive(:permitted?).and_return(false)
+    end
+
+    it "rejects without broadcasting" do
+      expect(OwnerBroadcast).not_to receive(:call)
+      expect(event).to receive(:respond).with(hash_including(content: a_string_including("permission"), ephemeral: true))
+
+      handle
+    end
+  end
+end

--- a/spec/bot/announce_modal_spec.rb
+++ b/spec/bot/announce_modal_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe AnnounceModal do
   subject(:handle) { described_class.new(event).handle }
 
-  let(:event) { double("event", bot: double("bot"), respond: nil) }
+  let(:event) { double("event", bot: double("bot"), respond: nil, defer: nil, edit_response: nil) }
 
   before do
     allow(event).to receive(:value).with(Commands::Announce::INPUT_ID).and_return("the announcement")
@@ -15,11 +15,12 @@ RSpec.describe AnnounceModal do
       allow(CommandPermissions).to receive(:permitted?).and_return(true)
     end
 
-    it "broadcasts the submitted text and reports a summary" do
+    it "defers, broadcasts the submitted text, and reports a summary" do
+      expect(event).to receive(:defer).with(ephemeral: true)
       expect(OwnerBroadcast).to receive(:call)
         .with(bots: [event.bot], content: "the announcement")
         .and_return(OwnerBroadcast::Result.new(owner_count: 3, sent: 3, server_count: 5))
-      expect(event).to receive(:respond).with(hash_including(content: a_string_including("3/3"), ephemeral: true))
+      expect(event).to receive(:edit_response).with(hash_including(content: a_string_including("3/3")))
 
       handle
     end

--- a/spec/bot/bot_registry_spec.rb
+++ b/spec/bot/bot_registry_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe BotRegistry do
+  after { described_class.register([]) }
+
+  it "stores and returns the registered bots" do
+    bots = [double("shard_one"), double("shard_two")]
+    described_class.register(bots)
+    expect(described_class.all).to eq(bots)
+  end
+
+  it "wraps a single bot in an array" do
+    bot = double("bot")
+    described_class.register(bot)
+    expect(described_class.all).to eq([bot])
+  end
+
+  it "returns an empty array before anything is registered" do
+    described_class.register(nil)
+    expect(described_class.all).to eq([])
+  end
+end

--- a/spec/bot/commands/announce_spec.rb
+++ b/spec/bot/commands/announce_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe Commands::Announce do
+  subject(:execute) { described_class.new(event).execute }
+
+  let(:event) { double("event") }
+  let(:modal) { double("modal") }
+  let(:row) { double("row") }
+
+  it "opens a paragraph modal for the announcement" do
+    expect(event).to receive(:show_modal)
+      .with(hash_including(custom_id: described_class::MODAL_ID))
+      .and_yield(modal)
+    allow(modal).to receive(:label).and_yield(row)
+    expect(row).to receive(:text_input)
+      .with(hash_including(style: :paragraph, custom_id: described_class::INPUT_ID, required: true))
+
+    execute
+  end
+
+  it "is owner-only" do
+    expect(described_class.owner_only?).to be(true)
+  end
+end

--- a/spec/bot/commands/donate_spec.rb
+++ b/spec/bot/commands/donate_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe Commands::Donate do
+  subject(:execute) { described_class.new(event).execute }
+
+  let(:event) { double("event", respond: nil) }
+
+  it "responds with the donation message" do
+    expect(event).to receive(:respond).with(hash_including(content: described_class::MESSAGE))
+    execute
+  end
+
+  describe "the message content" do
+    subject(:message) { described_class::MESSAGE }
+
+    it { is_expected.to include("https://paypal.me/trueblackshark") }
+    it { is_expected.to include("https://liberapay.com/badBlackShark") }
+    it { is_expected.to include("10.60€") }
+    it { is_expected.not_to match(/yahoo/i) }
+  end
+end

--- a/spec/bot/commands/donate_spec.rb
+++ b/spec/bot/commands/donate_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Commands::Donate do
 
   let(:event) { double("event", respond: nil) }
 
-  it "responds with the donation message" do
-    expect(event).to receive(:respond).with(hash_including(content: described_class::MESSAGE))
+  it "responds with the donation message, ephemerally" do
+    expect(event).to receive(:respond).with(hash_including(content: described_class::MESSAGE, ephemeral: true))
     execute
   end
 

--- a/spec/bot/commands/info_spec.rb
+++ b/spec/bot/commands/info_spec.rb
@@ -3,17 +3,34 @@ require "rails_helper"
 RSpec.describe Commands::Info do
   subject(:execute) { described_class.new(event).execute }
 
-  let(:profile) { double("profile", username: "shrkbot", avatar_url: "https://cdn/avatar.png") }
+  let(:profile) { double("profile", username: "shrkbot") }
   let(:event) { double("event", bot: double("bot", profile: profile), respond: nil) }
 
-  it "responds with an embed" do
+  def texts(args)
+    args[:components].first[:components].filter_map { |block| block[:content] }
+  end
+
+  it "responds with an ephemeral components-v2 message" do
     expect(event).to receive(:respond) do |args|
-      embed = args[:embeds].first
-      expect(embed[:author]).to eq(name: "shrkbot", icon_url: "https://cdn/avatar.png")
-      expect(embed[:description]).to include(described_class::INVITE_URL)
-      expect(embed[:description]).to include("Ruby")
-      expect(embed[:fields].first[:value]).to include("discordrb").and include("Ruby on Rails")
-      expect(embed[:footer][:text]).to include("/donate")
+      expect(args[:ephemeral]).to be(true)
+      expect(args[:has_components]).to be(true)
+      expect(args[:components].first).to include(
+        type: Discord::Components::CONTAINER,
+        accent_color: BotConfig::ACCENT_COLOR
+      )
+    end
+
+    execute
+  end
+
+  it "credits the stack and links the code, invite, and donate command" do
+    expect(event).to receive(:respond) do |args|
+      body = texts(args).join("\n")
+      expect(body).to include("shrkbot")
+      expect(body).to include("Ruby")
+      expect(body).to include(described_class::INVITE_URL)
+      expect(body).to include("discordrb").and include("Ruby on Rails")
+      expect(body).to include("/donate")
     end
 
     execute

--- a/spec/bot/commands/info_spec.rb
+++ b/spec/bot/commands/info_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe Commands::Info do
+  subject(:execute) { described_class.new(event).execute }
+
+  let(:profile) { double("profile", username: "shrkbot", avatar_url: "https://cdn/avatar.png") }
+  let(:event) { double("event", bot: double("bot", profile: profile), respond: nil) }
+
+  it "responds with an embed" do
+    expect(event).to receive(:respond) do |args|
+      embed = args[:embeds].first
+      expect(embed[:author]).to eq(name: "shrkbot", icon_url: "https://cdn/avatar.png")
+      expect(embed[:description]).to include(described_class::INVITE_URL)
+      expect(embed[:description]).to include("Ruby")
+      expect(embed[:fields].first[:value]).to include("discordrb").and include("Ruby on Rails")
+      expect(embed[:footer][:text]).to include("/donate")
+    end
+
+    execute
+  end
+end

--- a/spec/bot/owner_broadcast_spec.rb
+++ b/spec/bot/owner_broadcast_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe OwnerBroadcast do
+  describe ".call" do
+    subject(:result) { described_class.call(bots: bots, content: "hello owners") }
+
+    let(:bots) { [shard_one, shard_two] }
+    let(:shard_one) { double("shard_one", servers: {1 => server(10), 2 => server(20)}) }
+    let(:shard_two) { double("shard_two", servers: {3 => server(10), 4 => server(30)}) }
+    let(:channel) { double("channel", send_message: nil) }
+
+    def server(owner_id)
+      double("server", owner: double("owner", id: owner_id))
+    end
+
+    before do
+      allow(shard_one).to receive(:pm_channel).and_return(channel)
+    end
+
+    it "counts every server across all shards" do
+      expect(result.server_count).to eq(4)
+    end
+
+    it "dedupes owners across shards" do
+      expect(result.owner_count).to eq(3)
+    end
+
+    it "DMs each unique owner once, through one shard's REST" do
+      expect(shard_one).to receive(:pm_channel).with(10).once.and_return(channel)
+      expect(shard_one).to receive(:pm_channel).with(20).once.and_return(channel)
+      expect(shard_one).to receive(:pm_channel).with(30).once.and_return(channel)
+      result
+    end
+
+    it "appends the explanatory footer to the content" do
+      expect(channel).to receive(:send_message)
+        .with(a_string_including("hello owners").and(a_string_including("you own at least one server")))
+        .at_least(:once)
+      result
+    end
+
+    it "reports how many were sent" do
+      expect(result.sent).to eq(3)
+    end
+
+    context "when a DM fails" do
+      before do
+        allow(shard_one).to receive(:pm_channel).with(20).and_raise("403 cannot DM")
+      end
+
+      it "skips it and still reports the rest" do
+        expect(result.sent).to eq(2)
+        expect(result.owner_count).to eq(3)
+      end
+    end
+
+    context "when a server's owner can't be resolved" do
+      let(:shard_two) { double("shard_two", servers: {3 => double("server", owner: nil)}) }
+
+      it "excludes it from the owner count" do
+        expect(result.owner_count).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/bot/owner_broadcast_spec.rb
+++ b/spec/bot/owner_broadcast_spec.rb
@@ -32,10 +32,15 @@ RSpec.describe OwnerBroadcast do
       result
     end
 
-    it "appends the explanatory footer to the content" do
-      expect(channel).to receive(:send_message)
-        .with(a_string_including("hello owners").and(a_string_including("you own at least one server")))
-        .at_least(:once)
+    it "sends a components-v2 message with the content and a footer below a separator" do
+      expect(channel).to receive(:send_message).at_least(:once) do |*args|
+        blocks = args[6].first[:components]
+        expect(args[7]).to eq(Discord::Components::COMPONENTS_V2)
+        expect(blocks.map { |block| block[:type] }).to include(Discord::Components::SEPARATOR)
+        body = blocks.filter_map { |block| block[:content] }
+        expect(body).to include("hello owners")
+        expect(body.join).to include("-# ").and include("you own at least one server")
+      end
       result
     end
 

--- a/spec/plugins/roles/message_poster_spec.rb
+++ b/spec/plugins/roles/message_poster_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Roles::MessagePoster do
 
     it "sends with the components-v2 flag so the container is accepted" do
       expect(channel).to receive(:send_message)
-        .with(nil, false, nil, nil, nil, nil, anything, Roles::Message::COMPONENTS_V2)
+        .with(nil, false, nil, nil, nil, nil, anything, Discord::Components::COMPONENTS_V2)
         .and_return(double(id: 1))
       post
     end
@@ -43,7 +43,7 @@ RSpec.describe Roles::MessagePoster do
     end
 
     it "edits with the components-v2 flag" do
-      expect(message).to receive(:edit).with(nil, nil, anything, Roles::Message::COMPONENTS_V2)
+      expect(message).to receive(:edit).with(nil, nil, anything, Discord::Components::COMPONENTS_V2)
       post
     end
   end

--- a/spec/plugins/roles/message_spec.rb
+++ b/spec/plugins/roles/message_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Roles::Message do
   end
 
   def text_block(rendered)
-    container_blocks(rendered).find { |block| block[:type] == described_class::TEXT_DISPLAY }
+    container_blocks(rendered).find { |block| block[:type] == Discord::Components::TEXT_DISPLAY }
   end
 
   def row_components(rendered)
@@ -28,10 +28,10 @@ RSpec.describe Roles::Message do
     let(:set) { create(:role_set, role_setting: setting, selection_mode: "multi") }
 
     it "wraps the message in an accented container and sets the components-v2 flag" do
-      expect(rendered[:flags]).to eq(described_class::COMPONENTS_V2)
+      expect(rendered[:flags]).to eq(Discord::Components::COMPONENTS_V2)
       expect(rendered[:components].first).to include(
-        type: described_class::CONTAINER,
-        accent_color: described_class::ACCENT_COLOR
+        type: Discord::Components::CONTAINER,
+        accent_color: BotConfig::ACCENT_COLOR
       )
     end
 
@@ -56,7 +56,7 @@ RSpec.describe Roles::Message do
       end
 
       it "separates the text from the controls" do
-        expect(container_blocks(rendered).map { |block| block[:type] }).to include(described_class::SEPARATOR)
+        expect(container_blocks(rendered).map { |block| block[:type] }).to include(Discord::Components::SEPARATOR)
       end
 
       it "offers a manage button as a section accessory" do
@@ -91,7 +91,7 @@ RSpec.describe Roles::Message do
       end
 
       it "separates the text from the buttons" do
-        expect(container_blocks(rendered).map { |block| block[:type] }).to include(described_class::SEPARATOR)
+        expect(container_blocks(rendered).map { |block| block[:type] }).to include(Discord::Components::SEPARATOR)
       end
 
       context "with more than five roles" do
@@ -137,7 +137,7 @@ RSpec.describe Roles::Message do
     end
 
     it "sets the components-v2 flag" do
-      expect(described_class.multi_picker(set, [])[:flags]).to eq(described_class::COMPONENTS_V2)
+      expect(described_class.multi_picker(set, [])[:flags]).to eq(Discord::Components::COMPONENTS_V2)
     end
 
     it "is a string select carrying the set's custom id" do


### PR DESCRIPTION
Ports the three always-on (non-plugin, always-registered) commands from the old Crystal bot, modernized for slash commands and the new stack.

## Commands
- **/info** (global, everyone) — embed with the code link, current [invite link](https://discord.com/oauth2/authorize?client_id=346043915142561793), and stack credits (Ruby / Rails / discordrb / Solid Queue / pg / redis-rb). Author block uses the live bot profile.
- **/donate** (global, everyone) — running-costs message + PayPal/Liberapay links. The old Yahoo Finance cost line is gone (finance features were dropped); hosting updated to 10.60€/mo.
- **/announce** (global, **bot-owner only**) — operator broadcast that DMs every unique server owner. Renamed from the old `sendOwnerMessage` (Discord disallows uppercase in slash-command names). Text is entered via a **modal** (multi-line paragraph input), submitted through a `modal_submit` handler that re-checks owner, broadcasts, and replies with an ephemeral summary.

## Cross-shard broadcast
Each discordrb `Bot` only knows its own shard's servers, so a broadcast can't use `event.bot` alone. `bin/bot` registers the shard bots with `BotRegistry`; `OwnerBroadcast` unions every shard's servers, dedupes owners across shards, and DMs through any one bot (DMs are REST, shard-agnostic). Works because all shards share one process — no cross-process coordination. Documented in `docs/architecture.md` (Sharding).

## Layout
`Commands::Info/Donate/Announce` in `app/bot/commands/` (matches `Commands::Ping`); `AnnounceModal` (BaseEvent) + `OwnerBroadcast` + `BotRegistry` flat in `app/bot/` (matches the other top-level bot infra). `OwnerBroadcast` is bot-layer logic, not an Op — no DB write, no web caller.

## Tests
Embed structure (info), message content incl. links/cost and no-Yahoo assertion (donate), modal wiring (announce), owner-gating + summary (announce modal), and cross-shard dedup/fan-out/failure-skip (OwnerBroadcast). Full suite **338 green**, standardrb + zeitwerk + active_record_doctor clean.

## Live-gate notes (yours to run)
- /info, /donate render correctly; /announce opens the modal and DMs land.
- /announce is owner-gated at runtime (no Discord perm bit for "bot owner"), so it's visible but rejects non-owners — same pattern as other owner-only actions.