### PR TITLE
Add the activity logging framework (ModLog)

### DIFF
--- a/.active_record_doctor.rb
+++ b/.active_record_doctor.rb
@@ -41,7 +41,6 @@ ActiveRecordDoctor.configure do
     ignore_attributes: [
       "PluginActivation.enabled",
       "Reminders::Reminder.deliver_via_dm",
-      "Roles::Settings.log_on_assign",
       "ServerConfiguration.force_dm_reminders"
     ]
 end

--- a/app/bot/activity_log.rb
+++ b/app/bot/activity_log.rb
@@ -20,7 +20,7 @@ module ActivityLog
   def enabled?(server_configuration, action)
     return false unless server_configuration.plugins.enabled.exists?(key: :logging)
 
-    server_configuration.logging_setting&.action_enabled?(action) || false
+    server_configuration.logging_setting.action_enabled?(action)
   end
 
   def render(event, options)

--- a/app/bot/activity_log.rb
+++ b/app/bot/activity_log.rb
@@ -1,0 +1,43 @@
+module ActivityLog
+  EVENTS = {
+    role_gained: "roles.assignment",
+    role_lost: "roles.assignment",
+    roles_changed: "roles.assignment"
+  }.freeze
+
+  module_function
+
+  def record(server_configuration, event, bot:, **options)
+    action = EVENTS.fetch(event)
+    return unless enabled?(server_configuration, action)
+
+    channel_id = server_configuration.logging_setting.channel_id
+    return unless channel_id
+
+    deliver(bot, channel_id, render(event, options))
+  end
+
+  def enabled?(server_configuration, action)
+    return false unless server_configuration.plugins.enabled.exists?(key: :logging)
+
+    server_configuration.logging_setting&.action_enabled?(action) || false
+  end
+
+  def render(event, options)
+    I18n.t("activity_log.#{event}", locale: :en, raise: true, **humanize(options))
+  end
+
+  def humanize(options)
+    options.transform_values do |value|
+      value.is_a?(Array) ? value.to_sentence : value
+    end
+  end
+
+  def deliver(bot, channel_id, text)
+    bot.channel(channel_id)&.send_message(text)
+  rescue => e
+    Rails.logger.warn("[ActivityLog] could not write to ##{channel_id}: #{e.class}: #{e.message}")
+  end
+
+  private_class_method :enabled?, :render, :humanize, :deliver
+end

--- a/app/bot/activity_log.rb
+++ b/app/bot/activity_log.rb
@@ -1,20 +1,13 @@
 module ActivityLog
-  EVENTS = {
-    role_gained: "roles.assignment",
-    role_lost: "roles.assignment",
-    roles_changed: "roles.assignment"
-  }.freeze
-
   module_function
 
-  def record(server_configuration, event, bot:, **options)
-    action = EVENTS.fetch(event)
-    return unless enabled?(server_configuration, action)
+  def record(server_configuration, plugin, event, bot:, **options)
+    return unless enabled?(server_configuration, "#{plugin}.#{event}")
 
     channel_id = server_configuration.logging_setting.channel_id
     return unless channel_id
 
-    deliver(bot, channel_id, render(event, options))
+    deliver(bot, channel_id, render(plugin, event, options))
   end
 
   def enabled?(server_configuration, action)
@@ -23,8 +16,8 @@ module ActivityLog
     server_configuration.logging_setting.action_enabled?(action)
   end
 
-  def render(event, options)
-    I18n.t("activity_log.#{event}", locale: :en, raise: true, **humanize(options))
+  def render(plugin, event, options)
+    I18n.t("activity_log.#{plugin}.#{event}", locale: :en, raise: true, **humanize(options))
   end
 
   def humanize(options)

--- a/app/models/logging_setting.rb
+++ b/app/models/logging_setting.rb
@@ -1,3 +1,7 @@
 class LoggingSetting < ApplicationRecord
   belongs_to :server_configuration
+
+  def action_enabled?(action)
+    enabled_actions[action.to_s] == true
+  end
 end

--- a/app/operations/roles/settings/update.rb
+++ b/app/operations/roles/settings/update.rb
@@ -2,11 +2,11 @@ module Ops
   module Roles
     module Settings
       class Update < ApplicationOperation
-        receives :server_configuration, :channel_id, :log_on_assign
+        receives :server_configuration, :channel_id
 
         def call
           setting = server_configuration.role_setting
