### PR TITLE
Build the production image without dev/test gems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /app
 
 # Gems first, for layer caching.
 COPY Gemfile Gemfile.lock ./
-RUN bundle install
+RUN bundle config set --local without "development test" && bundle install
 
 COPY . .
 

--- a/Gemfile
+++ b/Gemfile
@@ -53,12 +53,15 @@ gem "thruster", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 gem "image_processing", "~> 2.0"
 
-group :development, :test do
-  # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem "debug", platforms: %i[mri windows], require: "debug/prelude"
+# Load env vars from .env in dev/test (12-factor; prod uses real env). Lives in
+# the default group so the runtime image keeps it when dev/test gems are pruned;
+# dotenv-rails only auto-loads .env in dev/test, so it stays inert in production.
+gem "dotenv-rails"
 
-  # Load env vars from .env in dev/test (12-factor; prod uses real env)
-  gem "dotenv-rails"
+# See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
+gem "debug", platforms: %i[mri windows], require: "debug/prelude"
+
+group :development, :test do
   # House test framework + test-data factories
   gem "rspec-rails"
   gem "factory_bot_rails"


### PR DESCRIPTION
The Dockerfile installs gems with the `development`/`test` groups excluded so the runtime image stays lean. `dotenv-rails` and `debug` move to the default group so they survive that prune — `dotenv-rails` has to load to read `.env` (it only auto-loads in dev/test, so it's inert in production anyway).

These are the local changes needed to get the web app running in the container.

> Note: this also keeps `debug` in the production image (moved to the default group alongside `dotenv-rails`). If that wasn't intended, say so and I'll scope the move to `dotenv-rails` only.