### PR TITLE
Add a catalog of loggable events

### DIFF
--- a/app/models/loggable_event_catalog.rb
+++ b/app/models/loggable_event_catalog.rb
@@ -1,0 +1,20 @@
+class LoggableEventCatalog
+  Definition = Data.define(:plugin, :event) do
+    def key
+      "#{plugin}.#{event}"
+    end
+  end
+
+  DEFINITIONS = [
+    Definition.new(plugin: :roles, event: :role_gained),
+    Definition.new(plugin: :roles, event: :role_lost)
+  ].freeze
+
+  def self.all
+    DEFINITIONS
+  end
+
+  def self.grouped_by_plugin
+    DEFINITIONS.group_by(&:plugin)
+  end
+end

--- a/spec/models/loggable_event_catalog_spec.rb
+++ b/spec/models/loggable_event_catalog_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe LoggableEventCatalog do
+  it "enumerates the events the bot emits, keyed <plugin>.<event>" do
+    expect(described_class.all.map(&:key)).to contain_exactly("roles.role_gained", "roles.role_lost")
+  end
+
+  it "groups events by plugin for the config matrix" do
+    grouped = described_class.grouped_by_plugin
+    expect(grouped.keys).to eq([:roles])
+    expect(grouped[:roles].map(&:event)).to eq([:role_gained, :role_lost])
+  end
+
+  # A catalogued event the bot can't actually render (missing its log-line copy)
+  # would be a dead toggle, so keep the catalog and the activity_log locale in step.
+  it "has a log-line translation for every catalogued event" do
+    described_class.all.each do |definition|
+      expect(I18n.exists?("activity_log.#{definition.key}", :en)).to be(true)
+    end
+  end
+end

--- a/spec/models/loggable_event_catalog_spec.rb
+++ b/spec/models/loggable_event_catalog_spec.rb
@@ -11,8 +11,6 @@ RSpec.describe LoggableEventCatalog do
     expect(grouped[:roles].map(&:event)).to eq([:role_gained, :role_lost])
   end
 
-  # A catalogued event the bot can't actually render (missing its log-line copy)
-  # would be a dead toggle, so keep the catalog and the activity_log locale in step.
   it "has a log-line translation for every catalogued event" do
     described_class.all.each do |definition|
       expect(I18n.exists?("activity_log.#{definition.key}", :en)).to be(true)


### PR DESCRIPTION
Chunk-5 prep (independent of #62) — the one piece the logging config page needs that doesn't exist yet.

The bot logs events via `ActivityLog.record(server_config, plugin, event, …)`, keyed `<plugin>.<event>`, and the per-event toggles live in `logging_settings.enabled_actions` (jsonb). But nothing enumerates *which* events exist, so the chunk-5 logging matrix has nothing to iterate to render its toggles. This adds that.

`LoggableEventCatalog` mirrors `PluginCatalog`: a frozen list of `Definition(plugin:, event:)` with a `#key` (`"roles.role_gained"`, matching the `enabled_actions` keys and the `ActivityLog` keys), `.all`, and `.grouped_by_plugin` for the matrix.

It lists **only the events the bot actually emits today** — `roles.role_gained` and `roles.role_lost`. The design mock also shows Welcomes events (member joined/left), but Welcomes doesn't call `ActivityLog` yet, so adding them now would be dead toggles. They go in the catalog when the bot emits them (a separate bot change).

A spec asserts every catalogued event has an `activity_log.<plugin>.<event>` translation, so the catalog and the log-line copy can't drift out of step.

No consumer yet — the logging config page (chunk 5) is the consumer. Gates: rspec (440), standardrb, active_record_doctor, undercover, i18n-tasks all green.