-          setting.update!(channel_id: channel_id, log_on_assign: log_on_assign)
+          setting.update!(channel_id: channel_id)
           ok(setting)
         end
       end

--- a/app/plugins/roles/events/component_handler.rb
+++ b/app/plugins/roles/events/component_handler.rb
@@ -23,5 +23,44 @@ module Roles
     def update(picker)
       event.update_message(components: picker[:components], has_components: true)
     end
+
+    def log_assignment(had, diff)
+      gained = diff[:add] - had
+      lost = diff[:remove] & had
+      return if gained.empty? && lost.empty?
+
+      names = role_names(gained + lost)
+      event_name, options = assignment_event(label(gained, names), label(lost, names))
+      ActivityLog.record(server_configuration, event_name, bot: event.bot, actor: member.mention, **options)
+    end
+
+    def member_set_role_ids
+      member.roles.map(&:id) & set_role_ids
+    end
+
+    def assignment_event(gained, lost)
+      if gained.any? && lost.any?
+        [:roles_changed, {gained:, lost:}]
+      elsif gained.any?
+        [:role_gained, {roles: gained}]
+      else
+        [:role_lost, {roles: lost}]
+      end
+    end
+
+    def label(role_ids, names)
+      role_ids.map { |role_id| names[role_id] || "an unknown role" }
+    end
+
+    def role_names(role_ids)
+      server_configuration.server_roles
+        .where(discord_id: role_ids)
+        .pluck(:discord_id, :name)
+        .to_h
+    end
+
+    def server_configuration
+      set.role_setting.server_configuration
+    end
   end
 end

--- a/app/plugins/roles/events/component_handler.rb
+++ b/app/plugins/roles/events/component_handler.rb
@@ -25,27 +25,19 @@ module Roles
     end
 
     def log_assignment(had, diff)
-      gained = diff[:add] - had
-      lost = diff[:remove] & had
-      return if gained.empty? && lost.empty?
+      names = role_names(diff[:add] + diff[:remove])
+      log_role_change(:role_gained, label(diff[:add] - had, names))
+      log_role_change(:role_lost, label(diff[:remove] & had, names))
+    end
 
-      names = role_names(gained + lost)
-      event_name, options = assignment_event(label(gained, names), label(lost, names))
-      ActivityLog.record(server_configuration, event_name, bot: event.bot, actor: member.mention, **options)
+    def log_role_change(name, roles)
+      return if roles.empty?
+
+      ActivityLog.record(server_configuration, :roles, name, bot: event.bot, actor: member.mention, roles:)
     end
 
     def member_set_role_ids
       member.roles.map(&:id) & set_role_ids
-    end
-
-    def assignment_event(gained, lost)
-      if gained.any? && lost.any?
-        [:roles_changed, {gained:, lost:}]
-      elsif gained.any?
-        [:role_gained, {roles: gained}]
-      else
-        [:role_lost, {roles: lost}]
-      end
     end
 
     def label(role_ids, names)

--- a/app/plugins/roles/events/pick.rb
+++ b/app/plugins/roles/events/pick.rb
@@ -8,8 +8,11 @@ module Roles
       picked = CustomId.parse(event.custom_id)[:role_id]
       return unless set_role_ids.include?(picked)
 
-      apply(Assignment.single(set_role_ids, picked))
+      diff = Assignment.single(set_role_ids, picked)
+      had = member_set_role_ids
+      apply(diff)
       event.respond(content: Message.selection_summary(set, [picked]), ephemeral: true)
+      log_assignment(had, diff)
     end
   end
 end

--- a/app/plugins/roles/events/select.rb
+++ b/app/plugins/roles/events/select.rb
@@ -6,8 +6,11 @@ module Roles
       return unless set && member
 
       selected = event.values.map(&:to_i)
-      apply(Assignment.multi(set_role_ids, selected))
+      diff = Assignment.multi(set_role_ids, selected)
+      had = member_set_role_ids
+      apply(diff)
       update(Message.multi_picker(set, selected & set_role_ids))
+      log_assignment(had, diff)
     end
   end
 end

--- a/config/locales/activity_log.en.yml
+++ b/config/locales/activity_log.en.yml
@@ -1,5 +1,5 @@
 en:
   activity_log:
