### PR TITLE
Add Discord OAuth login and the Phlex view layer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,9 @@ jobs:
       - name: Prepare the test database
         run: bin/rails db:test:prepare
 
+      - name: Build the Tailwind stylesheet (view specs render the layout)
+        run: bin/rails tailwindcss:build
+
       - name: Check model validations and DB constraints stay in sync
         run: bundle exec rake active_record_doctor
 

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,8 @@ gem "turbo-rails"
 gem "stimulus-rails"
 # Use Tailwind CSS [https://github.com/rails/tailwindcss-rails]
 gem "tailwindcss-rails"
+# Render views as Ruby objects [https://www.phlex.fun]
+gem "phlex-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,6 +260,13 @@ GEM
     pg (1.6.3-arm64-darwin)
     pg (1.6.3-x86_64-linux)
     pg (1.6.3-x86_64-linux-musl)
+    phlex (2.4.1)
+      refract (~> 1.0)
+      zeitwerk (~> 2.7)
+    phlex-rails (2.4.0)
+      phlex (~> 2.4.0)
+      railties (>= 7.1, < 9)
+      zeitwerk (~> 2.7)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -331,6 +338,9 @@ GEM
       redis-client (>= 0.22.0)
     redis-client (0.30.0)
       connection_pool
+    refract (1.1.0)
+      prism
+      zeitwerk
     regexp_parser (2.12.0)
     reline (0.6.3)
       io-console (~> 0.5)
@@ -498,6 +508,7 @@ DEPENDENCIES
   omniauth-discord
   omniauth-rails_csrf_protection
   pg (~> 1.1)
+  phlex-rails
   propshaft
   puma (>= 5.0)
   rails (~> 8.1.3)
@@ -624,6 +635,8 @@ CHECKSUMS
   pg (1.6.3-arm64-darwin) sha256=7240330b572e6355d7c75a7de535edb5dfcbd6295d9c7777df4d9dddfb8c0e5f
   pg (1.6.3-x86_64-linux) sha256=5d9e188c8f7a0295d162b7b88a768d8452a899977d44f3274d1946d67920ae8d
   pg (1.6.3-x86_64-linux-musl) sha256=9c9c90d98c72f78eb04c0f55e9618fe55d1512128e411035fe229ff427864009
+  phlex (2.4.1) sha256=e596717fbfe38b5271840266758779ebe75092e02629f0c170287e6290a70b12
+  phlex-rails (2.4.0) sha256=2bcddbd488681acb25753bab1887d3ac150e644244ff8ba307f2171a4d0195f5
   pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
@@ -647,6 +660,7 @@ CHECKSUMS
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
   redis (5.4.1) sha256=b5e675b57ad22b15c9bcc765d5ac26f60b675408af916d31527af9bd5a81faae
   redis-client (0.30.0) sha256=743f11ed42f0a41a0341554087b077479fec7e2d47a7c123fd90a12c0db5e477
+  refract (1.1.0) sha256=ee3b9627e39f7692831101e2fedd73e0d09a592ff5d5c05f171d14211fc7a9c7
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
   rest-client (2.1.0) sha256=35a6400bdb14fae28596618e312776c158f7ebbb0ccad752ff4fa142bf2747e3

--- a/app/components/base.rb
+++ b/app/components/base.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Components::Base < Phlex::HTML
+  # Include any helpers you want to be available across all components
+  include Phlex::Rails::Helpers::Routes
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,12 @@
 class ApplicationController < ActionController::Base
   allow_browser versions: :modern
   stale_when_importmap_changes
