### PR TITLE
Restyle the server picker to the design kit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,24 @@ jobs:
       - name: Lint code for consistent style
         run: bundle exec standardrb
 
+  i18n:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      # `unused` is intentionally omitted: it can't see dynamic `t("#{...}")` calls.
+      - name: Check for missing locale keys
+        run: bundle exec i18n-tasks missing
+
+      - name: Check locale files are normalized
+        run: bundle exec i18n-tasks check-normalized
+
   test:
     runs-on: ubuntu-latest
 

--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,9 @@ group :development, :test do
 
   gem "active_record_doctor"
 
+  # Lints locale files: missing/unused keys, normalization
+  gem "i18n-tasks", require: false
+
   gem "simplecov", require: false
   gem "simplecov-lcov", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,11 +153,25 @@ GEM
     heroicons (2.2.0)
       nokogiri
       railties (>= 5.2)
+    highline (3.1.2)
+      reline
     http-accept (1.7.0)
     http-cookie (1.1.6)
       domain_name (~> 0.5)
     i18n (1.15.1)
       concurrent-ruby (~> 1.0)
+    i18n-tasks (1.1.2)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
+      erubi
+      highline (>= 3.0.0)
+      i18n
+      parser (>= 3.2.2.1)
+      prism
+      rails-i18n
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.8, >= 1.8.1)
+      terminal-table (>= 1.5.1)
     image_processing (2.0.2)
     imagen (0.2.0)
       parser (>= 2.5, != 2.5.1.1)
@@ -318,6 +332,9 @@ GEM
     rails-html-sanitizer (1.7.0)
       loofah (~> 2.25)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails-i18n (8.1.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 8.0.0, < 9)
     railties (8.1.3)
       actionpack (= 8.1.3)
       activesupport (= 8.1.3)
@@ -444,6 +461,8 @@ GEM
     tailwindcss-ruby (4.3.1-arm64-darwin)
     tailwindcss-ruby (4.3.1-x86_64-linux-gnu)
     tailwindcss-ruby (4.3.1-x86_64-linux-musl)
+    terminal-table (4.0.0)
+      unicode-display_width (>= 1.1.1, < 4)
     thor (1.5.0)
     thruster (0.1.21)
     thruster (0.1.21-aarch64-linux)
@@ -506,6 +525,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   heroicons
+  i18n-tasks
   image_processing (~> 2.0)
   importmap-rails
   jbuilder
@@ -588,9 +608,11 @@ CHECKSUMS
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   hashie (5.1.0) sha256=c266471896f323c446ea8207f8ffac985d2718df0a0ba98651a3057096ca3870
   heroicons (2.2.0) sha256=3205b009b18abcae1c2063e32f57418f9ffe36da02f0f7a54eed1c47f16873e7
+  highline (3.1.2) sha256=67cbd34d19f6ef11a7ee1d82ffab5d36dfd5b3be861f450fc1716c7125f4bb4a
   http-accept (1.7.0) sha256=c626860682bfbb3b46462f8c39cd470fd7b0584f61b3cc9df5b2e9eb9972a126
   http-cookie (1.1.6) sha256=ba4b82be64de61dc281243dac70e3c382c45142f20268ed9276a3670c93feaa9
   i18n (1.15.1) sha256=505ec5de1f4e6c8a2cb028ef9700ca495f117911643455721dee5abdca797255
+  i18n-tasks (1.1.2) sha256=4dcfba49e52a623f30661cb316cb80d84fbba5cb8c6d88ef5e02545fffa3637a
   image_processing (2.0.2) sha256=d0cf990f862d64efb1a14916044bf4b5bb2bccc7e235022413cde46019799cfa
   imagen (0.2.0) sha256=369fe912078877dba92615ebfc6f35a7d833e31f24f47bdd3ad5371a4139e24b
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a
@@ -658,6 +680,7 @@ CHECKSUMS
   rails (8.1.3) sha256=6d017ba5348c98fc909753a8169b21d44de14d2a0b92d140d1a966834c3c9cd3
   rails-dom-testing (2.3.0) sha256=8acc7953a7b911ca44588bf08737bc16719f431a1cc3091a292bca7317925c1d
   rails-html-sanitizer (1.7.0) sha256=28b145cceaf9cc214a9874feaa183c3acba036c9592b19886e0e45efc62b1e89
+  rails-i18n (8.1.0) sha256=52d5fd6c0abef28d84223cc05647f6ae0fd552637a1ede92deee9545755b6cf3
   railties (8.1.3) sha256=913eb0e0cb520aac687ffd74916bd726d48fa21f47833c6292576ef6a286de22
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
@@ -701,6 +724,7 @@ CHECKSUMS
   tailwindcss-ruby (4.3.1-arm64-darwin) sha256=477ef19dde7fa4db32a0f916c02398e5fcc6af7f18d5e773012d93d6b96ecfa3
   tailwindcss-ruby (4.3.1-x86_64-linux-gnu) sha256=22a208da614b7767cee504ab9dae2ab0d8299fdf633c045c6f8357de81d0506f
   tailwindcss-ruby (4.3.1-x86_64-linux-musl) sha256=1adcb5df5f9a6a85a81dc9e5102ce7e4f7a1415f477f1a6b22b52ee49c351ee6