-    role_gained: "%{actor} gained %{roles}."
-    role_lost: "%{actor} lost %{roles}."
-    roles_changed: "%{actor} gained %{gained} and lost %{lost}."
+    roles:
+      role_gained: "%{actor} gained %{roles}."
+      role_lost: "%{actor} lost %{roles}."

--- a/config/locales/activity_log.en.yml
+++ b/config/locales/activity_log.en.yml
@@ -1,0 +1,5 @@
+en:
+  activity_log:
+    role_gained: "%{actor} gained %{roles}."
+    role_lost: "%{actor} lost %{roles}."
+    roles_changed: "%{actor} gained %{gained} and lost %{lost}."

--- a/db/migrate/20260620170456_introduce_activity_log_toggles.rb
+++ b/db/migrate/20260620170456_introduce_activity_log_toggles.rb
@@ -1,0 +1,6 @@
+class IntroduceActivityLogToggles < ActiveRecord::Migration[8.1]
+  def change
+    add_column :logging_settings, :enabled_actions, :jsonb, null: false, default: {}
+    remove_column :role_settings, :log_on_assign, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_19_220209) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_20_170456) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -48,6 +48,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_19_220209) do
   create_table "logging_settings", id: :string, default: -> { "('lgs_'::text || gen_random_uuid())" }, force: :cascade do |t|
     t.bigint "channel_id"
     t.datetime "created_at", null: false
+    t.jsonb "enabled_actions", default: {}, null: false
     t.string "server_configuration_id", null: false
     t.datetime "updated_at", null: false
     t.index ["server_configuration_id"], name: "index_logging_settings_on_server_configuration_id", unique: true
@@ -101,7 +102,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_19_220209) do
   create_table "role_settings", id: :string, default: -> { "('rls_'::text || gen_random_uuid())" }, force: :cascade do |t|
     t.bigint "channel_id"
     t.datetime "created_at", null: false
-    t.boolean "log_on_assign", default: false, null: false
     t.string "server_configuration_id", null: false
     t.datetime "updated_at", null: false
     t.index ["server_configuration_id"], name: "index_role_settings_on_server_configuration_id", unique: true

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 Design and how-to documentation for the Ruby/Rails rewrite of shrkbot.
 
-- [architecture.md](architecture.md) — system overview: processes, persistence, the operations layer, plugin model, command/event registration, guild metadata sync, sharding.
+- [architecture.md](architecture.md) — system overview: processes, persistence, the operations layer, plugin model, command/event registration, guild metadata sync, activity logging, sharding.
 - [adding-a-plugin.md](adding-a-plugin.md) — how to add a new plugin.
 - [adding-a-command.md](adding-a-command.md) — how to add a slash command.
 - [adding-an-event.md](adding-an-event.md) — how to add a gateway event handler.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -255,6 +255,32 @@ not a stored label — Discord exposes no way to colour a button by the role's c
 the name is the only useful signal. A role missing from the sync falls back to a
 placeholder so a component is never empty.
 