+
+  helper_method :current_user
+
+  private
+
+  def current_user
+    User.find_by(id: session[:user_id])
+  end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,5 @@
+class PagesController < ApplicationController
+  def home
+    render Views::Home.new(user: current_user)
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,16 @@
+class SessionsController < ApplicationController
+  def create
+    user = User.from_omniauth(request.env["omniauth.auth"])
+    session[:user_id] = user.id
+    redirect_to root_path, notice: "Signed in as #{user.username}."
+  end
+
+  def destroy
+    reset_session
+    redirect_to root_path, notice: "Signed out."
+  end
+
+  def failure
+    redirect_to root_path, alert: "Sign-in failed or was cancelled."
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,10 @@
+class User < ApplicationRecord
+  validates :discord_id, presence: true, uniqueness: true
+  validates :username, presence: true
+
+  def self.from_omniauth(auth)
+    user = find_or_initialize_by(discord_id: auth.uid)
+    user.update!(username: auth.info.name)
+    user
+  end
+end

--- a/app/views/base.rb
+++ b/app/views/base.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Views::Base < Components::Base
+  # The `Views::Base` is an abstract class for all your views.
+
+  # By default, it inherits from `Components::Base`, but you
+  # can change that to `Phlex::HTML` if you want to keep views and
+  # components independent.
+
+  # More caching options at https://www.phlex.fun/components/caching
+  def cache_store = Rails.cache
+end

--- a/app/views/home.rb
+++ b/app/views/home.rb
@@ -8,14 +8,27 @@ class Views::Home < Views::Base
   end
 
   def view_template
-    h1 { "shrkbot" }
+    div(class: "mx-auto max-w-md") do
+      h1(class: "mb-2 text-3xl font-bold") { "shrkbot" }
 
-    if @user
-      p { "Signed in as #{@user.username}." }
-      button_to("Sign out", logout_path, method: :delete)
-    else
-      p { "Sign in to configure shrkbot for your servers." }
-      button_to("Sign in with Discord", "/auth/discord", method: :post, data: {turbo: false})
+      if @user
+        p(class: "mb-6 text-gray-600") { "Signed in as #{@user.username}." }
+        button_to(
+          "Sign out",
+          logout_path,
+          method: :delete,
+          class: "rounded-md bg-gray-200 px-4 py-2 font-medium hover:bg-gray-300"
+        )
+      else
+        p(class: "mb-6 text-gray-600") { "Sign in to configure shrkbot for your servers." }
+        button_to(
+          "Sign in with Discord",
+          "/auth/discord",
+          method: :post,
+          data: {turbo: false},
+          class: "rounded-md bg-[#39afe5] px-4 py-2 font-medium text-white hover:brightness-95"
+        )
+      end
     end
   end
 end

--- a/app/views/home.rb
+++ b/app/views/home.rb
@@ -15,7 +15,7 @@ class Views::Home < Views::Base
       button_to("Sign out", logout_path, method: :delete)
     else
       p { "Sign in to configure shrkbot for your servers." }
-      button_to("Sign in with Discord", "/auth/discord", method: :post)
+      button_to("Sign in with Discord", "/auth/discord", method: :post, data: {turbo: false})
     end
   end
 end

--- a/app/views/home.rb
+++ b/app/views/home.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Views::Home < Views::Base
+  include Phlex::Rails::Helpers::ButtonTo
+
+  def initialize(user:)
+    @user = user
+  end
+
+  def view_template
+    h1 { "shrkbot" }
+
+    if @user
+      p { "Signed in as #{@user.username}." }
+      button_to("Sign out", logout_path, method: :delete)
+    else
+      p { "Sign in to configure shrkbot for your servers." }
+      button_to("Sign in with Discord", "/auth/discord", method: :post)
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,13 +18,13 @@
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
 
-    <%# Includes all stylesheet files in app/assets/stylesheets %>
-    <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
+    <%# Tailwind build (app/assets/builds/tailwind.css) + app-wide styles %>
+    <%= stylesheet_link_tag "tailwind", "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
 
   <body>
-    <main class="container mx-auto mt-28 px-5 flex">
+    <main class="container mx-auto mt-28 px-5">
       <%= yield %>
     </main>
   </body>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,10 @@
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :discord,
+    ENV["DISCORD_CLIENT_ID"],
+    ENV["DISCORD_CLIENT_SECRET"],
+    scope: "identify email guilds"
+end
+
+OmniAuth.config.on_failure = proc do |env|
+  SessionsController.action(:failure).call(env)
+end

