### PR TITLE
Server picker with token re-auth, and dev/test DB separation (Phase 6 part 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,9 @@ jobs:
 
     env:
       RAILS_ENV: test
-      DATABASE_URL: postgres://postgres:postgres@localhost:5432/app_test
+      # The primary/dev database URL; the test suite derives <name>_test from it
+      # (see config/database.yml), so specs run against postgres .../shrkbot_db_test.
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/shrkbot_db
 
     steps:
       - name: Checkout code

--- a/app/bot/discord/guild.rb
+++ b/app/bot/discord/guild.rb
@@ -16,5 +16,9 @@ module Discord
     def manageable?
       owner || permissions.anybits?(ADMINISTRATOR | MANAGE_GUILD)
     end
+
+    def icon_url
+      "https://cdn.discordapp.com/icons/#{id}/#{icon}.png?size=64" if icon
+    end
   end
 end

--- a/app/bot/discord/guild.rb
+++ b/app/bot/discord/guild.rb
@@ -1,0 +1,20 @@
+module Discord
+  ADMINISTRATOR = 0x8
+  MANAGE_GUILD = 0x20
+
+  Guild = Data.define(:id, :name, :owner, :permissions, :icon) do
+    def self.from_api(payload)
+      new(
+        id: payload["id"].to_i,
+        name: payload["name"],
+        owner: payload["owner"] == true,
+        permissions: payload["permissions"].to_i,
+        icon: payload["icon"]
+      )
+    end
+
+    def manageable?
+      owner || permissions.anybits?(ADMINISTRATOR | MANAGE_GUILD)
+    end
+  end
+end

--- a/app/bot/discord/user_guilds.rb
+++ b/app/bot/discord/user_guilds.rb
@@ -1,0 +1,42 @@
+require "net/http"
+require "json"
+
+module Discord
+  class UserGuilds
+    ENDPOINT = URI("https://discord.com/api/v10/users/@me/guilds")
+
+    class Error < StandardError; end
+
+    class Unauthorized < Error; end
+
+    def self.call(access_token)
+      new(access_token).call
+    end
+
+    def initialize(access_token)
+      @access_token = access_token
+    end
+
+    def call
+      response = request
+      raise Unauthorized, "Discord rejected the access token" if response.code.to_i == 401
+      unless response.code.to_i.between?(200, 299)
+        raise Error, "Discord responded with #{response.code}"
+      end
+
+      JSON.parse(response.body).map { |guild| Guild.from_api(guild) }
+    rescue Net::OpenTimeout, Net::ReadTimeout, SocketError, JSON::ParserError => e
+      raise Error, e.message
+    end
+
+    private
+
+    def request
+      Net::HTTP.start(ENDPOINT.host, ENDPOINT.port, use_ssl: true, open_timeout: 5, read_timeout: 5) do |http|
+        get = Net::HTTP::Get.new(ENDPOINT)
+        get["Authorization"] = "Bearer #{@access_token}"
+        http.request(get)
+      end
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,4 +9,8 @@ class ApplicationController < ActionController::Base
   def current_user
     User.find_by(id: session[:user_id])
   end
+
+  def require_login
+    redirect_to root_path, alert: "Please sign in to continue." unless current_user
+  end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,7 @@
 class PagesController < ApplicationController
   def home
-    render Views::Home.new(user: current_user)
+    return redirect_to servers_path if current_user
+
+    render Views::Home.new
   end
 end

--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -1,0 +1,30 @@
+class ServersController < ApplicationController
+  before_action :require_login
+
+  def index
+    manageable = Discord::UserGuilds.call(session[:discord_token]).select(&:manageable?)
+    session.delete(:reauth_attempted)
+    configured_ids = ServerConfiguration.where(discord_id: manageable.map(&:id)).pluck(:discord_id)
+    present, absent = manageable.partition { |guild| configured_ids.include?(guild.id) }
+
+    render Views::Servers::Index.new(present:, absent:)
+  rescue Discord::UserGuilds::Unauthorized
+    reauthenticate
+  rescue Discord::UserGuilds::Error
+    render_error
+  end
+
+  private
+
+  def reauthenticate
+    return render_error if session[:reauth_attempted]
+
+    session[:reauth_attempted] = true
+    render Views::Reauth.new
+  end
+
+  def render_error
+    session.delete(:reauth_attempted)
+    render Views::Servers::Index.new(present: [], absent: [], error: true)
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,8 +1,10 @@
 class SessionsController < ApplicationController
   def create
-    user = User.from_omniauth(request.env["omniauth.auth"])
+    auth = request.env["omniauth.auth"]
+    user = User.from_omniauth(auth)
     session[:user_id] = user.id
-    redirect_to root_path, notice: "Signed in as #{user.username}."
+    session[:discord_token] = auth.credentials.token
+    redirect_to servers_path, notice: "Signed in as #{user.username}."
   end
 
   def destroy

--- a/app/javascript/controllers/reauth_controller.js
+++ b/app/javascript/controllers/reauth_controller.js
@@ -1,0 +1,9 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Automatically re-runs the Discord OAuth request when a session's access token
+// has expired, so the user is signed back in without having to click.
+export default class extends Controller {
+  connect() {
+    this.element.requestSubmit()
+  }
+}

--- a/app/views/home.rb
+++ b/app/views/home.rb
@@ -3,32 +3,17 @@
 class Views::Home < Views::Base
   include Phlex::Rails::Helpers::ButtonTo
 
-  def initialize(user:)
-    @user = user
-  end
-
   def view_template
     div(class: "mx-auto max-w-md") do
       h1(class: "mb-2 text-3xl font-bold") { "shrkbot" }
-
-      if @user
-        p(class: "mb-6 text-gray-600") { "Signed in as #{@user.username}." }
-        button_to(
-          "Sign out",
-          logout_path,
-          method: :delete,
-          class: "rounded-md bg-gray-200 px-4 py-2 font-medium hover:bg-gray-300"
-        )
-      else
-        p(class: "mb-6 text-gray-600") { "Sign in to configure shrkbot for your servers." }
-        button_to(
-          "Sign in with Discord",
-          "/auth/discord",
-          method: :post,
-          data: {turbo: false},
-          class: "rounded-md bg-[#39afe5] px-4 py-2 font-medium text-white hover:brightness-95"
-        )
-      end
+      p(class: "mb-6 text-gray-600") { "Sign in to configure shrkbot for your servers." }
+      button_to(
+        "Sign in with Discord",
+        "/auth/discord",
+        method: :post,
+        data: {turbo: false},
+        class: "rounded-md bg-[#39afe5] px-4 py-2 font-medium text-white hover:brightness-95"
+      )
     end
   end
 end

--- a/app/views/reauth.rb
+++ b/app/views/reauth.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Views::Reauth < Views::Base
+  include Phlex::Rails::Helpers::ButtonTo
+
+  def view_template
+    div(class: "mx-auto max-w-md px-6 py-16 text-center") do
+      h1(class: "mb-2 text-xl font-bold") { "Signing you back in" }
+      p(class: "mb-6 text-gray-600") { "Your Discord sign-in expired. Please stand by - we're refreshing it for you." }
+      button_to(
+        "Continue",
+        "/auth/discord",
+        method: :post,
+        form: {data: {controller: "reauth", turbo: false}},
+        class: "rounded-md bg-[#39afe5] px-4 py-2 font-medium text-white hover:brightness-95"
+      )
+    end
+  end
+end

--- a/app/views/servers/index.rb
+++ b/app/views/servers/index.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Views::Servers::Index < Views::Base
+  include Phlex::Rails::Helpers::ButtonTo
+
   def initialize(present:, absent:, error: false)
     @present = present
     @absent = absent
@@ -9,8 +11,13 @@ class Views::Servers::Index < Views::Base
 
   def view_template
     div(class: "mx-auto max-w-4xl px-6 py-10") do
-      h1(class: "mb-1 text-2xl font-bold") { "Your servers" }
-      p(class: "mb-6 text-gray-600") { "Pick a server to configure. Servers without shrkbot show an invite link instead." }
+      div(class: "mb-6 flex items-start justify-between gap-4") do
+        div do
+          h1(class: "mb-1 text-2xl font-bold") { "Your servers" }
+          p(class: "text-gray-600") { "Pick a server to configure. Servers without shrkbot show an invite link instead." }
+        end
+        sign_out_button
+      end
 
       error_banner if @error
 
@@ -26,6 +33,15 @@ class Views::Servers::Index < Views::Base
   end
 
   private
+
+  def sign_out_button
+    button_to(
+      "Sign out",
+      logout_path,
+      method: :delete,
+      class: "flex-none rounded-md border border-gray-300 px-3 py-1.5 text-sm font-semibold hover:bg-gray-50"
+    )
+  end
 
   def present_card(guild)
     # future (Phase 7): link to the server's config dashboard
@@ -44,8 +60,16 @@ class Views::Servers::Index < Views::Base
 
   def card_heading(guild)
     div(class: "flex items-center gap-3") do
-      span(class: "grid h-12 w-12 place-items-center rounded-lg bg-gray-100 font-semibold text-gray-600") { initials(guild.name) }
+      avatar(guild)
       span(class: "truncate font-semibold") { guild.name }
+    end
+  end
+
+  def avatar(guild)
+    if guild.icon_url
+      img(src: guild.icon_url, alt: "", loading: "lazy", class: "h-12 w-12 flex-none rounded-lg object-cover")
+    else
+      span(class: "grid h-12 w-12 flex-none place-items-center rounded-lg bg-gray-100 font-semibold text-gray-600") { initials(guild.name) }
     end
   end
 

--- a/app/views/servers/index.rb
+++ b/app/views/servers/index.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+class Views::Servers::Index < Views::Base
+  def initialize(present:, absent:, error: false)
+    @present = present
+    @absent = absent
+    @error = error
+  end
+
+  def view_template
+    div(class: "mx-auto max-w-4xl px-6 py-10") do
+      h1(class: "mb-1 text-2xl font-bold") { "Your servers" }
+      p(class: "mb-6 text-gray-600") { "Pick a server to configure. Servers without shrkbot show an invite link instead." }
+
+      error_banner if @error
+
+      if @present.empty? && @absent.empty?
+        empty_state
+      else
+        div(class: "grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3") do
+          @present.each { |guild| present_card(guild) }
+          @absent.each { |guild| invite_card(guild) }
+        end
+      end
+    end
+  end
+
+  private
+
+  def present_card(guild)
+    # future (Phase 7): link to the server's config dashboard
+    a(href: "#", class: "flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-5 shadow-sm transition hover:shadow-md") do
+      card_heading(guild)
+      span(class: "self-start rounded-full bg-[#e6f5fc] px-2.5 py-1 text-xs font-semibold text-[#1a729e]") { "Configure" }
+    end
+  end
+
+  def invite_card(guild)
+    div(class: "flex flex-col gap-3 rounded-lg border border-dashed border-gray-300 bg-white p-5") do
+      card_heading(guild)
+      a(href: invite_url(guild), class: "self-start rounded-md border border-gray-300 px-3 py-1.5 text-sm font-semibold hover:bg-gray-50") { "Invite shrkbot" }
+    end
+  end
+
+  def card_heading(guild)
+    div(class: "flex items-center gap-3") do
+      span(class: "grid h-12 w-12 place-items-center rounded-lg bg-gray-100 font-semibold text-gray-600") { initials(guild.name) }
+      span(class: "truncate font-semibold") { guild.name }
+    end
+  end
+
+  def empty_state
+    div(class: "rounded-lg border border-dashed border-gray-300 bg-white p-10 text-center") do
+      h2(class: "text-lg font-bold") { "shrkbot isn't in any of your servers yet" }
+      p(class: "mx-auto mt-2 max-w-md text-sm text-gray-600") { "You need Manage Server permissions and shrkbot must be present. Invite it to a server, then come back and refresh." }
+    end
+  end
+
+  def error_banner
+    div(class: "mb-6 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800") { "We couldn't reach Discord to load your servers. Try again in a moment." }
+  end
+
+  def initials(name)
+    name.split.filter_map { |word| word[0] }.first(2).join.upcase
+  end
+
+  def invite_url(guild)
+    # future (Phase 7): set the real permission integer for shrkbot's required scopes
+    client_id = ENV["CLIENT_ID"]
+    "https://discord.com/oauth2/authorize?client_id=#{client_id}&scope=bot+applications.commands&guild_id=#{guild.id}&disable_guild_select=true"
+  end
+end

--- a/config/database.yml
+++ b/config/database.yml
@@ -56,7 +56,9 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: app_test
+  # A bare DATABASE_URL is merged on top of every environment, so without this
+  # the test suite would share the development database (see database_config_spec).
+  url: <%= ENV["DATABASE_URL"]&.sub(%r{/([^/?]+)(\?|\z)}, '/\1_test\2') || "postgres:///app_test" %>
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,1 @@
+Rails.application.config.session_store :cookie_store, expire_after: 2.weeks

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
   get "/auth/failure", to: "sessions#failure"
   delete "/logout", to: "sessions#destroy", as: :logout
 
+  resources :servers, only: :index
+
   # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
   # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,15 @@ services:
       redis:
         condition: service_healthy
 
+  css:
+    build: .
+    command: "bin/rails tailwindcss:watch[always]"
+    restart: unless-stopped
+    environment:
+      RAILS_ENV: development
+    volumes:
+      - ./:/app
+
   bot:
     build: .
     command: bin/bot

--- a/spec/bot/discord/guild_spec.rb
+++ b/spec/bot/discord/guild_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe Discord::Guild do
+  describe ".from_api" do
+    subject(:guild) { described_class.from_api(payload) }
+
+    let(:payload) do
+      {
+        "id" => "123",
+        "name" => "Dev Refuge",
+        "owner" => false,
+        "permissions" => "32",
+        "icon" => "abc"
+      }
+    end
+
+    it "coerces the snowflake id to an integer" do
+      expect(guild.id).to eq(123)
+    end
+
+    it "parses the permissions bitfield to an integer" do
+      expect(guild.permissions).to eq(32)
+    end
+  end
+
+  describe "#manageable?" do
+    subject(:manageable) { guild.manageable? }
+
+    let(:guild) { described_class.new(id: 1, name: "S", owner:, permissions:, icon: nil) }
+    let(:owner) { false }
+    let(:permissions) { 0 }
+
+    context "when the user owns the server" do
+      let(:owner) { true }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "with the ADMINISTRATOR permission" do
+      let(:permissions) { 0x8 }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "with the MANAGE_GUILD permission" do
+      let(:permissions) { 0x20 }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "with neither ownership nor a managing permission" do
+      let(:permissions) { 0x400 }
+
+      it { is_expected.to be(false) }
+    end
+  end
+end

--- a/spec/bot/discord/guild_spec.rb
+++ b/spec/bot/discord/guild_spec.rb
@@ -54,4 +54,22 @@ RSpec.describe Discord::Guild do
       it { is_expected.to be(false) }
     end
   end
+
+  describe "#icon_url" do
+    subject(:icon_url) { described_class.new(id: 7, name: "S", owner: false, permissions: 0, icon:).icon_url }
+
+    context "with an icon" do
+      let(:icon) { "abc123" }
+
+      it "builds the Discord CDN URL" do
+        expect(icon_url).to eq("https://cdn.discordapp.com/icons/7/abc123.png?size=64")
+      end
+    end
+
+    context "without an icon" do
+      let(:icon) { nil }
+
+      it { is_expected.to be_nil }
+    end
+  end
 end

--- a/spec/bot/discord/user_guilds_spec.rb
+++ b/spec/bot/discord/user_guilds_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe Discord::UserGuilds do
+  subject(:fetch) { described_class.call("access-token") }
+
+  let(:response) { instance_double(Net::HTTPResponse, code: code, body: body) }
+  let(:code) { "200" }
+  let(:body) { [{"id" => "42", "name" => "Dev Refuge", "owner" => true, "permissions" => "8", "icon" => nil}].to_json }
+
+  before { allow(Net::HTTP).to receive(:start).and_return(response) }
+
+  it "maps the response into guilds" do
+    expect(fetch).to contain_exactly(an_instance_of(Discord::Guild))
+  end
+
+  it "carries the parsed fields" do
+    expect(fetch.first).to have_attributes(id: 42, name: "Dev Refuge", owner: true, permissions: 8)
+  end
+
+  context "when Discord rejects the access token" do
+    let(:code) { "401" }
+    let(:body) { "" }
+
+    it "raises Unauthorized" do
+      expect { fetch }.to raise_error(described_class::Unauthorized)
+    end
+  end
+
+  context "when Discord responds with another error status" do
+    let(:code) { "500" }
+    let(:body) { "" }
+
+    it "raises a generic error, not Unauthorized" do
+      expect { fetch }.to raise_error(described_class::Error) do |error|
+        expect(error).not_to be_a(described_class::Unauthorized)
+      end
+    end
+  end
+
+  context "when the body is not valid JSON" do
+    let(:body) { "not json" }
+
+    it "raises a wrapped error" do
+      expect { fetch }.to raise_error(described_class::Error)
+    end
+  end
+end

--- a/spec/bot/discord/user_guilds_spec.rb
+++ b/spec/bot/discord/user_guilds_spec.rb
@@ -3,11 +3,15 @@ require "rails_helper"
 RSpec.describe Discord::UserGuilds do
   subject(:fetch) { described_class.call("access-token") }
 
+  let(:http) { instance_double(Net::HTTP) }
   let(:response) { instance_double(Net::HTTPResponse, code: code, body: body) }
   let(:code) { "200" }
   let(:body) { [{"id" => "42", "name" => "Dev Refuge", "owner" => true, "permissions" => "8", "icon" => nil}].to_json }
 
-  before { allow(Net::HTTP).to receive(:start).and_return(response) }
+  before do
+    allow(http).to receive(:request).and_return(response)
+    allow(Net::HTTP).to receive(:start).and_yield(http).and_return(response)
+  end
 
   it "maps the response into guilds" do
     expect(fetch).to contain_exactly(an_instance_of(Discord::Guild))

--- a/spec/database_config_spec.rb
+++ b/spec/database_config_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe "database configuration" do
+  it "uses a separate database from development so a live-gate session can't pollute the test suite" do
+    test_database = ActiveRecord::Base.connection_db_config.database
+    development_database = ActiveRecord::Base.configurations.configs_for(env_name: "development").first.database
+
+    expect(test_database).not_to eq(development_database)
+  end
+end

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Authentication", type: :request do
-  let(:auth) { OmniAuth::AuthHash.new(provider: "discord", uid: "12345", info: {name: "shrk"}) }
+  let(:auth) { OmniAuth::AuthHash.new(provider: "discord", uid: "12345", info: {name: "shrk"}, credentials: {token: "discord-access-token"}) }
 
   before do
     OmniAuth.config.test_mode = true
@@ -18,10 +18,10 @@ RSpec.describe "Authentication", type: :request do
   describe "the Discord callback" do
     subject(:callback) { post "/auth/discord/callback" }
 
-    it "signs the user in and redirects home" do
+    it "signs the user in and redirects to the server picker" do
       expect { callback }.to change(User, :count).by(1)
       expect(session[:user_id]).to eq(User.find_by(discord_id: 12345).id)
-      expect(callback).to redirect_to(root_path)
+      expect(callback).to redirect_to(servers_path)
     end
   end
 

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -55,11 +55,11 @@ RSpec.describe "Authentication", type: :request do
       expect(response.body).to include('data-turbo="false"')
     end
 
-    it "greets the user once signed in" do
+    it "redirects a signed-in user to the server picker" do
       post "/auth/discord/callback"
       get root_path
 
-      expect(response.body).to include("Signed in as shrk")
+      expect(response).to redirect_to(servers_path)
     end
   end
 end

--- a/spec/requests/server_picker_spec.rb
+++ b/spec/requests/server_picker_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Server picker", type: :request do
     end
 
     context "when signed in" do
-      let(:present_guild) { Discord::Guild.new(id: 900_000_001, name: "Dev Refuge", owner: true, permissions: 0, icon: nil) }
+      let(:present_guild) { Discord::Guild.new(id: 900_000_001, name: "Dev Refuge", owner: true, permissions: 0, icon: "icyhash") }
       let(:absent_guild) { Discord::Guild.new(id: 900_000_002, name: "Speedrun HQ", owner: false, permissions: 0x20, icon: nil) }
       let(:unmanaged_guild) { Discord::Guild.new(id: 900_000_003, name: "Lurker Lounge", owner: false, permissions: 0, icon: nil) }
 
@@ -43,9 +43,15 @@ RSpec.describe "Server picker", type: :request do
         allow(Discord::UserGuilds).to receive(:call).and_return([present_guild, absent_guild, unmanaged_guild])
       end
 
-      it "lists a managed server the bot is already in" do
+      it "lists a managed server the bot is already in, with its icon" do
         get_servers
         expect(response.body).to include("Dev Refuge")
+        expect(response.body).to include("cdn.discordapp.com/icons/900000001/icyhash.png")
+      end
+
+      it "offers a way to sign out" do
+        get_servers
+        expect(response.body).to include("Sign out")
       end
 
       it "offers an invite for a managed server without the bot" do

--- a/spec/requests/server_picker_spec.rb
+++ b/spec/requests/server_picker_spec.rb
@@ -1,0 +1,98 @@
+require "rails_helper"
+
+RSpec.describe "Server picker", type: :request do
+  let(:auth) do
+    OmniAuth::AuthHash.new(
+      provider: "discord",
+      uid: "12345",
+      info: {name: "shrk"},
+      credentials: {token: "discord-access-token"}
+    )
+  end
+
+  before do
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:discord] = auth
+    Rails.application.env_config["omniauth.auth"] = auth
+  end
+
+  after do
+    OmniAuth.config.test_mode = false
+    OmniAuth.config.mock_auth[:discord] = nil
+    Rails.application.env_config.delete("omniauth.auth")
+  end
+
+  describe "GET /servers" do
+    subject(:get_servers) { get servers_path }
+
+    context "when signed out" do
+      it "redirects to the sign-in page" do
+        get_servers
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "when signed in" do
+      let(:present_guild) { Discord::Guild.new(id: 900_000_001, name: "Dev Refuge", owner: true, permissions: 0, icon: nil) }
+      let(:absent_guild) { Discord::Guild.new(id: 900_000_002, name: "Speedrun HQ", owner: false, permissions: 0x20, icon: nil) }
+      let(:unmanaged_guild) { Discord::Guild.new(id: 900_000_003, name: "Lurker Lounge", owner: false, permissions: 0, icon: nil) }
+
+      before do
+        post "/auth/discord/callback"
+        create(:server_configuration, discord_id: present_guild.id)
+        allow(Discord::UserGuilds).to receive(:call).and_return([present_guild, absent_guild, unmanaged_guild])
+      end
+
+      it "lists a managed server the bot is already in" do
+        get_servers
+        expect(response.body).to include("Dev Refuge")
+      end
+
+      it "offers an invite for a managed server without the bot" do
+        get_servers
+        expect(response.body).to include("Speedrun HQ").and include("Invite shrkbot")
+      end
+
+      it "hides servers the user cannot manage" do
+        get_servers
+        expect(response.body).not_to include("Lurker Lounge")
+      end
+
+      context "with no manageable servers" do
+        before { allow(Discord::UserGuilds).to receive(:call).and_return([unmanaged_guild]) }
+
+        it "shows the empty state" do
+          get_servers
+          expect(response.body).to include("in any of your servers yet")
+        end
+      end
+
+      context "when Discord cannot be reached" do
+        before { allow(Discord::UserGuilds).to receive(:call).and_raise(Discord::UserGuilds::Error) }
+
+        it "renders the error state without raising" do
+          get_servers
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include("reach Discord")
+        end
+      end
+
+      context "when the Discord access token has expired" do
+        before { allow(Discord::UserGuilds).to receive(:call).and_raise(Discord::UserGuilds::Unauthorized) }
+
+        it "kicks off automatic re-authentication" do
+          get_servers
+          expect(response.body).to include("Signing you back in")
+          expect(session[:reauth_attempted]).to be(true)
+        end
+
+        it "falls back to the error state instead of looping if re-auth still fails" do
+          get servers_path
+          get servers_path
+          expect(response.body).to include("reach Discord")
+          expect(session[:reauth_attempted]).to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Phase 6 part 2: manageable-server picker

