### PR TITLE
Sync role hierarchy metadata for the Phase 7 configurator

### DIFF
--- a/.active_record_doctor.rb
+++ b/.active_record_doctor.rb
@@ -41,6 +41,7 @@ ActiveRecordDoctor.configure do
     ignore_attributes: [
       "PluginActivation.enabled",
       "Reminders::Reminder.deliver_via_dm",
-      "ServerConfiguration.force_dm_reminders"
+      "ServerConfiguration.force_dm_reminders",
+      "ServerRole.managed"
     ]
 end

--- a/app/bot/guild_metadata.rb
+++ b/app/bot/guild_metadata.rb
@@ -4,7 +4,11 @@ module GuildMetadata
   def sync(server, bot)
     config = Ops::ServerConfiguration::Ensure.call(discord_id: server.id).value
     Ops::ServerConfiguration::ServerChannels::Sync.call(server_configuration: config, channels: channels(server))
-    Ops::ServerConfiguration::ServerRoles::Sync.call(server_configuration: config, roles: roles(server))
+    Ops::ServerConfiguration::ServerRoles::Sync.call(
+      server_configuration: config,
+      roles: roles(server),
+      bot_role_position: bot_role_position(server, bot)
+    )
     Ops::ServerConfiguration::Channels::Reconcile.call(server_configuration: config, bot: bot)
     ServerOnboarder.notify(bot, server, config)
     config
@@ -17,7 +21,13 @@ module GuildMetadata
   end
 
   def roles(server)
-    server.roles.map { |role| {discord_id: role.id, name: role.name} }
+    server.roles.map do |role|
+      {discord_id: role.id, name: role.name, position: role.position, managed: role.managed?}
+    end
+  end
+
+  def bot_role_position(server, bot)
+    server.member(bot.profile.id).roles.map(&:position).max || 0
   end
 
   def overwrites(channel)

--- a/app/bot/role_sync.rb
+++ b/app/bot/role_sync.rb
@@ -7,6 +7,10 @@ class RoleSync < BaseEvent
     config = ServerConfiguration.find_by(discord_id: event.server.id)
     return unless config
 
-    Ops::ServerConfiguration::ServerRoles::Sync.call(server_configuration: config, roles: GuildMetadata.roles(event.server))
+    Ops::ServerConfiguration::ServerRoles::Sync.call(
+      server_configuration: config,
+      roles: GuildMetadata.roles(event.server),
+      bot_role_position: GuildMetadata.bot_role_position(event.server, event.bot)
+    )
   end
 end

--- a/app/operations/server_configuration/server_roles/sync.rb
+++ b/app/operations/server_configuration/server_roles/sync.rb
@@ -2,14 +2,15 @@ module Ops
   module ServerConfiguration
     module ServerRoles
       class Sync < ApplicationOperation
-        receives :server_configuration, :roles
+        receives :server_configuration, :roles, :bot_role_position
 
         def call
           roles.each do |data|
             role = server_configuration.server_roles.find_or_initialize_by(discord_id: data[:discord_id])
-            role.update!(name: data[:name])
+            role.update!(name: data[:name], position: data[:position], managed: data[:managed])
           end
           server_configuration.server_roles.where.not(discord_id: roles.map { |r| r[:discord_id] }).delete_all
+          server_configuration.update!(bot_role_position: bot_role_position)
           ok(server_configuration.server_roles.reload)
         end
       end

--- a/db/migrate/20260620184029_add_role_hierarchy_metadata.rb
+++ b/db/migrate/20260620184029_add_role_hierarchy_metadata.rb
@@ -1,0 +1,7 @@
+class AddRoleHierarchyMetadata < ActiveRecord::Migration[8.1]
+  def change
+    add_column :server_roles, :position, :integer
+    add_column :server_roles, :managed, :boolean, null: false, default: false
+    add_column :server_configurations, :bot_role_position, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_20_170456) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_20_184029) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -118,6 +118,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_20_170456) do
   end
 
   create_table "server_configurations", id: :string, default: -> { "('srv_'::text || gen_random_uuid())" }, force: :cascade do |t|