+## Activity logging
+
+`ActivityLog.record(server_configuration, event, bot:, **options)` (`app/bot/`) is the
+one-line API for writing a user action to a server's logging channel. It's gated twice:
+the logging plugin must be enabled, and the action behind the `event` must be toggled on.
+
+Two granularities, deliberately separate:
+- **Action** — the unit a server owner toggles, keyed `"<plugin>.<action>"` (e.g.
+  `"roles.assignment"`). Toggles live in `logging_settings.enabled_actions` (a jsonb map,
+  default `{}` = everything off); `LoggingSetting#action_enabled?` reads it. The Phase 7
+  web UI writes this map and greys it all out when the logging plugin is off.
+- **Event** — the specific message variant, which is also the i18n key. `ActivityLog::EVENTS`
+  maps each event to its gating action. One action owns several events so phrasing can vary
+  without conditionals: `role_gained`, `role_lost`, `roles_changed` all gate on
+  `"roles.assignment"`, and the caller picks the event it's actually in.
+
+Message text is `config/locales/activity_log.en.yml`, looked up with `I18n.t(..., locale:
+:en, raise: true)` — the bot is English-only, so I18n is a string registry here, not
+localization. `**options` are interpolation values; Array values are run through
+`to_sentence` so `roles: ["A", "B"]` renders "A and B". Adding a loggable action = a key in
+the locale file + an `EVENTS` entry + a `record` call. A bad event/key **raises** (surfaces
+in the consumer's spec; owner-reported in prod via `BaseEvent`); only the channel send is
+rescued, so a delivery failure never breaks the user's action. Welcomes are excluded by
+design. Roles assignment is the first consumer — `Roles::ComponentHandler#log_assignment`
+diffs gained/lost from the pre-apply roles and picks the event.
+
 ## Sharding
 
 Static only (`SHARD_COUNT`, floored at 1). discordrb is one shard per `Bot` instance,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -257,29 +257,36 @@ placeholder so a component is never empty.
 
 ## Activity logging
 
-`ActivityLog.record(server_configuration, event, bot:, **options)` (`app/bot/`) is the
-one-line API for writing a user action to a server's logging channel. It's gated twice:
-the logging plugin must be enabled, and the action behind the `event` must be toggled on.
+`ActivityLog.record(server_configuration, plugin, event, bot:, **options)` (`app/bot/`) is
+the one-line API for writing a user action to a server's logging channel. It's gated twice:
+the logging plugin must be enabled, and the specific event must be toggled on.
 
-Two granularities, deliberately separate:
-- **Action** — the unit a server owner toggles, keyed `"<plugin>.<action>"` (e.g.
-  `"roles.assignment"`). Toggles live in `logging_settings.enabled_actions` (a jsonb map,
-  default `{}` = everything off); `LoggingSetting#action_enabled?` reads it. The Phase 7
-  web UI writes this map and greys it all out when the logging plugin is off.
-- **Event** — the specific message variant, which is also the i18n key. `ActivityLog::EVENTS`
-  maps each event to its gating action. One action owns several events so phrasing can vary
-  without conditionals: `role_gained`, `role_lost`, `roles_changed` all gate on
-  `"roles.assignment"`, and the caller picks the event it's actually in.
+One toggle per event, keyed `"<plugin>.<event>"` (e.g. `"roles.role_gained"`) — the same
+string is the toggle key, derived directly from the `plugin`/`event` args, so there's no
+separate event→action map to maintain. Toggles live in `logging_settings.enabled_actions`
+(a jsonb map, default `{}` = everything off); `LoggingSetting#action_enabled?` reads it. The
+Phase 7 web UI gives each plugin a logging tab listing its events as independent toggles, and
+greys the lot out when the logging plugin is off.
 
-Message text is `config/locales/activity_log.en.yml`, looked up with `I18n.t(..., locale:
-:en, raise: true)` — the bot is English-only, so I18n is a string registry here, not
-localization. `**options` are interpolation values; Array values are run through
-`to_sentence` so `roles: ["A", "B"]` renders "A and B". Adding a loggable action = a key in
-the locale file + an `EVENTS` entry + a `record` call. A bad event/key **raises** (surfaces
-in the consumer's spec; owner-reported in prod via `BaseEvent`); only the channel send is
-rescued, so a delivery failure never breaks the user's action. Welcomes are excluded by
-design. Roles assignment is the first consumer — `Roles::ComponentHandler#log_assignment`
-diffs gained/lost from the pre-apply roles and picks the event.
+Events are **atomic**, never composite: a role swap emits two lines (`role_gained` +
+`role_lost`), each gated by its own toggle, rather than a combined `roles_changed` — so the
+toggles compose cleanly with no hidden "swap logs nothing" gap, and each message stays a flat
+i18n string with no conditionals.
+
+Message text is `config/locales/activity_log.en.yml`, nested by plugin, looked up with
+`I18n.t("activity_log.#{plugin}.#{event}", locale: :en, raise: true)` — the bot is
+English-only, so I18n is a string registry here, not localization. `**options` are
+interpolation values; Array values are run through `to_sentence` so `roles: ["A", "B"]`
+renders "A and B". Adding a loggable event = a key in the locale file + a `record` call. A
+bad plugin/event **raises** (missing translation surfaces in the consumer's spec;
+owner-reported in prod via `BaseEvent`); only the channel send is rescued, so a delivery
+failure never breaks the user's action. Welcomes are excluded by design. Roles assignment is
+the first consumer — `Roles::ComponentHandler#log_assignment` diffs gained/lost from the
+pre-apply roles and emits one atomic event per non-empty side.
+
+The enumerable catalog of each plugin's loggable events (so the web tab can render the toggle
+list) is a Phase 7 concern — a per-plugin declaration added when that UI is built. The bot
+side doesn't need it: the i18n lookup raising on an unknown key covers typos.
 
 ## Sharding
 

--- a/spec/bot/activity_log_spec.rb
+++ b/spec/bot/activity_log_spec.rb
@@ -73,6 +73,14 @@ RSpec.describe ActivityLog do
     end
   end
 
+  context "when the logging channel no longer exists" do
+    before { allow(bot).to receive(:channel).with(555).and_return(nil) }
+
+    it "writes nothing and doesn't raise" do
+      expect { record }.not_to raise_error
+    end
+  end
+
   context "when the channel send fails" do
     before { allow(channel).to receive(:send_message).and_raise("403 missing access") }
 

--- a/spec/bot/activity_log_spec.rb
+++ b/spec/bot/activity_log_spec.rb
@@ -1,0 +1,91 @@
+require "rails_helper"
+
+RSpec.describe ActivityLog do
+  subject(:record) { described_class.record(server_config, event, bot:, **options) }
+
+  let(:server_config) { create(:server_configuration) }
+  let(:event) { :role_gained }
+  let(:options) { {actor: "<@42>", roles: ["Gamer"]} }
+
+  let(:channel) { double("channel", send_message: nil) }
+  let(:bot) { double("bot") }
+
+  before do
+    create(
+      :logging_setting,
+      server_configuration: server_config,
+      channel_id: 555,
+      enabled_actions: {"roles.assignment" => true}
+    )
+    logging = create(:plugin, key: "logging", name: "Logging")
+    create(:plugin_activation, server_configuration: server_config, plugin: logging, enabled: true)
+    allow(bot).to receive(:channel).with(555).and_return(channel)
+  end
+
+  it "writes the rendered line to the logging channel" do
+    expect(channel).to receive(:send_message).with("<@42> gained Gamer.")
+    record
+  end
+
+  context "with several roles" do
+    let(:options) { {actor: "<@42>", roles: ["Gamer", "Artist"]} }
+
+    it "joins the list into a sentence" do
+      expect(channel).to receive(:send_message).with("<@42> gained Gamer and Artist.")
+      record
+    end
+  end
+
+  context "for a gained-and-lost change" do
+    let(:event) { :roles_changed }
+    let(:options) { {actor: "<@42>", gained: ["Gamer"], lost: ["Artist", "News"]} }
+
+    it "renders both sides" do
+      expect(channel).to receive(:send_message).with("<@42> gained Gamer and lost Artist and News.")
+      record
+    end
+  end
+
+  context "when the logging plugin is disabled" do
+    before { PluginActivation.update_all(enabled: false) }
+
+    it "writes nothing" do
+      expect(channel).not_to receive(:send_message)
+      record
+    end
+  end
+
+  context "when the action is toggled off" do
+    before { server_config.logging_setting.update!(enabled_actions: {}) }
+
+    it "writes nothing" do
+      expect(channel).not_to receive(:send_message)
+      record
+    end
+  end
+
+  context "when no logging channel is set" do
+    before { server_config.logging_setting.update!(channel_id: nil) }
+
+    it "writes nothing" do
+      expect(channel).not_to receive(:send_message)
+      record
+    end
+  end
+
+  context "when the channel send fails" do
+    before { allow(channel).to receive(:send_message).and_raise("403 missing access") }
+
+    it "swallows the error so the user's action is unaffected" do
+      expect { record }.not_to raise_error
+    end
+  end
+
+  context "for an unregistered event" do
+    let(:event) { :not_a_real_event }
+
+    it "raises so the wiring mistake surfaces" do
+      expect { record }.to raise_error(KeyError)
+    end
+  end
+end

--- a/spec/bot/activity_log_spec.rb
+++ b/spec/bot/activity_log_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe ActivityLog do
-  subject(:record) { described_class.record(server_config, event, bot:, **options) }
+  subject(:record) { described_class.record(server_config, :roles, event, bot:, **options) }
 
   let(:server_config) { create(:server_configuration) }
   let(:event) { :role_gained }
@@ -15,7 +15,7 @@ RSpec.describe ActivityLog do
       :logging_setting,
       server_configuration: server_config,
       channel_id: 555,
-      enabled_actions: {"roles.assignment" => true}
+      enabled_actions: {"roles.role_gained" => true}
     )
     logging = create(:plugin, key: "logging", name: "Logging")
     create(:plugin_activation, server_configuration: server_config, plugin: logging, enabled: true)