After login, the user lands on a server picker showing the Discord servers they can manage (owner, or Administrator / Manage Server) where the bot is present, with invite affordances for manageable servers the bot isn't in yet, plus an empty state.

### Server list
- `Discord::UserGuilds` fetches `GET /users/@me/guilds` behind a mockable seam (stdlib `Net::HTTP` - the only web→Discord call we make; specs never hit Discord). `Discord::Guild` is a value object deciding manageability via permission bits.
- The manageable filter is a read, so it lives in the value object, not an Op. `ServersController` intersects against `ServerConfiguration`.
- `require_login` (first protected page); login now lands on `/servers`.

### Session lifetime + token re-auth
- The Discord access token (~7 days) is kept in the encrypted session, not persisted on `User`.
- App login previously had no expiry; added a 2-week `expire_after`.
- On a 401 from the guild fetch (expired/revoked token), the picker auto-re-runs the OAuth request via a small Stimulus controller (`Views::Reauth`), with a one-shot guard so a persistently-bad token can't redirect-loop. No refresh-token flow - re-auth is seamless for an already-consented user and the token is only needed on this page.

### Dev/test database separation
- A bare `DATABASE_URL` is merged on top of every environment, so the test suite shared the **development** database - a live-gate login committed rows the suite then read. The `test:` entry now derives a dedicated `<dev db>_test` database that overrides the ambient URL; guarded by `spec/database_config_spec.rb`. CI aligned to derive it the same way. (Bonus: the chronic `EnvironmentMismatchError` rspec noise is gone.)

### Gates
All green locally: `rspec` (394), `standardrb`, `active_record_doctor`, `undercover --compare origin/main`.

### Running locally
Your test database is new - run once: `RAILS_ENV=test bin/rails db:create db:schema:load`.

### Live gate
- Real Discord login → correct manageable-server list.
- Let the token expire or revoke the app authorization → picker auto-signs you back in.