+    t.integer "bot_role_position"
     t.datetime "created_at", null: false
     t.bigint "discord_id", null: false
     t.boolean "force_dm_reminders", default: false, null: false
@@ -129,7 +130,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_20_170456) do
   create_table "server_roles", id: :string, default: -> { "('srl_'::text || gen_random_uuid())" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.bigint "discord_id", null: false
+    t.boolean "managed", default: false, null: false
     t.string "name", null: false
+    t.integer "position"
     t.string "server_configuration_id", null: false
     t.datetime "updated_at", null: false
     t.index ["server_configuration_id", "discord_id"], name: "index_server_roles_on_server_configuration_id_and_discord_id", unique: true

--- a/spec/bot/guild_metadata_spec.rb
+++ b/spec/bot/guild_metadata_spec.rb
@@ -25,10 +25,35 @@ RSpec.describe GuildMetadata do
   describe ".roles" do
     subject(:roles) { described_class.roles(server) }
 
-    let(:server) { double("server", roles: [double("role", id: 222, name: "Admin")]) }
+    let(:server) { double("server", roles: [double("role", id: 222, name: "Admin", position: 3, managed?: false)]) }
 
-    it "maps each role to a plain hash" do
-      expect(roles).to eq([{discord_id: 222, name: "Admin"}])
+    it "maps each role to a plain hash with its position and managed flag" do
+      expect(roles).to eq([{discord_id: 222, name: "Admin", position: 3, managed: false}])
+    end
+  end
+
+  describe ".bot_role_position" do
+    subject(:position) { described_class.bot_role_position(server, bot) }
+
+    let(:bot) { double("bot", profile: double("profile", id: 99)) }
+    let(:server) { double("server") }
+
+    before { allow(server).to receive(:member).with(99).and_return(member) }
+
+    context "when the bot has roles above @everyone" do
+      let(:member) { double("member", roles: [double("role", position: 2), double("role", position: 5)]) }
+
+      it "is the bot's highest role position" do
+        expect(position).to eq(5)
+      end
+    end
+
+    context "when the bot has only @everyone" do
+      let(:member) { double("member", roles: []) }
+
+      it "is 0" do
+        expect(position).to eq(0)
+      end
     end
   end
 
@@ -42,12 +67,13 @@ RSpec.describe GuildMetadata do
     before do
       allow(Ops::ServerConfiguration::Ensure).to receive(:call)
         .with(discord_id: 77).and_return(double(value: config))
+      allow(described_class).to receive(:bot_role_position).with(server, bot).and_return(7)
       allow(ServerOnboarder).to receive(:notify)
     end
 
     it "ensures the config, then syncs channels and roles, then reconciles deletions" do
       expect(Ops::ServerConfiguration::ServerChannels::Sync).to receive(:call).with(server_configuration: config, channels: [])
-      expect(Ops::ServerConfiguration::ServerRoles::Sync).to receive(:call).with(server_configuration: config, roles: [])
+      expect(Ops::ServerConfiguration::ServerRoles::Sync).to receive(:call).with(server_configuration: config, roles: [], bot_role_position: 7)
       expect(Ops::ServerConfiguration::Channels::Reconcile).to receive(:call).with(server_configuration: config, bot:)
       sync
     end

--- a/spec/bot/role_sync_spec.rb
+++ b/spec/bot/role_sync_spec.rb
@@ -4,18 +4,20 @@ RSpec.describe RoleSync do
   subject(:handle) { described_class.new(event).handle }
 
   let(:server) { double("server", id: 1) }
-  let(:event) { double("event", server:) }
+  let(:bot) { double("bot") }
+  let(:event) { double("event", server:, bot:) }
   let(:op) { Ops::ServerConfiguration::ServerRoles::Sync }
 
   before do
     allow(GuildMetadata).to receive(:roles).with(server).and_return([:role_data])
+    allow(GuildMetadata).to receive(:bot_role_position).with(server, bot).and_return(6)
   end
 
   context "for a configured server" do
     let!(:config) { create(:server_configuration, discord_id: 1) }
 
-    it "re-syncs the server's roles" do
-      expect(op).to receive(:call).with(server_configuration: config, roles: [:role_data])
+    it "re-syncs the server's roles and the bot's role position" do
+      expect(op).to receive(:call).with(server_configuration: config, roles: [:role_data], bot_role_position: 6)
       handle
     end
   end

--- a/spec/operations/server_configuration/server_roles/sync_spec.rb
+++ b/spec/operations/server_configuration/server_roles/sync_spec.rb
@@ -1,33 +1,50 @@
 require "rails_helper"
 
 RSpec.describe Ops::ServerConfiguration::ServerRoles::Sync do
-  subject(:result) { described_class.call(server_configuration: server, roles:) }
+  subject(:result) { described_class.call(server_configuration: server, roles:, bot_role_position: 4) }
 
   let(:server) { create(:server_configuration) }
 
   describe "upserting roles" do
-    let(:roles) { [{discord_id: 111, name: "Admin"}, {discord_id: 222, name: "Member"}] }
+    let(:roles) do
+      [
+        {discord_id: 111, name: "Admin", position: 3, managed: false},
+        {discord_id: 222, name: "Bot", position: 2, managed: true}
+      ]
+    end
 
     it "creates a row per incoming role" do
       expect { result }.to change { server.server_roles.count }.from(0).to(2)
     end
 
-    context "when a role was renamed since the last sync" do
+    it "stores each role's position and managed flag" do
+      result
+
+      expect(server.server_roles.find_by(discord_id: 222)).to have_attributes(position: 2, managed: true)
+    end
+
+    it "records the bot's highest role position on the server" do
+      result
+
+      expect(server.reload.bot_role_position).to eq(4)
+    end
+
+    context "when a role was renamed or moved since the last sync" do
       before do
-        create(:server_role, server_configuration: server, discord_id: 111, name: "old")
+        create(:server_role, server_configuration: server, discord_id: 111, name: "old", position: 9)
       end
 
       it "updates the existing row in place rather than duplicating" do
         result
 
-        expect(server.server_roles.find_by(discord_id: 111).name).to eq("Admin")
+        expect(server.server_roles.find_by(discord_id: 111)).to have_attributes(name: "Admin", position: 3)
         expect(server.server_roles.where(discord_id: 111).count).to eq(1)
       end
     end
   end
 
   describe "pruning" do
-    let(:roles) { [{discord_id: 111, name: "Admin"}] }
+    let(:roles) { [{discord_id: 111, name: "Admin", position: 1, managed: false}] }
 
     before do
       create(:server_role, server_configuration: server, discord_id: 999, name: "gone")


### PR DESCRIPTION
Closes the lingering Phase 5 role-sync TODO (`position`/`managed`/bot-top-role).

## What
Role sync now captures, alongside name:
- **`server_roles.position`** + **`server_roles.managed`** — each role's hierarchy position and whether it's a managed (integration/bot) role.
- **`server_configurations.bot_role_position`** — the bot's own highest role position in that guild.

Persisted on the **full sync** (`GuildMetadata.sync`, on ready/guild_create) and on **role create/update/delete** (`RoleSync`). `GuildMetadata.bot_role_position` reads the bot member's roles (`max` position, `|| 0` when it only has @everyone).

## Why
The Phase 7 roles configurator greys out roles the bot can't assign (above its top role, or `managed`). The web process has no live gateway connection, so the bot has to persist this at sync time for the UI to read. Runtime assignment already fails gracefully on a forged/too-high role — this is UI prevention only.

## Notes
- `position` / `bot_role_position` are nullable (set on first sync; no misleading default). `managed` is `NOT NULL default false` — added to the ar_doctor presence ignore-list like the other boolean-with-default columns (a presence validator would wrongly reject `false`).
- Granting the bot a *new* role fires `guild_member_update`, which `RoleSync` doesn't listen to; `bot_role_position` refreshes on the next role event or ready-sweep. The grey-out is advisory and the backend fails gracefully, so eventual consistency is fine here — not adding a member-update listener for it.

## Tests
Sync op stores position/managed + records bot position; `GuildMetadata.roles` shape; `.bot_role_position` (roles above @everyone → max; only @everyone → 0); `RoleSync` passes it through. Full suite **364 green**, standardrb + ar_doctor + undercover clean.