@@ -36,12 +36,14 @@ RSpec.describe ActivityLog do
     end
   end
 
-  context "for a gained-and-lost change" do
-    let(:event) { :roles_changed }
-    let(:options) { {actor: "<@42>", gained: ["Gamer"], lost: ["Artist", "News"]} }
+  context "for an event gated by its own toggle" do
+    let(:event) { :role_lost }
+    let(:options) { {actor: "<@42>", roles: ["Artist"]} }
 
-    it "renders both sides" do
-      expect(channel).to receive(:send_message).with("<@42> gained Gamer and lost Artist and News.")
+    before { server_config.logging_setting.update!(enabled_actions: {"roles.role_lost" => true}) }
+
+    it "renders that event's own line" do
+      expect(channel).to receive(:send_message).with("<@42> lost Artist.")
       record
     end
   end
@@ -55,8 +57,8 @@ RSpec.describe ActivityLog do
     end
   end
 
-  context "when the action is toggled off" do
-    before { server_config.logging_setting.update!(enabled_actions: {}) }
+  context "when this event's toggle is off" do
+    before { server_config.logging_setting.update!(enabled_actions: {"roles.role_lost" => true}) }
 
     it "writes nothing" do
       expect(channel).not_to receive(:send_message)
@@ -92,8 +94,10 @@ RSpec.describe ActivityLog do
   context "for an unregistered event" do
     let(:event) { :not_a_real_event }
 