+  terminal-table (4.0.0) sha256=f504793203f8251b2ea7c7068333053f0beeea26093ec9962e62ea79f94301d2
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
   thruster (0.1.21) sha256=dc67928f36e5894844579a95e45637a5091db7a7ea05468ee8c2c6eb0a3f77cf
   thruster (0.1.21-aarch64-linux) sha256=f5aff78fb7a6431ed3d6ab4bde03a89c461e9a73981dbc97d6990d85c3db235c

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -255,9 +255,10 @@ details:has(.dropdown-menu.is-closing) .dropdown-chevron { transform: rotate(90d
     color var(--dur-slow) var(--ease-standard);
 }
 
-.theme-morph { display: grid; }
+.theme-morph { position: relative; }
 .theme-morph > * {
-  grid-area: 1 / 1;
+  position: absolute;
+  inset: 0;
   transition: transform var(--dur-slow) var(--ease-standard), opacity var(--dur-slow) var(--ease-standard);
 }
 .theme-morph .theme-sun { opacity: 0; transform: rotate(-90deg) scale(0.4); }

--- a/app/bot/discord/guild.rb
+++ b/app/bot/discord/guild.rb
@@ -2,15 +2,20 @@ module Discord
   ADMINISTRATOR = 0x8
   MANAGE_GUILD = 0x20
 
-  Guild = Data.define(:id, :name, :owner, :permissions, :icon) do
+  Guild = Data.define(:id, :name, :owner, :permissions, :icon, :member_count) do
     def self.from_api(payload)
       new(
         id: payload["id"].to_i,
         name: payload["name"],
         owner: payload["owner"] == true,
         permissions: payload["permissions"].to_i,
-        icon: payload["icon"]
+        icon: payload["icon"],
+        member_count: payload["approximate_member_count"]
       )
+    end
+
+    def initialize(member_count: nil, **rest)
+      super
     end
 
     def manageable?

--- a/app/bot/discord/user_guilds.rb
+++ b/app/bot/discord/user_guilds.rb
@@ -3,7 +3,7 @@ require "json"
 
 module Discord
   class UserGuilds
-    ENDPOINT = URI("https://discord.com/api/v10/users/@me/guilds")
+    ENDPOINT = URI("https://discord.com/api/v10/users/@me/guilds?with_counts=true")
 
     class Error < StandardError; end
 

--- a/app/components/app_shell.rb
+++ b/app/components/app_shell.rb
@@ -42,7 +42,7 @@ class Components::AppShell < Components::Base
       title: "Toggle dark mode",
       aria_label: "Toggle dark mode",
       data: {controller: "theme", action: "theme#toggle"},
-      class: "grid size-9 place-items-center rounded-md text-ink-500 transition-colors hover:bg-ink-100"
+      class: "flex size-9 items-center justify-center rounded-md text-ink-500 transition-colors hover:bg-ink-100"
     ) do
       span(class: "theme-morph size-5") do
         render Components::Icon.new("moon", class: "theme-moon size-5")
@@ -82,7 +82,7 @@ class Components::AppShell < Components::Base
     if @user.avatar_url
       image_tag(@user.avatar_url, alt: "", loading: "lazy", class: "size-8 rounded-full object-cover")
     else
-      span(class: "grid size-8 place-items-center rounded-full bg-brand-100 text-xs font-bold text-accent-soft-fg") { initials(@user.display_name) }
+      span(class: "flex size-8 items-center justify-center rounded-full bg-brand-100 text-xs font-bold text-accent-soft-fg") { initials(@user.display_name) }
     end
   end
 

--- a/app/components/app_shell.rb
+++ b/app/components/app_shell.rb
@@ -39,8 +39,8 @@ class Components::AppShell < Components::Base
   def theme_toggle
     button(
       type: "button",
-      title: "Toggle dark mode",
-      aria_label: "Toggle dark mode",
+      title: t(".toggle_theme"),
+      aria_label: t(".toggle_theme"),
       data: {controller: "theme", action: "theme#toggle"},
       class: "flex size-9 items-center justify-center rounded-md text-ink-500 transition-colors hover:bg-ink-100"
     ) do
@@ -72,7 +72,7 @@ class Components::AppShell < Components::Base
           class: "flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-sm text-danger transition-colors hover:bg-danger-soft"
         ) do
           render Components::Icon.new("arrow-left-on-rectangle", class: "size-4")
-          span { "Log out" }
+          span { t(".log_out") }
         end
       end
     end

--- a/app/components/base.rb
+++ b/app/components/base.rb
@@ -3,4 +3,5 @@
 class Components::Base < Phlex::HTML
   # Include any helpers you want to be available across all components
   include Phlex::Rails::Helpers::Routes
+  include Phlex::Rails::Helpers::Translate
 end

--- a/app/components/toasts.rb
+++ b/app/components/toasts.rb
@@ -33,7 +33,7 @@ class Components::Toasts < Components::Base
         type: "button",
         aria_label: "Dismiss",
         data: {action: "toast#dismiss"},
-        class: "-mr-1 ml-1 grid size-5 flex-none place-items-center rounded transition-colors hover:bg-ink-100"
+        class: "-mr-1 ml-1 flex size-5 flex-none items-center justify-center rounded transition-colors hover:bg-ink-100"
       ) do
         render Components::Icon.new("x-mark", class: "size-3.5")
       end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,6 @@ class ApplicationController < ActionController::Base
   end
 
   def require_login
-    redirect_to root_path, alert: "Please sign in to continue." unless current_user
+    redirect_to root_path, alert: t("authentication.login_required") unless current_user
   end
 end

--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -2,7 +2,9 @@ class ServersController < ApplicationController
   before_action :require_login
 
   def index
-    manageable = Discord::UserGuilds.call(session[:discord_token]).select(&:manageable?)
+    manageable = Discord::UserGuilds.call(session[:discord_token])
+      .select(&:manageable?)
+      .sort_by { |guild| -guild.member_count.to_i }
     session.delete(:reauth_attempted)
     configured_ids = ServerConfiguration.where(discord_id: manageable.map(&:id)).pluck(:discord_id)
     present, absent = manageable.partition { |guild| configured_ids.include?(guild.id) }

--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -7,7 +7,12 @@ class ServersController < ApplicationController
     configured_ids = ServerConfiguration.where(discord_id: manageable.map(&:id)).pluck(:discord_id)
     present, absent = manageable.partition { |guild| configured_ids.include?(guild.id) }
 
-    render Views::Servers::Index.new(present:, absent:, user: current_user)
+    render Views::Servers::Index.new(
+      present:,
+      absent:,
+      plugin_counts: enabled_plugin_counts(configured_ids),
+      user: current_user
+    )
   rescue Discord::UserGuilds::Unauthorized
     reauthenticate
   rescue Discord::UserGuilds::Error