--- a/config/initializers/phlex.rb
+++ b/config/initializers/phlex.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Views
+end
+
+module Components
+  extend Phlex::Kit
+end
+
+Rails.autoloaders.main.push_dir(
+  Rails.root.join("app/views"), namespace: Views
+)
+
+Rails.autoloaders.main.push_dir(
+  Rails.root.join("app/components"), namespace: Components
+)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,12 @@ Rails.application.routes.draw do
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", :as => :rails_health_check
 
+  root "pages#home"
+
+  match "/auth/discord/callback", to: "sessions#create", via: [:get, :post]
+  get "/auth/failure", to: "sessions#failure"
+  delete "/logout", to: "sessions#destroy", as: :logout
+
   # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
   # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker

--- a/db/migrate/20260620185143_create_users.rb
+++ b/db/migrate/20260620185143_create_users.rb
@@ -1,0 +1,14 @@
+class CreateUsers < ActiveRecord::Migration[8.1]
+  def change
+    create_table :users, id: false do |t|
+      t.string :id, null: false, primary_key: true
+      t.bigint :discord_id, null: false, index: {unique: true}
+      t.string :username, null: false
+      t.timestamps
+    end
+
+    reversible do |dir|
+      dir.up { execute "ALTER TABLE users ALTER COLUMN id SET DEFAULT ('usr_' || gen_random_uuid())" }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_20_184029) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_20_185143) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -257,6 +257,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_20_184029) do
     t.index ["expires_at"], name: "index_solid_queue_semaphores_on_expires_at"
     t.index ["key", "value"], name: "index_solid_queue_semaphores_on_key_and_value"
     t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
+  end
+
+  create_table "users", id: :string, default: -> { "('usr_'::text || gen_random_uuid())" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "discord_id", null: false
+    t.datetime "updated_at", null: false
+    t.string "username", null: false
+    t.index ["discord_id"], name: "index_users_on_discord_id", unique: true
   end
 
   create_table "welcome_settings", id: :string, default: -> { "('wls_'::text || gen_random_uuid())" }, force: :cascade do |t|

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user do
+    sequence(:discord_id) { |n| 700_000 + n }
+    sequence(:username) { |n| "user-#{n}" }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe User do
+  describe ".from_omniauth" do
+    subject(:user) { described_class.from_omniauth(auth) }
+
+    let(:auth) { OmniAuth::AuthHash.new(provider: "discord", uid: "12345", info: {name: "shrk"}) }
+
+    it "creates a user from the Discord identity" do
+      expect { user }.to change(described_class, :count).by(1)
+      expect(user).to have_attributes(discord_id: 12345, username: "shrk")
+    end
+
+    context "when the user has signed in before" do
+      let!(:existing) { described_class.create!(discord_id: 12345, username: "old name") }
+
+      it "reuses the row and refreshes the username" do
+        expect { user }.not_to change(described_class, :count)
+        expect(existing.reload.username).to eq("shrk")
+      end
+    end
+  end
+
+  describe "validations" do
+    subject(:user) { build(:user) }
+
+    it { expect(user).to be_valid }
+
+    it "requires a unique discord_id" do
+      described_class.create!(discord_id: 999, username: "a")
+      expect(build(:user, discord_id: 999)).not_to be_valid
+    end
+  end
+end

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -50,6 +50,11 @@ RSpec.describe "Authentication", type: :request do
       expect(response.body).to include("Sign in with Discord")
     end
 
+    it "submits the sign-in natively so Turbo doesn't swallow the cross-origin Discord redirect" do
+      get root_path
+      expect(response.body).to include('data-turbo="false"')
+    end
+
     it "greets the user once signed in" do
       post "/auth/discord/callback"
       get root_path

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Authentication", type: :request do
 
     it "signs the user in and redirects home" do
       expect { callback }.to change(User, :count).by(1)
-      expect(session[:user_id]).to eq(User.last.id)
+      expect(session[:user_id]).to eq(User.find_by(discord_id: 12345).id)
       expect(callback).to redirect_to(root_path)
     end
   end

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe "Authentication", type: :request do
+  let(:auth) { OmniAuth::AuthHash.new(provider: "discord", uid: "12345", info: {name: "shrk"}) }
+
+  before do
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:discord] = auth
+    Rails.application.env_config["omniauth.auth"] = auth
+  end
+
+  after do
+    OmniAuth.config.test_mode = false
+    OmniAuth.config.mock_auth[:discord] = nil
+    Rails.application.env_config.delete("omniauth.auth")
+  end
+
+  describe "the Discord callback" do
+    subject(:callback) { post "/auth/discord/callback" }
+
+    it "signs the user in and redirects home" do
+      expect { callback }.to change(User, :count).by(1)
+      expect(session[:user_id]).to eq(User.last.id)
+      expect(callback).to redirect_to(root_path)
+    end
+  end
+
+  describe "signing out" do
+    before { post "/auth/discord/callback" }
+
+    it "clears the session" do
+      delete logout_path
+      expect(session[:user_id]).to be_nil
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  describe "a failed sign-in" do
+    it "redirects home with an alert" do
+      get "/auth/failure"
+
+      expect(response).to redirect_to(root_path)
+      expect(flash[:alert]).to be_present
+    end
+  end
+
+  describe "the home page" do
+    it "offers a sign-in button when signed out" do
+      get root_path
+      expect(response.body).to include("Sign in with Discord")
+    end
+
+    it "greets the user once signed in" do
+      post "/auth/discord/callback"
+      get root_path
+
+      expect(response.body).to include("Signed in as shrk")
+    end
+  end
+end