+    before { server_config.logging_setting.update!(enabled_actions: {"roles.not_a_real_event" => true}) }
+
     it "raises so the wiring mistake surfaces" do
-      expect { record }.to raise_error(KeyError)
+      expect { record }.to raise_error(I18n::MissingTranslationData)
     end
   end
 end

--- a/spec/models/logging_setting_spec.rb
+++ b/spec/models/logging_setting_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe LoggingSetting do
+  subject(:setting) { build(:logging_setting, enabled_actions: actions) }
+
+  describe "#action_enabled?" do
+    context "when the action is toggled on" do
+      let(:actions) { {"roles.assignment" => true} }
+
+      it { expect(setting.action_enabled?("roles.assignment")).to be(true) }
+
+      it "accepts a symbol" do
+        expect(setting.action_enabled?(:"roles.assignment")).to be(true)
+      end
+    end
+
+    context "when the action is absent" do
+      let(:actions) { {} }
+
+      it { expect(setting.action_enabled?("roles.assignment")).to be(false) }
+    end
+
+    context "when the action is explicitly off" do
+      let(:actions) { {"roles.assignment" => false} }
+
+      it { expect(setting.action_enabled?("roles.assignment")).to be(false) }
+    end
+  end
+end

--- a/spec/operations/roles/settings/update_spec.rb
+++ b/spec/operations/roles/settings/update_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Ops::Roles::Settings::Update do
   subject(:result) do
-    described_class.call(server_configuration: server, channel_id:, log_on_assign: false)
+    described_class.call(server_configuration: server, channel_id:)
   end
 
   let(:server) { create(:server_configuration) }
@@ -11,7 +11,7 @@ RSpec.describe Ops::Roles::Settings::Update do
 
   it "sets the role settings" do
     expect(result.success?).to be(true)
-    expect(setting.reload).to have_attributes(channel_id: 99, log_on_assign: false)
+    expect(setting.reload).to have_attributes(channel_id: 99)
   end
 
   context "updating existing values" do

--- a/spec/plugins/roles/events/pick_spec.rb
+++ b/spec/plugins/roles/events/pick_spec.rb
@@ -15,14 +15,26 @@ RSpec.describe Roles::Pick do
   end
 
   let(:user) { double("user", id: 42) }
-  let(:member) { double("member", roles: [], modify_roles: nil) }
+  let(:member) { double("member", roles: [], modify_roles: nil, mention: "<@42>") }
   let(:server) { double("server", member: member) }
+  let(:bot) { double("bot") }
   let(:event) do
-    double("event", custom_id: Roles::CustomId.pick(set, blue), server:, user:, respond: nil)
+    double("event", custom_id: Roles::CustomId.pick(set, blue), server:, user:, respond: nil, bot:)
+  end
+
+  before do
+    allow(ActivityLog).to receive(:record)
   end
 
   it "adds the picked role and removes the other roles in the set" do
     expect(member).to receive(:modify_roles).with([200], [100])