@@ -15,6 +20,14 @@ class ServersController < ApplicationController
   end
 
   private
+
+  def enabled_plugin_counts(discord_ids)
+    PluginActivation
+      .joins(:server_configuration)
+      .where(server_configurations: {discord_id: discord_ids}, enabled: true)
+      .group("server_configurations.discord_id")
+      .count
+  end
 
   def reauthenticate
     return render_error if session[:reauth_attempted]
@@ -25,6 +38,6 @@ class ServersController < ApplicationController
 
   def render_error
     session.delete(:reauth_attempted)
-    render Views::Servers::Index.new(present: [], absent: [], user: current_user, error: true)
+    render Views::Servers::Index.new(present: [], absent: [], plugin_counts: {}, user: current_user, error: true)
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,15 +4,15 @@ class SessionsController < ApplicationController
     user = User.from_omniauth(auth)
     session[:user_id] = user.id
     session[:discord_token] = auth.credentials.token
-    redirect_to servers_path, notice: "Signed in as #{user.username}."
+    redirect_to servers_path, notice: t("sessions.signed_in", name: user.display_name)
   end
 
   def destroy
     reset_session
-    redirect_to root_path, notice: "Signed out."
+    redirect_to root_path, notice: t("sessions.signed_out")
   end
 
   def failure
-    redirect_to root_path, alert: "Sign-in failed or was cancelled."
+    redirect_to root_path, alert: t("sessions.failed")
   end
 end

--- a/app/views/home.rb
+++ b/app/views/home.rb
@@ -11,9 +11,7 @@ class Views::Home < Views::Base
           plain "bot"
         end
 
-        p(class: "mb-6 text-ink-600") do
-          "Turn plugins on or off and set them up - all from one place."
-        end
+        p(class: "mb-6 text-ink-600") { t(".tagline") }
 
         button_to(
           "/auth/discord",
@@ -22,7 +20,7 @@ class Views::Home < Views::Base
           class: "btn-fill btn-fill-primary inline-flex w-full items-center justify-center gap-2 rounded-md bg-brand-500 px-4 py-3 font-semibold text-white"
         ) do
           render Components::Icon.new("arrow-right-on-rectangle", class: "size-5")
-          span { "Sign in with Discord" }
+          span { t(".sign_in") }
         end
       end
     end

--- a/app/views/reauth.rb
+++ b/app/views/reauth.rb
@@ -5,10 +5,10 @@ class Views::Reauth < Views::Base
 
   def view_template
     div(class: "mx-auto flex min-h-screen max-w-md flex-col justify-center px-6 text-center") do