### PR DESCRIPTION
**Phase 6 (web auth), part 1 of 2.** Proves the OAuth round-trip and stands up the view layer; the manageable-server list is part 2.

## Auth
- OmniAuth Discord provider (scope `identify email guilds` — guilds scope requested now so part 2 needs no re-consent) + `omniauth-rails_csrf_protection`. Client id/secret from `DISCORD_CLIENT_ID`/`DISCORD_CLIENT_SECRET` (already in `.env.example`).
- `User` — `find_or_create` by `discord_id`, refreshing `username` on each login. Prefixed-UUID PK (`usr_`) like the rest; `discord_id` unique + bigint.
- `SessionsController` — callback (`User.from_omniauth` → `session[:user_id]`), logout (`reset_session`), failure. `ApplicationController#current_user` helper.
- Routes: `/auth/discord/callback`, `/auth/failure`, `DELETE /logout`, root → `pages#home`.

## Phlex
Introduces Phlex as the view layer (locked decision H1). `phlex:install` set up `Views::`/`Components::` base classes; Phlex views render into the existing ERB layout, so no layout rewrite. Dropped the generator's dev-only `before_template` comment hook. The landing page is the first Phlex view (`Views::Home`): sign-in button when logged out, a greeting + sign-out when logged in.

## Tests
`User.from_omniauth` (create + reuse/refresh) + validations; request specs for the callback (signs in, redirects), logout (clears session), failure, and the home page rendering both states — via `OmniAuth.config.test_mode`. Full suite **373 green**, standardrb + ar_doctor + undercover clean (run locally now).

## Your part (live gate)
A Discord OAuth2 app — client id/secret + a dev redirect URI `http://localhost:<port>/auth/discord/callback` — into the env. Everything here is tested with OmniAuth mock, so the build isn't blocked on it; the live login is yours to verify.

## Next (part 2)
Manageable-server list: fetch the user's guilds (`/users/@me/guilds`, separate call — `omniauth-discord` only returns identity), keep those where the user has Admin/Manage-Server ∩ the bot is present, render the list in Phlex. Adds `require_login` + memoized `current_user` then (multiple call sites make both worth it + naturally covered).