+    handle
+  end
+
+  it "logs the role the user gained" do
+    expect(ActivityLog).to receive(:record).with(
+      server_config, :role_gained, bot:, actor: "<@42>", roles: ["Blue"]
+    )
     handle
   end
 

--- a/spec/plugins/roles/events/pick_spec.rb
+++ b/spec/plugins/roles/events/pick_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Roles::Pick do
 
   it "logs the role the user gained" do
     expect(ActivityLog).to receive(:record).with(
-      server_config, :role_gained, bot:, actor: "<@42>", roles: ["Blue"]
+      server_config, :roles, :role_gained, bot:, actor: "<@42>", roles: ["Blue"]
     )
     handle
   end

--- a/spec/plugins/roles/events/select_spec.rb
+++ b/spec/plugins/roles/events/select_spec.rb
@@ -4,19 +4,45 @@ RSpec.describe Roles::Select do
   subject(:handle) { described_class.new(event).handle }
 
   let(:set) { create(:role_set, selection_mode: "multi") }
+  let(:server_config) { set.role_setting.server_configuration }
   let!(:news) { create(:assignable_role, role_set: set, role_id: 100, position: 0) }
   let!(:events_role) { create(:assignable_role, role_set: set, role_id: 200, position: 1) }
 
+  before do
+    create(:server_role, server_configuration: server_config, discord_id: 100, name: "News")
+    create(:server_role, server_configuration: server_config, discord_id: 200, name: "Events")
+    allow(ActivityLog).to receive(:record)
+  end
+
   let(:user) { double("user", id: 42) }
-  let(:member) { double("member", modify_roles: nil) }
+  let(:member) { double("member", roles: [], modify_roles: nil, mention: "<@42>") }
   let(:server) { double("server", member: member) }
+  let(:bot) { double("bot") }
   let(:event) do
-    double("event", custom_id: Roles::CustomId.select(set), server:, user:, values: ["100"], update_message: nil)
+    double("event", custom_id: Roles::CustomId.select(set), server:, user:, values: ["100"], update_message: nil, bot:)
   end
 
   it "adds the selected set roles and removes the unselected ones" do
     expect(member).to receive(:modify_roles).with([100], [200])
     handle
+  end
+
+  it "logs the gained role" do
+    expect(ActivityLog).to receive(:record).with(
+      server_config, :role_gained, bot:, actor: "<@42>", roles: ["News"]
+    )
+    handle
+  end
+
+  context "when the user swaps one role for another" do
+    let(:member) { double("member", roles: [double("role", id: 200)], modify_roles: nil, mention: "<@42>") }
+
+    it "logs both the gained and lost roles" do
+      expect(ActivityLog).to receive(:record).with(
+        server_config, :roles_changed, bot:, actor: "<@42>", gained: ["News"], lost: ["Events"]
+      )
+      handle
+    end
   end
 
   context "outside a server (no member to assign)" do

--- a/spec/plugins/roles/events/select_spec.rb
+++ b/spec/plugins/roles/events/select_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Roles::Select do
 
   it "logs the gained role" do
     expect(ActivityLog).to receive(:record).with(
-      server_config, :role_gained, bot:, actor: "<@42>", roles: ["News"]
+      server_config, :roles, :role_gained, bot:, actor: "<@42>", roles: ["News"]
     )
     handle
   end
@@ -37,9 +37,12 @@ RSpec.describe Roles::Select do
   context "when the user swaps one role for another" do
     let(:member) { double("member", roles: [double("role", id: 200)], modify_roles: nil, mention: "<@42>") }
 
-    it "logs both the gained and lost roles" do
+    it "logs the gained and lost roles as separate lines" do
       expect(ActivityLog).to receive(:record).with(
-        server_config, :roles_changed, bot:, actor: "<@42>", gained: ["News"], lost: ["Events"]
+        server_config, :roles, :role_gained, bot:, actor: "<@42>", roles: ["News"]
+      )
+      expect(ActivityLog).to receive(:record).with(
+        server_config, :roles, :role_lost, bot:, actor: "<@42>", roles: ["Events"]
       )
       handle
     end