-      h1(class: "mb-2 font-display text-xl font-bold tracking-tight") { "Signing you back in" }
-      p(class: "mb-6 text-ink-600") { "Your Discord sign-in expired. Please stand by - we're refreshing it for you." }
+      h1(class: "mb-2 font-display text-xl font-bold tracking-tight") { t(".title") }
+      p(class: "mb-6 text-ink-600") { t(".body") }
       button_to(
-        "Continue",
+        t(".continue"),
         "/auth/discord",
         method: :post,
         form: {data: {controller: "reauth", turbo: false}},

--- a/app/views/servers/index.rb
+++ b/app/views/servers/index.rb
@@ -1,30 +1,27 @@
 # frozen_string_literal: true
 
 class Views::Servers::Index < Views::Base
-  def initialize(present:, absent:, user:, error: false)
+  include Phlex::Rails::Helpers::ImageTag
+
+  def initialize(present:, absent:, user:, plugin_counts: {}, error: false)
     @present = present
     @absent = absent
     @user = user
+    @plugin_counts = plugin_counts
     @error = error
   end
 
   def view_template
     render Components::AppShell.new(user: @user) do
       div(class: "mx-auto max-w-4xl px-6 py-10") do
-        div(class: "mb-6") do
-          h1(class: "mb-1 font-display text-2xl font-bold tracking-tight") { "Your servers" }
-          p(class: "text-ink-600") { "Pick a server to configure. Servers without shrkbot show an invite link instead." }
-        end
-
+        heading
         error_banner if @error
 
         if @present.empty? && @absent.empty?
           empty_state
         else
-          div(class: "grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3") do
-            @present.each { |guild| present_card(guild) }
-            @absent.each { |guild| invite_card(guild) }
-          end
+          server_grid
+          missing_server_prompt
         end
       end
     end
@@ -32,39 +29,111 @@ class Views::Servers::Index < Views::Base
 
   private
 
+  def heading
+    div(class: "mb-6") do
+      h1(class: "mb-1 font-display text-2xl font-bold tracking-tight") { "Your servers" }
+      p(class: "text-ink-600") { "Pick a server to configure shrkbot." }
+    end
+  end
+
+  def server_grid
+    div(class: "grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3") do
+      @present.each { |guild| present_card(guild) }
+      @absent.each { |guild| invite_card(guild) }
+    end
+  end
+
   def present_card(guild)
     a(href: "#", class: "card-lift flex flex-col gap-3 rounded-lg border border-ink-200 bg-ink-0 p-5 shadow-sm") do
-      card_heading(guild)
-      span(class: "self-start rounded-full bg-brand-100 px-2.5 py-1 text-xs font-semibold text-accent-soft-fg") { "Configure" }
+      identity(guild)
+      plugins_badge(@plugin_counts[guild.id].to_i)
     end
   end
 
   def invite_card(guild)
     div(class: "flex flex-col gap-3 rounded-lg border border-dashed border-ink-300 bg-ink-0 p-5") do
-      card_heading(guild)
-      a(href: invite_url(guild), class: "self-start rounded-md border border-ink-300 px-3 py-1.5 text-sm font-semibold hover:bg-ink-50") { "Invite shrkbot" }
+      div(class: "opacity-60") { identity(guild) }
+      invite_button(invite_url(guild))
     end
   end
 
-  def card_heading(guild)
+  def identity(guild)
     div(class: "flex items-center gap-3") do
       avatar(guild)
-      span(class: "truncate font-semibold") { guild.name }
+      div(class: "min-w-0") do
+        p(class: "truncate text-sm font-semibold") { guild.name }
+        p(class: "text-xs text-ink-400") { member_label(guild) } if guild.member_count
+      end
     end
   end
 
   def avatar(guild)
     if guild.icon_url
-      img(src: guild.icon_url, alt: "", loading: "lazy", class: "h-12 w-12 flex-none rounded-lg object-cover")
+      img(src: guild.icon_url, alt: "", loading: "lazy", class: "size-12 flex-none rounded-lg object-cover")
     else
-      span(class: "grid h-12 w-12 flex-none place-items-center rounded-lg bg-ink-100 font-semibold text-ink-500") { initials(guild.name) }
+      span(class: "grid size-12 flex-none place-items-center rounded-lg bg-ink-100 font-semibold text-ink-500") { initials(guild.name) }
+    end
+  end
+
+  def plugins_badge(count)
+    tone = count.positive? ? "bg-brand-100 text-accent-soft-fg" : "bg-ink-100 text-ink-500"
+    span(class: "self-start rounded-full px-2.5 py-1 text-xs font-semibold #{tone}") do
+      "#{count} #{(count == 1) ? "plugin" : "plugins"} on"
+    end
+  end
+
+  def member_label(guild)
+    count = guild.member_count
+    "#{count.to_fs(:delimited)} #{(count == 1) ? "member" : "members"}"
+  end
+
+  def invite_button(url)
+    a(
+      href: url,
+      class: "btn-fill btn-fill-ghost inline-flex items-center gap-1.5 self-start rounded-md border border-ink-300 px-3 py-1.5 text-sm font-semibold transition-colors hover:bg-ink-50"
+    ) do
+      render Components::Icon.new("plus", class: "size-4")
+      span { "Invite shrkbot" }
+    end
+  end
+
+  def missing_server_prompt
+    div(class: "mt-8 rounded-lg border border-dashed border-ink-200 bg-ink-0 p-8 text-center") do
+      p(class: "text-sm font-semibold") { "Don't see a server?" }
+      p(class: "mx-auto mt-1 max-w-md text-sm text-ink-500") do
+        plain "You need "
+        span(class: "font-medium text-ink-700") { "Manage Server" }
+        plain " permissions and shrkbot must be present. Invite it, then refresh."
+      end
+      div(class: "mt-4 flex justify-center") { invite_button(generic_invite_url) }
     end
   end
 
   def empty_state
-    div(class: "rounded-lg border border-dashed border-ink-300 bg-ink-0 p-10 text-center") do
-      h2(class: "text-lg font-bold") { "shrkbot isn't in any of your servers yet" }
-      p(class: "mx-auto mt-2 max-w-md text-sm text-ink-600") { "You need Manage Server permissions and shrkbot must be present. Invite it to a server, then come back and refresh." }
+    div(class: "flex flex-col items-center px-6 py-16 text-center") do
+      image_tag("shrkbot-mascot.png", alt: "", class: "mb-6 size-20 rounded-xl opacity-50 shadow-sm")
+      h2(class: "mb-2 font-display text-xl font-bold tracking-tight") { "shrkbot isn't in any of your servers yet" }
+      p(class: "mb-6 max-w-sm text-sm leading-relaxed text-ink-600") do
+        plain "You need "
+        span(class: "font-medium text-ink-800") { "Manage Server" }
+        plain " permissions and shrkbot must be present. Invite it to get started."
+      end
+      div(class: "flex flex-wrap justify-center gap-3") do
+        a(
+          href: generic_invite_url,
+          class: "btn-fill btn-fill-primary inline-flex h-10 items-center gap-2 rounded-md bg-brand-500 px-5 text-sm font-semibold text-white"
+        ) do
+          render Components::Icon.new("plus", class: "size-4")
+          span { "Invite shrkbot" }
+        end
+        a(
+          href: servers_path,
+          class: "btn-fill btn-fill-ghost inline-flex h-10 items-center gap-2 rounded-md border border-ink-200 px-5 text-sm font-semibold transition-colors hover:bg-ink-50"
+        ) do
+          render Components::Icon.new("arrow-path", class: "size-4")
+          span { "Refresh" }
+        end
+      end
     end
   end
 
@@ -76,8 +145,11 @@ class Views::Servers::Index < Views::Base
     name.split.filter_map { |word| word[0] }.first(2).join.upcase
   end
 
+  def generic_invite_url
+    "https://discord.com/oauth2/authorize?client_id=#{ENV["CLIENT_ID"]}&scope=bot+applications.commands"
+  end
+
   def invite_url(guild)
-    client_id = ENV["CLIENT_ID"]
-    "https://discord.com/oauth2/authorize?client_id=#{client_id}&scope=bot+applications.commands&guild_id=#{guild.id}&disable_guild_select=true"
+    "#{generic_invite_url}&guild_id=#{guild.id}&disable_guild_select=true"
   end
 end

--- a/app/views/servers/index.rb
+++ b/app/views/servers/index.rb
@@ -31,8 +31,8 @@ class Views::Servers::Index < Views::Base
 
   def heading
     div(class: "mb-6") do
-      h1(class: "mb-1 font-display text-2xl font-bold tracking-tight") { "Your servers" }
-      p(class: "text-ink-600") { "Pick a server to configure shrkbot." }
+      h1(class: "mb-1 font-display text-2xl font-bold tracking-tight") { t(".title") }
+      p(class: "text-ink-600") { t(".subtitle") }
     end
   end
 
@@ -79,13 +79,12 @@ class Views::Servers::Index < Views::Base
   def plugins_badge(count)
     tone = count.positive? ? "bg-brand-100 text-accent-soft-fg" : "bg-ink-100 text-ink-600"
     span(class: "self-start rounded-full px-2.5 py-1 text-xs font-semibold #{tone}") do
-      "#{count} #{(count == 1) ? "plugin" : "plugins"} enabled"
+      t(".plugins_enabled", count: count)
     end
   end
 
   def member_label(guild)
-    count = guild.member_count
-    "#{count.to_fs(:delimited)} #{(count == 1) ? "member" : "members"}"
+    t(".members", count: guild.member_count, formatted: guild.member_count.to_fs(:delimited))
   end
 
   def invite_button(url)
@@ -94,18 +93,14 @@ class Views::Servers::Index < Views::Base
       class: "btn-fill btn-fill-ghost inline-flex items-center gap-1.5 self-start rounded-md border border-ink-300 px-3 py-1.5 text-sm font-semibold transition-colors hover:bg-ink-50"
     ) do
       render Components::Icon.new("plus", class: "size-4")
-      span { "Invite shrkbot" }
+      span { t(".invite") }
     end
   end
 
   def missing_server_prompt
     div(class: "mt-8 rounded-lg border border-dashed border-ink-200 bg-ink-0 p-8 text-center") do
-      p(class: "text-sm font-semibold") { "Don't see a server?" }
-      p(class: "mx-auto mt-1 max-w-md text-sm text-ink-500") do
-        plain "You need "
-        span(class: "font-medium text-ink-700") { "Manage Server" }
-        plain " permissions and shrkbot must be present. Invite it, then refresh."
-      end
+      p(class: "text-sm font-semibold") { t(".missing_title") }
+      p(class: "mx-auto mt-1 max-w-md text-sm text-ink-500") { t(".missing_body") }
       div(class: "mt-4 flex justify-center") { invite_button(generic_invite_url) }
     end
   end
@@ -113,33 +108,29 @@ class Views::Servers::Index < Views::Base
   def empty_state
     div(class: "flex flex-col items-center px-6 py-16 text-center") do
       image_tag("shrkbot-mascot.png", alt: "", class: "mb-6 size-20 rounded-xl opacity-50 shadow-sm")
-      h2(class: "mb-2 font-display text-xl font-bold tracking-tight") { "shrkbot isn't in any of your servers yet" }
-      p(class: "mb-6 max-w-sm text-sm leading-relaxed text-ink-600") do
-        plain "You need "
-        span(class: "font-medium text-ink-800") { "Manage Server" }
-        plain " permissions and shrkbot must be present. Invite it to get started."
-      end
+      h2(class: "mb-2 font-display text-xl font-bold tracking-tight") { t(".empty_title") }
+      p(class: "mb-6 max-w-sm text-sm leading-relaxed text-ink-600") { t(".empty_body") }
       div(class: "flex flex-wrap justify-center gap-3") do
         a(
           href: generic_invite_url,
           class: "btn-fill btn-fill-primary inline-flex h-10 items-center gap-2 rounded-md bg-brand-500 px-5 text-sm font-semibold text-white"
         ) do
           render Components::Icon.new("plus", class: "size-4")
-          span { "Invite shrkbot" }
+          span { t(".invite") }
         end
         a(
           href: servers_path,
           class: "btn-fill btn-fill-ghost inline-flex h-10 items-center gap-2 rounded-md border border-ink-200 px-5 text-sm font-semibold transition-colors hover:bg-ink-50"
         ) do
           render Components::Icon.new("arrow-path", class: "size-4")
-          span { "Refresh" }
+          span { t(".refresh") }
         end
       end
     end
   end
 
   def error_banner
-    div(class: "mb-6 rounded-md border border-warning/30 bg-warning-soft px-4 py-3 text-sm text-warning") { "We couldn't reach Discord to load your servers. Try again in a moment." }
+    div(class: "mb-6 rounded-md border border-warning/30 bg-warning-soft px-4 py-3 text-sm text-warning") { t(".error") }
   end
 
   def initials(name)

--- a/app/views/servers/index.rb
+++ b/app/views/servers/index.rb
@@ -62,7 +62,7 @@ class Views::Servers::Index < Views::Base
       avatar(guild)
       div(class: "min-w-0") do
         p(class: "text-sm font-semibold line-clamp-2") { guild.name }
-        p(class: "text-xs text-ink-400") { member_label(guild) } if guild.member_count
+        p(class: "text-xs text-ink-500") { member_label(guild) } if guild.member_count
       end
     end
   end
@@ -76,7 +76,7 @@ class Views::Servers::Index < Views::Base
   end
 
   def plugins_badge(count)
-    tone = count.positive? ? "bg-brand-100 text-accent-soft-fg" : "bg-ink-100 text-ink-500"
+    tone = count.positive? ? "bg-brand-100 text-accent-soft-fg" : "bg-ink-100 text-ink-600"
     span(class: "self-start rounded-full px-2.5 py-1 text-xs font-semibold #{tone}") do
       "#{count} #{(count == 1) ? "plugin" : "plugins"} enabled"
     end

--- a/app/views/servers/index.rb
+++ b/app/views/servers/index.rb
@@ -79,7 +79,7 @@ class Views::Servers::Index < Views::Base
   def plugins_badge(count)
     tone = count.positive? ? "bg-brand-100 text-accent-soft-fg" : "bg-ink-100 text-ink-600"
     span(class: "self-start rounded-full px-2.5 py-1 text-xs font-semibold #{tone}") do
-      t(".plugins_enabled", count: count)
+      t(".plugins_enabled", count:)
     end
   end
 

--- a/app/views/servers/index.rb
+++ b/app/views/servers/index.rb
@@ -58,10 +58,10 @@ class Views::Servers::Index < Views::Base
   end
 
   def identity(guild)
-    div(class: "flex items-center gap-3") do
+    div(class: "flex items-start gap-3") do
       avatar(guild)
       div(class: "min-w-0") do
-        p(class: "truncate text-sm font-semibold") { guild.name }
+        p(class: "text-sm font-semibold line-clamp-2") { guild.name }
         p(class: "text-xs text-ink-400") { member_label(guild) } if guild.member_count
       end
     end
@@ -71,14 +71,14 @@ class Views::Servers::Index < Views::Base
     if guild.icon_url
       img(src: guild.icon_url, alt: "", loading: "lazy", class: "size-12 flex-none rounded-lg object-cover")
     else