@@ -54,8 +57,9 @@ RSpec.describe Roles::Select do
     end
 
     it "logs only the lost roles" do
+      expect(ActivityLog).not_to receive(:record).with(server_config, :roles, :role_gained, any_args)
       expect(ActivityLog).to receive(:record).with(
-        server_config, :role_lost, bot:, actor: "<@42>", roles: ["News", "Events"]
+        server_config, :roles, :role_lost, bot:, actor: "<@42>", roles: ["News", "Events"]
       )
       handle
     end

--- a/spec/plugins/roles/events/select_spec.rb
+++ b/spec/plugins/roles/events/select_spec.rb
@@ -45,6 +45,31 @@ RSpec.describe Roles::Select do
     end
   end
 
+  context "when the user clears their roles" do
+    let(:member) do
+      double("member", roles: [double("role", id: 100), double("role", id: 200)], modify_roles: nil, mention: "<@42>")
+    end
+    let(:event) do
+      double("event", custom_id: Roles::CustomId.select(set), server:, user:, values: [], update_message: nil, bot:)
+    end
+
+    it "logs only the lost roles" do
+      expect(ActivityLog).to receive(:record).with(
+        server_config, :role_lost, bot:, actor: "<@42>", roles: ["News", "Events"]
+      )
+      handle
+    end
+  end
+
+  context "when the selection changes nothing" do
+    let(:member) { double("member", roles: [double("role", id: 100)], modify_roles: nil, mention: "<@42>") }
+
+    it "logs nothing" do
+      expect(ActivityLog).not_to receive(:record)
+      handle
+    end
+  end
+
   context "outside a server (no member to assign)" do
     let(:server) { nil }
 


### PR DESCRIPTION
The generalized, long-deferred ModLog — review-plans item 5, its own phase.

## API
`ActivityLog.record(server_configuration, plugin, event, bot:, **options)` — one line to log a user action to a server's logging channel. Gated twice: the **logging plugin** must be enabled, and the **event** must be toggled on. No-op otherwise.

## One toggle per event
The toggle key is the event itself, keyed `"<plugin>.<event>"` (e.g. `"roles.role_gained"`), derived straight from the `record` args — no separate event→action map. Toggles live in a new `logging_settings.enabled_actions` jsonb map (default `{}` = all off); `LoggingSetting#action_enabled?` reads it. Phase 7 gives each plugin a logging tab listing its events as independent toggles, greyed out when the logging plugin is off.

## Atomic events, no composite
A role swap emits **two lines** (`role_gained` + `role_lost`), each gated by its own toggle, rather than a combined `roles_changed`. The toggles compose cleanly (no hidden "swap logs nothing" gap), and every message stays a flat i18n string with no conditionals.

## Message text
`config/locales/activity_log.en.yml`, nested by plugin, via `I18n.t("activity_log.#{plugin}.#{event}", locale: :en, raise: true)`. The bot is English-only, so I18n is a **string registry** here, not localization. `**options` are interpolation values; Array values run through `to_sentence` (`roles: ["A","B"]` → "A and B"). Adding a loggable event = a locale key + a `record` call.

## Failure behavior
A bad plugin/event **raises** (missing translation surfaces in the consumer's spec; owner-reported in prod via `BaseEvent`). Only the channel send is rescued, so a delivery failure (channel gone, perms) never breaks the user's action.

## First consumer
Roles assignment. `Roles::ComponentHandler#log_assignment` diffs gained/lost from the pre-apply roles and emits one atomic event per non-empty side; `Pick`/`Select` call it after responding. **Subsumes `role_settings.log_on_assign`**, which is dropped (column + op param + ar_doctor ignore).

## Tests
`ActivityLog` gating (plugin off / event toggle off / no channel → silent), list-to-sentence, per-event rendering, deleted-channel + send-failure swallowed, unknown-event raises; `LoggingSetting#action_enabled?`; roles handlers assert the right `(plugin, event)` + payload incl. the swap (two atomic lines) and no-op cases. Full suite **360 green**, standardrb + ar_doctor clean, undercover satisfied. Documented in `docs/architecture.md` (Activity logging).

## Not in scope (Phase 7)
- Writing the toggles — no setter op/UI yet, so enabling an event is DB-only for now.
- The enumerable per-plugin catalog of loggable events that the web tab renders — a per-plugin declaration added when that UI is built.