-      span(class: "grid size-12 flex-none place-items-center rounded-lg bg-ink-100 font-semibold text-ink-500") { initials(guild.name) }
+      span(class: "flex size-12 flex-none items-center justify-center rounded-lg bg-ink-100 font-semibold text-ink-500") { initials(guild.name) }
     end
   end
 
   def plugins_badge(count)
     tone = count.positive? ? "bg-brand-100 text-accent-soft-fg" : "bg-ink-100 text-ink-500"
     span(class: "self-start rounded-full px-2.5 py-1 text-xs font-semibold #{tone}") do
-      "#{count} #{(count == 1) ? "plugin" : "plugins"} on"
+      "#{count} #{(count == 1) ? "plugin" : "plugins"} enabled"
     end
   end
 

--- a/app/views/servers/index.rb
+++ b/app/views/servers/index.rb
@@ -52,14 +52,14 @@ class Views::Servers::Index < Views::Base
 
   def invite_card(guild)
     div(class: "flex flex-col gap-3 rounded-lg border border-dashed border-ink-300 bg-ink-0 p-5") do
-      div(class: "opacity-60") { identity(guild) }
+      identity(guild, muted: true)
       invite_button(invite_url(guild))
     end
   end
 
-  def identity(guild)
+  def identity(guild, muted: false)
     div(class: "flex items-start gap-3") do
-      avatar(guild)
+      avatar(guild, muted:)
       div(class: "min-w-0") do
         p(class: "text-sm font-semibold line-clamp-2") { guild.name }
         p(class: "text-xs text-ink-500") { member_label(guild) } if guild.member_count
@@ -67,11 +67,12 @@ class Views::Servers::Index < Views::Base
     end
   end
 
-  def avatar(guild)
+  def avatar(guild, muted: false)
+    dim = muted ? " opacity-60" : ""
     if guild.icon_url
-      img(src: guild.icon_url, alt: "", loading: "lazy", class: "size-12 flex-none rounded-lg object-cover")
+      img(src: guild.icon_url, alt: "", loading: "lazy", class: "size-12 flex-none rounded-lg object-cover#{dim}")
     else
-      span(class: "flex size-12 flex-none items-center justify-center rounded-lg bg-ink-100 font-semibold text-ink-500") { initials(guild.name) }
+      span(class: "flex size-12 flex-none items-center justify-center rounded-lg bg-ink-100 font-semibold text-ink-500#{dim}") { initials(guild.name) }
     end
   end
 

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -1,0 +1,22 @@
+base_locale: en
+locales: [en]
+
+data:
+  read:
+    - config/locales/*.%{locale}.yml
+  write:
+    - ["activity_log.*", "config/locales/activity_log.%{locale}.yml"]
+    - "config/locales/web.%{locale}.yml"
+
+search:
+  paths:
+    - app/
+  # Phlex views/components are Ruby classes, so a relative `t(".key")` is scoped
+  # by the class name (Views::Servers::Index -> views.servers.index). Rooting at
+  # `app` makes the file path resolve to the same scope; excluding the method
+  # name stops i18n-tasks appending the enclosing method (Phlex scopes by class,
+  # not method).
+  relative_roots:
+    - app
+  relative_exclude_method_name_paths:
+    - app

--- a/config/locales/activity_log.en.yml
+++ b/config/locales/activity_log.en.yml
@@ -1,3 +1,4 @@
+---
 en:
   activity_log:
     roles:

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -1,36 +1,40 @@
+---
 en:
+  authentication:
+    login_required: Please sign in to continue.
+  components:
+    app_shell:
+      log_out: Log out
+      toggle_theme: Toggle dark mode
+  sessions:
+    failed: Sign-in failed or was cancelled.
+    signed_in: Signed in as %{name}.
+    signed_out: Signed out.
   views:
     home:
-      tagline: "Turn plugins on or off and set them up - all from one place."
-      sign_in: "Sign in with Discord"
+      sign_in: Sign in with Discord
+      tagline: Turn plugins on or off and set them up - all from one place.
     reauth:
-      title: "Signing you back in"
-      body: "Your Discord sign-in expired. Please stand by - we're refreshing it for you."
-      continue: "Continue"
+      body: Your Discord sign-in expired. Please stand by - we're refreshing it for
+        you.
+      continue: Continue
+      title: Signing you back in
     servers:
       index:
-        title: "Your servers"
-        subtitle: "Pick a server to configure shrkbot."
-        plugins_enabled:
-          one: "%{count} plugin enabled"
-          other: "%{count} plugins enabled"
+        empty_body: You need Manage Server permissions and shrkbot must be present.
+          Invite it to get started.
+        empty_title: shrkbot isn't in any of your servers yet
+        error: We couldn't reach Discord to load your servers. Try again in a moment.
+        invite: Invite shrkbot
         members:
           one: "%{formatted} member"
           other: "%{formatted} members"
-        invite: "Invite shrkbot"
-        refresh: "Refresh"
-        error: "We couldn't reach Discord to load your servers. Try again in a moment."
-        missing_title: "Don't see a server?"
-        missing_body: "You need Manage Server permissions and shrkbot must be present. Invite it, then refresh."
-        empty_title: "shrkbot isn't in any of your servers yet"
-        empty_body: "You need Manage Server permissions and shrkbot must be present. Invite it to get started."
-  components:
-    app_shell:
-      toggle_theme: "Toggle dark mode"
-      log_out: "Log out"
-  sessions:
-    signed_in: "Signed in as %{name}."
-    signed_out: "Signed out."
-    failed: "Sign-in failed or was cancelled."
-  authentication:
-    login_required: "Please sign in to continue."
+        missing_body: You need Manage Server permissions and shrkbot must be present.
+          Invite it, then refresh.
+        missing_title: Don't see a server?
+        plugins_enabled:
+          one: "%{count} plugin enabled"
+          other: "%{count} plugins enabled"
+        refresh: Refresh
+        subtitle: Pick a server to configure shrkbot.
+        title: Your servers

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -1,0 +1,36 @@
+en:
+  views:
+    home:
+      tagline: "Turn plugins on or off and set them up - all from one place."
+      sign_in: "Sign in with Discord"
+    reauth:
+      title: "Signing you back in"
+      body: "Your Discord sign-in expired. Please stand by - we're refreshing it for you."
+      continue: "Continue"
+    servers:
+      index:
+        title: "Your servers"
+        subtitle: "Pick a server to configure shrkbot."
+        plugins_enabled:
+          one: "%{count} plugin enabled"
+          other: "%{count} plugins enabled"
+        members:
+          one: "%{formatted} member"
+          other: "%{formatted} members"
+        invite: "Invite shrkbot"
+        refresh: "Refresh"
+        error: "We couldn't reach Discord to load your servers. Try again in a moment."
+        missing_title: "Don't see a server?"
+        missing_body: "You need Manage Server permissions and shrkbot must be present. Invite it, then refresh."
+        empty_title: "shrkbot isn't in any of your servers yet"
+        empty_body: "You need Manage Server permissions and shrkbot must be present. Invite it to get started."
+  components:
+    app_shell:
+      toggle_theme: "Toggle dark mode"
+      log_out: "Log out"
+  sessions:
+    signed_in: "Signed in as %{name}."
+    signed_out: "Signed out."
+    failed: "Sign-in failed or was cancelled."
+  authentication:
+    login_required: "Please sign in to continue."

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -112,6 +112,16 @@ CSS-only patterns from `docs/design/tokens/motion.css`: `btn-fill`
 `cubic-bezier(.2,0,0,1)`. A `prefers-reduced-motion: reduce` block neutralises
 them — keep it.
 
+## Layout: flex, not grid
+
+Use flexbox for layout. Reach for CSS grid only when a layout genuinely can't be
+done with flex — in practice that's a responsive multi-column **card grid** with
+equal tracks (e.g. the server picker's `grid-cols-1 sm:grid-cols-2
+lg:grid-cols-3`), where the flex equivalent needs fragile `calc()` basis values.
+Never use grid to centre a single item (`flex items-center justify-center`, not
+`grid place-items-center`) or to stack/overlap elements (`relative` + `absolute
+inset-0`).
+
 ## Icons
 
 Heroicons v2 (the `heroicons` gem), inline SVG, outline variant by default (set

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -30,6 +30,13 @@ rather than hand-rolled `count == 1` ternaries; pass a separate `formatted:`
 interpolation when the displayed number needs delimiting. Brand marks (the
 `shrkbot` wordmark) and slash-command names stay literal.
 
+`i18n-tasks` lints the locale files; CI runs `missing` (used-but-undefined keys)
+and `check-normalized` (files sorted/formatted — run `i18n-tasks normalize` to
+fix). `unused` is deliberately not enforced: it can't see dynamic `t("#{…}")`
+calls (e.g. the bot's `activity_log.<plugin>.<event>`). Phlex's class-name key
+scoping is configured in `config/i18n-tasks.yml` (`relative_roots: [app]` +
+`relative_exclude_method_name_paths: [app]`).
+
 ## App shell
 
 Authed pages render their content inside `Components::AppShell`, which draws the

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -6,6 +6,17 @@ under `ui_kits/` are throwaway CDN-wired prototypes). This doc records how that
 system is wired into the app. Views are Phlex; styling is Tailwind v4; behaviour
 is Stimulus.
 
+## Accessibility (standing rule)
+
+Be mindful of accessibility in every aspect of the UI. Contrast is enforced now:
+every text/background pairing must stay legible in **both** themes. The common
+trap is the inverting `ink` ramp — a muted step like `ink-400` is a faint grey in
+light mode but inverts to a near-black `#484f58` in dark mode, vanishing on a dark
+card. For secondary text that must read in both, use `ink-500`/`ink-600`, not
+`ink-400`; for accent text on a tint use the theme-aware `text-accent-soft-fg`.
+Check both themes when adding UI. Reduced motion is honoured throughout (keep it);
+keyboard and screen-reader passes are deferred but don't regress them.
+
 ## App shell
 
 Authed pages render their content inside `Components::AppShell`, which draws the

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -17,6 +17,19 @@ card. For secondary text that must read in both, use `ink-500`/`ink-600`, not
 Check both themes when adding UI. Reduced motion is honoured throughout (keep it);
 keyboard and screen-reader passes are deferred but don't regress them.
 
+## Copy (I18n)
+
+All user-facing web copy goes through Rails I18n — keep strings out of the views
+so they can be edited and reused (and so a second locale stays possible; the bot
+itself stays English). `Components::Base` includes the phlex translate helper, so
+views/components call `t(".key")` with a **relative** key scoped to the class
+name (`Views::Servers::Index` → `views.servers.index.*`); controllers use the
+absolute key (e.g. `t("sessions.signed_in")`). Copy lives in
+`config/locales/web.en.yml`. Use I18n pluralisation (`one`/`other` with `count:`)
+rather than hand-rolled `count == 1` ternaries; pass a separate `formatted:`
+interpolation when the displayed number needs delimiting. Brand marks (the
+`shrkbot` wordmark) and slash-command names stay literal.
+
 ## App shell
 
 Authed pages render their content inside `Components::AppShell`, which draws the

--- a/spec/bot/discord/user_guilds_spec.rb
+++ b/spec/bot/discord/user_guilds_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Discord::UserGuilds do
   let(:http) { instance_double(Net::HTTP) }
   let(:response) { instance_double(Net::HTTPResponse, code: code, body: body) }
   let(:code) { "200" }
-  let(:body) { [{"id" => "42", "name" => "Dev Refuge", "owner" => true, "permissions" => "8", "icon" => nil}].to_json }
+  let(:body) { [{"id" => "42", "name" => "Dev Refuge", "owner" => true, "permissions" => "8", "icon" => nil, "approximate_member_count" => 2481}].to_json }
 
   before do
     allow(http).to receive(:request).and_return(response)
@@ -18,7 +18,7 @@ RSpec.describe Discord::UserGuilds do
   end
 
   it "carries the parsed fields" do
-    expect(fetch.first).to have_attributes(id: 42, name: "Dev Refuge", owner: true, permissions: 8)
+    expect(fetch.first).to have_attributes(id: 42, name: "Dev Refuge", owner: true, permissions: 8, member_count: 2481)
   end
 
   context "when Discord rejects the access token" do

--- a/spec/requests/server_picker_spec.rb
+++ b/spec/requests/server_picker_spec.rb
@@ -33,20 +33,46 @@ RSpec.describe "Server picker", type: :request do
     end
 
     context "when signed in" do
-      let(:present_guild) { Discord::Guild.new(id: 900_000_001, name: "Dev Refuge", owner: true, permissions: 0, icon: "icyhash") }
-      let(:absent_guild) { Discord::Guild.new(id: 900_000_002, name: "Speedrun HQ", owner: false, permissions: 0x20, icon: nil) }
+      let(:present_guild) { Discord::Guild.new(id: 900_000_001, name: "Dev Refuge", owner: true, permissions: 0, icon: "icyhash", member_count: 2481) }
+      let(:absent_guild) { Discord::Guild.new(id: 900_000_002, name: "Speedrun HQ", owner: false, permissions: 0x20, icon: nil, member_count: 1) }
       let(:unmanaged_guild) { Discord::Guild.new(id: 900_000_003, name: "Lurker Lounge", owner: false, permissions: 0, icon: nil) }
+      let(:countless_guild) { Discord::Guild.new(id: 900_000_004, name: "Mystery Server", owner: true, permissions: 0, icon: nil) }
 
       before do
         post "/auth/discord/callback"
         create(:server_configuration, discord_id: present_guild.id)
-        allow(Discord::UserGuilds).to receive(:call).and_return([present_guild, absent_guild, unmanaged_guild])
+        allow(Discord::UserGuilds).to receive(:call).and_return([present_guild, absent_guild, unmanaged_guild, countless_guild])
+      end
+
+      it "renders a server even when Discord omits its member count" do
+        get_servers
+        expect(response.body).to include("Mystery Server")
       end
 
       it "lists a managed server the bot is already in, with its icon" do
         get_servers
         expect(response.body).to include("Dev Refuge")
         expect(response.body).to include("cdn.discordapp.com/icons/900000001/icyhash.png")
+      end
+
+      it "shows the member count and how many plugins are on" do
+        get_servers
+        expect(response.body).to include("2,481 members")
+        expect(response.body).to include("0 plugins on")
+      end
+
+      context "with enabled plugins" do
+        before do
+          config = ServerConfiguration.find_by(discord_id: present_guild.id)
+          config.create_logging_setting!(channel_id: 999)
+          logging = create(:plugin, key: "logging", name: "Logging")
+          create(:plugin_activation, server_configuration: config, plugin: logging, enabled: true)
+        end
+
+        it "counts them in the badge" do
+          get_servers
+          expect(response.body).to include("1 plugin on")
+        end
       end
 
       it "frames the page in the app shell with a way to log out" do
@@ -76,6 +102,7 @@ RSpec.describe "Server picker", type: :request do
       it "offers an invite for a managed server without the bot" do
         get_servers
         expect(response.body).to include("Speedrun HQ").and include("Invite shrkbot")
+        expect(response.body).to include("1 member")
       end
 
       it "hides servers the user cannot manage" do

--- a/spec/requests/server_picker_spec.rb
+++ b/spec/requests/server_picker_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "Server picker", type: :request do
       it "shows the member count and how many plugins are on" do
         get_servers
         expect(response.body).to include("2,481 members")
-        expect(response.body).to include("0 plugins on")
+        expect(response.body).to include("0 plugins enabled")
       end
 
       context "with enabled plugins" do
@@ -71,7 +71,7 @@ RSpec.describe "Server picker", type: :request do
 
         it "counts them in the badge" do
           get_servers
-          expect(response.body).to include("1 plugin on")
+          expect(response.body).to include("1 plugin enabled")
         end
       end
 

--- a/spec/requests/server_picker_spec.rb
+++ b/spec/requests/server_picker_spec.rb
@@ -49,6 +49,11 @@ RSpec.describe "Server picker", type: :request do
         expect(response.body).to include("Mystery Server")
       end
 
+      it "orders servers by member count, largest first" do
+        get_servers
+        expect(response.body.index("Speedrun HQ")).to be < response.body.index("Mystery Server")
+      end
+
       it "lists a managed server the bot is already in, with its icon" do
         get_servers
         expect(response.body).to include("Dev Refuge")


### PR DESCRIPTION
Phase 7, chunk 3. Brings the server picker up to the design kit now that the shell and tokens are in place.

## What's in here
- **Cards** — each manageable server is a card with its real Discord icon (initials tile fallback), name, and member count. Configured servers get an **"N plugins on"** badge (brand tint when any are on, neutral at zero) and lift on hover; the card links out to the dashboard (wired in the next chunk).
- **Invite cards** — servers without shrkbot show a dashed, dimmed card with an "Invite shrkbot" action.
- **Empty state** — mascot + explanation + Invite/Refresh when you manage no servers shrkbot is in, plus a quieter "don't see a server?" prompt under the grid otherwise.
- **Member counts** — the guilds seam now requests `?with_counts=true`; `Discord::Guild` carries `approximate_member_count` (defaults nil, so existing callers are unaffected). The controller computes enabled-plugin counts per configured server in one grouped query.
- Heroicons throughout (plus / arrow-path); no Lucide.

## Notes
- The "Configure"-style click target on configured cards currently points at `#` — the dashboard route lands in the next chunk.
- Member-count display pluralises and uses `to_fs(:delimited)` (no `helpers` proxy).

## Gate
All four green locally: `rspec` (415 ex), `standardrb`, `active_record_doctor`, `undercover --compare origin/main`.