### PR TITLE
Add the Welcomes plugin config page

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -279,3 +279,52 @@ details:has(.dropdown-menu.is-closing) .dropdown-chevron { transform: rotate(90d
   .theme-switching *,
   .theme-morph > * { transition: none; }
 }
+
+/* Tom Select, themed with our tokens so the searchable dropdowns match the rest
+   of the UI and respond to dark mode (Tom Select ships only behaviour; this is
+   the whole skin). */
+.ts-wrapper { font: inherit; }
+.ts-wrapper.single .ts-control,
+.ts-wrapper.multi .ts-control {
+  min-height: 2.5rem;
+  border: 1px solid var(--ink-200);
+  border-radius: var(--radius-md);
+  background: var(--ink-0);
+  color: var(--ink-900);
+  padding: 0.375rem 0.625rem;
+  box-shadow: none;
+  gap: 0.375rem;
+}
+.ts-wrapper.single .ts-control { cursor: pointer; }
+.ts-wrapper .ts-control::placeholder,
+.ts-wrapper .ts-control input::placeholder { color: var(--ink-500); }
+.ts-wrapper.focus .ts-control {
+  border-color: var(--brand-500);
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+.ts-wrapper.disabled .ts-control { opacity: 0.6; cursor: not-allowed; }
+.ts-control input { color: var(--ink-900); }
+.ts-control > .item {
+  background: var(--brand-100);
+  color: var(--accent-soft-fg);
+  border-radius: var(--radius-sm);
+  padding: 0.0625rem 0.375rem;
+}
+.ts-dropdown {
+  margin-top: 0.25rem;
+  border: 1px solid var(--ink-200);
+  border-radius: var(--radius-md);
+  background: var(--ink-0);
+  color: var(--ink-900);
+  box-shadow: 0 8px 24px rgba(22, 26, 31, 0.12);
+  overflow: hidden;
+}
+.ts-dropdown .option {
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-sm);
+  color: var(--ink-700);
+}
+.ts-dropdown .option.active { background: var(--surface-sunken); color: var(--ink-900); }
+.ts-dropdown .option[data-selectable].disabled,
+.ts-dropdown .option.disabled { color: var(--ink-500); cursor: not-allowed; opacity: 0.7; }
+.ts-dropdown .no-results { padding: 0.5rem 0.75rem; color: var(--ink-500); }

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -280,9 +280,7 @@ details:has(.dropdown-menu.is-closing) .dropdown-chevron { transform: rotate(90d
   .theme-morph > * { transition: none; }
 }
 
-/* Tom Select, themed with our tokens so the searchable dropdowns match the rest
-   of the UI and respond to dark mode (Tom Select ships only behaviour; this is
-   the whole skin). */
+/* Tom Select skin (the gem ships no CSS). */
 .ts-wrapper { font: inherit; }
 .ts-wrapper.single .ts-control,
 .ts-wrapper.multi .ts-control {

--- a/app/components/config_page.rb
+++ b/app/components/config_page.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class Components::ConfigPage < Components::Base
   def initialize(icon:, title:, description:, dashboard_path:)
     @icon = icon

--- a/app/components/config_page.rb
+++ b/app/components/config_page.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class Components::ConfigPage < Components::Base
+  def initialize(icon:, title:, description:, dashboard_path:)
+    @icon = icon
+    @title = title
+    @description = description
+    @dashboard_path = dashboard_path
+  end
+
+  def view_template(&block)
+    div(class: "mx-auto max-w-3xl px-6 py-8") do
+      breadcrumb
+      header
+      yield
+    end
+  end
+
+  private
+
+  def breadcrumb
+    nav(class: "mb-4 flex items-center gap-1.5 text-xs text-ink-500") do
+      a(href: servers_path, class: "transition-colors hover:text-ink-700") { t(".servers") }
+      render Components::Icon.new("chevron-right", class: "size-3")
+      a(href: @dashboard_path, class: "transition-colors hover:text-ink-700") { t(".dashboard") }
+      render Components::Icon.new("chevron-right", class: "size-3")
+      span(class: "font-medium text-ink-700") { @title }
+    end
+  end
+
+  def header
+    div(class: "mb-6 flex items-start gap-4") do
+      span(class: "flex size-12 flex-none items-center justify-center rounded-xl bg-brand-100 text-accent-soft-fg") do
+        render Components::Icon.new(@icon, class: "size-6")
+      end
+      div do
+        h1(class: "font-display text-2xl font-bold tracking-tight") { @title }
+        p(class: "mt-1 text-sm text-ink-600") { @description }
+      end
+    end
+  end
+end

--- a/app/components/plugin_row.rb
+++ b/app/components/plugin_row.rb
@@ -73,11 +73,18 @@ class Components::PluginRow < Components::Base
 
   def configure_link
     a(
-      href: "#",
+      href: configure_href,
       class: "btn-fill btn-fill-ghost inline-flex h-9 flex-none items-center gap-1.5 rounded-md border border-ink-200 px-3.5 text-sm font-semibold transition-colors hover:bg-ink-50"
     ) do
       span { t(".configure") }
       render Components::Icon.new("arrow-right", class: "size-4")
+    end
+  end
+
+  def configure_href
+    case @key.to_sym
+    when :welcomes then server_welcomes_path(@server_id)
+    else "#"
     end
   end
 end

--- a/app/components/tom_select.rb
+++ b/app/components/tom_select.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class Components::TomSelect < Components::Base
+  Option = Data.define(:value, :label, :disabled) do
+    def self.for(value:, label:, disabled: false)
+      new(value: value, label: label, disabled: disabled)
+    end
+  end
+
+  def initialize(name:, options:, selected: nil, placeholder: nil, include_blank: false, dom_id: nil)
+    @name = name
+    @options = options
+    @selected = selected
+    @placeholder = placeholder
+    @include_blank = include_blank
+    @dom_id = dom_id
+  end
+
+  def view_template
+    select(name: @name, id: @dom_id, autocomplete: "off", class: "w-full", data: data) do
+      option(value: "") { @placeholder.to_s } if @include_blank
+      @options.each do |opt|
+        option(**option_attrs(opt)) { opt.label }
+      end
+    end
+  end
+
+  private
+
+  def data
+    attrs = {controller: "tom-select"}
+    attrs[:tom_select_placeholder_value] = @placeholder if @placeholder
+    attrs
+  end
+
+  def option_attrs(opt)
+    attrs = {value: opt.value}
+    attrs[:selected] = true if @selected.present? && opt.value.to_s == @selected.to_s
+    attrs[:disabled] = true if opt.disabled
+    attrs
+  end
+end

--- a/app/components/tom_select.rb
+++ b/app/components/tom_select.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class Components::TomSelect < Components::Base
   Option = Data.define(:value, :label, :disabled) do
     def self.for(value:, label:, disabled: false)

--- a/app/components/welcomes/config_form.rb
+++ b/app/components/welcomes/config_form.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class Components::Welcomes::ConfigForm < Components::Base
   include Phlex::Rails::Helpers::FormWith
 

--- a/app/components/welcomes/config_form.rb
+++ b/app/components/welcomes/config_form.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+class Components::Welcomes::ConfigForm < Components::Base
+  include Phlex::Rails::Helpers::FormWith
+
+  FIELD = "w-full rounded-md border border-ink-200 bg-ink-0 px-3 py-2 text-sm text-ink-900 " \
+    "placeholder:text-ink-500 focus:border-brand-500 focus:outline-none focus:ring-3 focus:ring-[var(--focus-ring)]"
+  CARD = "rounded-lg border border-ink-200 bg-ink-0 p-5 shadow-sm"
+
+  def initialize(server_configuration:, enabled:, enable_error: nil)
+    @config = server_configuration
+    @settings = server_configuration.welcome_settings
+    @enabled = enabled
+    @enable_error = enable_error
+  end
+
+  def view_template
+    div(id: "welcomes-config", data: {controller: "welcome-preview"}) do
+      form_with(url: server_welcomes_path(@config.discord_id), method: :patch, class: "flex flex-col gap-5") do
+        enable_card
+        channel_card
+        messages_card
+        save_bar
+      end
+    end
+  end
+
+  private
+
+  def enable_card
+    div(class: CARD) do
+      div(class: "flex items-center justify-between gap-4") do
+        div do
+          p(class: "font-semibold") { t(".enable.label") }
+          p(class: "mt-0.5 text-sm text-ink-600") { t(".enable.help") }
+        end
+        render Components::Toggle.new(name: "welcomes[enabled]", checked: @enabled, label: t(".enable.label"))
+      end
+      field_error(@enable_error)
+    end
+  end
+
+  def channel_card
+    div(class: CARD) do
+      label(class: "block text-sm font-semibold") { t(".channel.label") }
+      p(class: "mb-2 mt-0.5 text-sm text-ink-600") { t(".channel.help") }
+      if channels.empty?
+        p(class: "text-sm text-ink-500") { t(".channel.none") }
+      else
+        render Components::TomSelect.new(
+          name: "welcomes[channel_id]",
+          options: channels,
+          selected: @settings.channel_id,
+          placeholder: t(".channel.placeholder"),
+          include_blank: true
+        )
+      end
+    end
+  end
+
+  def messages_card
+    div(class: CARD) do
+      message_field(:join_message, @settings.join_message)
+      div(class: "my-5 border-t border-ink-200")
+      message_field(:leave_message, @settings.leave_message)
+      placeholder_help
+      preview
+    end
+  end
+
+  def message_field(name, value)
+    div do
+      label(class: "block text-sm font-semibold") { t(".#{name}.label") }
+      p(class: "mb-2 mt-0.5 text-sm text-ink-600") { t(".#{name}.help") }
+      textarea(
+        name: "welcomes[#{name}]",
+        rows: 3,
+        class: FIELD,
+        placeholder: t(".#{name}.placeholder"),
+        data: {welcome_preview_target: camel(name), action: "input->welcome-preview#render"}
+      ) { value }
+    end
+  end
+
+  def placeholder_help
+    div(class: "mt-4 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-ink-500") do
+      span { t(".placeholders.intro") }
+      placeholder_chip("{user}", t(".placeholders.user"))
+      placeholder_chip("{membercount}", t(".placeholders.membercount"))
+    end
+  end
+
+  def placeholder_chip(token, description)
+    span(class: "inline-flex items-center gap-1.5") do
+      code(class: "rounded bg-ink-100 px-1.5 py-0.5 font-mono text-accent-soft-fg") { token }
+      span { description }
+    end
+  end
+
+  def preview
+    div(class: "mt-5") do
+      p(class: "mb-2 text-[11px] font-semibold uppercase tracking-widest text-ink-500") { t(".preview.label") }
+      div(class: "flex flex-col gap-3 rounded-md bg-ink-50 p-4") do
+        preview_row(:join)
+        preview_row(:leave)
+      end
+    end
+  end
+
+  def preview_row(kind)
+    div(class: "flex items-start gap-3") do
+      span(class: "flex size-9 flex-none items-center justify-center rounded-full bg-brand-500 text-xs font-bold text-white") { "n" }
+      div(class: "min-w-0") do
+        p(class: "text-xs font-semibold text-ink-500") { t(".preview.#{kind}") }
+        p(
+          class: "text-sm text-ink-800",
+          data: {welcome_preview_target: "#{kind}Output", empty_hint: t(".preview.empty")}
+        )
+      end
+    end
+  end
+
+  def save_bar
+    div(class: "flex justify-end") do
+      button(
+        type: "submit",
+        class: "btn-fill btn-fill-primary inline-flex h-10 items-center gap-2 rounded-md bg-brand-500 px-5 text-sm font-semibold text-white transition-colors"
+      ) do
+        render Components::Icon.new("check", class: "size-4")
+        span { t(".save") }
+      end
+    end
+  end
+
+  def field_error(message)
+    return unless message
+
+    p(class: "mt-3 flex items-center gap-1.5 text-sm text-danger") do
+      render Components::Icon.new("exclamation-triangle", class: "size-4 flex-none")
+      span { message }
+    end
+  end
+
+  def channels
+    @channels ||= @config.server_channels.text.map do |channel|
+      Components::TomSelect::Option.for(value: channel.discord_id, label: "# #{channel.name}")
+    end
+  end
+
+  def camel(name)
+    name.to_s.camelize(:lower)
+  end
+end

--- a/app/controllers/servers/welcomes_controller.rb
+++ b/app/controllers/servers/welcomes_controller.rb
@@ -1,0 +1,46 @@
+class Servers::WelcomesController < ApplicationController
+  include RequiresManageableServer
+
+  def show
+    render Views::Servers::Welcomes::Show.new(
+      server_configuration: @server_configuration,
+      user: current_user,
+      enabled: plugin_enabled?
+    )
+  end
+
+  def update
+    result = Ops::Welcomes::Configure.call(
+      server_configuration: @server_configuration,
+      channel_id: welcomes_params[:channel_id],
+      join_message: welcomes_params[:join_message],
+      leave_message: welcomes_params[:leave_message],
+      enabled: welcomes_params[:enabled]
+    )
+    activation = result.value
+    @enabled = activation.enabled?
+    @enable_error = activation.errors[:enabled].first
+    @toast = {level: "notice", message: t("servers.welcomes.saved")} if result.success?
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to server_welcomes_path(params[:server_id]), **flash_for(result) }
+    end
+  end
+
+  private
+
+  def plugin_enabled?
+    @server_configuration.plugins.enabled.exists?(key: :welcomes)
+  end
+
+  def welcomes_params
+    params.expect(welcomes: [:channel_id, :join_message, :leave_message, :enabled])
+  end
+
+  def flash_for(result)
+    return {notice: t("servers.welcomes.saved")} if result.success?
+
+    {alert: result.errors.to_sentence}
+  end
+end

--- a/app/javascript/controllers/tom_select_controller.js
+++ b/app/javascript/controllers/tom_select_controller.js
@@ -1,0 +1,20 @@
+import { Controller } from "@hotwired/stimulus"
+import TomSelect from "tom-select"
+
+// The underlying <select> keeps its name and options, so the form submits the
+// same value whether or not this enhancement runs.
+export default class extends Controller {
+  static values = { placeholder: String }
+
+  connect() {
+    this.select = new TomSelect(this.element, {
+      placeholder: this.placeholderValue || undefined,
+      allowEmptyOption: true,
+      maxOptions: null
+    })
+  }
+
+  disconnect() {
+    this.select?.destroy()
+  }
+}

--- a/app/javascript/controllers/tom_select_controller.js
+++ b/app/javascript/controllers/tom_select_controller.js
@@ -1,8 +1,6 @@
 import { Controller } from "@hotwired/stimulus"
 import TomSelect from "tom-select"
 
-// The underlying <select> keeps its name and options, so the form submits the
-// same value whether or not this enhancement runs.
 export default class extends Controller {
   static values = { placeholder: String }
 

--- a/app/javascript/controllers/welcome_preview_controller.js
+++ b/app/javascript/controllers/welcome_preview_controller.js
@@ -1,6 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
 
-// User-entered text is inserted as text nodes, never innerHTML.
 const SAMPLE = { user: "newmember", membercount: "1,234" }
 
 export default class extends Controller {

--- a/app/javascript/controllers/welcome_preview_controller.js
+++ b/app/javascript/controllers/welcome_preview_controller.js
@@ -1,0 +1,58 @@
+import { Controller } from "@hotwired/stimulus"
+
+// User-entered text is inserted as text nodes, never innerHTML.
+const SAMPLE = { user: "newmember", membercount: "1,234" }
+
+export default class extends Controller {
+  static targets = ["joinMessage", "leaveMessage", "joinOutput", "leaveOutput"]
+
+  connect() {
+    this.render()
+  }
+
+  render() {
+    this.paint(this.joinMessageTarget, this.joinOutputTarget, "join")
+    this.paint(this.leaveMessageTarget, this.leaveOutputTarget, "leave")
+  }
+
+  paint(input, output, kind) {
+    output.replaceChildren()
+
+    if (!input.value.trim()) {
+      const hint = document.createElement("span")
+      hint.className = "italic text-ink-500"
+      hint.textContent = output.dataset.emptyHint
+      output.append(hint)
+      return
+    }
+
+    for (const node of this.nodes(input.value, kind)) output.append(node)
+  }
+
+  nodes(text, kind) {
+    const out = []
+    const pattern = /\{user\}|\{membercount\}/g
+    let last = 0
+    let match
+    while ((match = pattern.exec(text))) {
+      if (match.index > last) out.push(document.createTextNode(text.slice(last, match.index)))
+      out.push(this.token(match[0], kind))
+      last = pattern.lastIndex
+    }
+    if (last < text.length) out.push(document.createTextNode(text.slice(last)))
+    return out
+  }
+
+  token(token, kind) {
+    if (token === "{membercount}") return document.createTextNode(SAMPLE.membercount)
+
+    if (kind === "join") {
+      const pill = document.createElement("span")
+      pill.className = "rounded bg-brand-100 px-1 font-medium text-accent-soft-fg"
+      pill.textContent = "@" + SAMPLE.user
+      return pill
+    }
+
+    return document.createTextNode("@" + SAMPLE.user)
+  }
+}

--- a/app/models/server_channel.rb
+++ b/app/models/server_channel.rb
@@ -8,6 +8,10 @@ class ServerChannel < ApplicationRecord
 
   VIEW_CHANNEL = 1 << 10
 
+  TEXT_TYPES = [0, 5].freeze
+
+  scope :text, -> { where(channel_type: TEXT_TYPES).order(:name) }
+
   def everyone_visible?
     overwrite = channel_overwrites.find_by(target_id: server_configuration.discord_id)
     return true unless overwrite

--- a/app/operations/application_operation.rb
+++ b/app/operations/application_operation.rb
@@ -75,8 +75,8 @@ module Ops
       Result.new(true, value, [], warnings)
     end
 
-    def failure(*errors)
-      Result.new(false, nil, errors.flatten, [])
+    def failure(*errors, value: nil)
+      Result.new(false, value, errors.flatten, [])
     end
 
     def transaction(&)

--- a/app/operations/welcomes/configure.rb
+++ b/app/operations/welcomes/configure.rb
@@ -1,0 +1,31 @@
+module Ops
+  module Welcomes
+    class Configure < ApplicationOperation
+      receives :server_configuration, :channel_id, :join_message, :leave_message, :enabled
+
+      def call
+        settings = server_configuration.welcome_settings
+        settings.assign_attributes(channel_id: channel_id, join_message: join_message, leave_message: leave_message)
+        activation = staged_activation
+
+        return failure(messages(settings, activation), value: activation) unless settings.valid? && activation.valid?
+
+        settings.save!
+        activation.save!
+        ok(activation)
+      end
+
+      private
+
+      def staged_activation
+        activation = server_configuration.plugin_activations.find_or_initialize_by(plugin: Plugin.find_by!(key: :welcomes))
+        activation.enabled = enabled
+        activation
+      end
+
+      def messages(*records)
+        records.flat_map { |record| record.errors.full_messages }
+      end
+    end
+  end
+end

--- a/app/views/servers/welcomes/show.rb
+++ b/app/views/servers/welcomes/show.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Views::Servers::Welcomes::Show < Views::Base
+  def initialize(server_configuration:, user:, enabled:)
+    @config = server_configuration
+    @user = user
+    @enabled = enabled
+  end
+
+  def view_template
+    render Components::AppShell.new(user: @user) do
+      render Components::ConfigPage.new(
+        icon: "hand-raised",
+        title: t(".title"),
+        description: t(".description"),
+        dashboard_path: server_path(@config.discord_id)
+      ) do
+        render Components::Welcomes::ConfigForm.new(server_configuration: @config, enabled: @enabled)
+      end
+    end
+  end
+end

--- a/app/views/servers/welcomes/show.rb
+++ b/app/views/servers/welcomes/show.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class Views::Servers::Welcomes::Show < Views::Base
   def initialize(server_configuration:, user:, enabled:)
     @config = server_configuration

--- a/app/views/servers/welcomes/update.turbo_stream.erb
+++ b/app/views/servers/welcomes/update.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%= turbo_stream.replace "welcomes-config", html: render(Components::Welcomes::ConfigForm.new(server_configuration: @server_configuration, enabled: @enabled, enable_error: @enable_error)) %>
+<%= turbo_stream.append "toasts", html: render(Components::Toast.new(**@toast)) if @toast %>

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -10,6 +10,9 @@ en:
         one: "%{count} plugin on"
         other: "%{count} plugins on"
       toggle_theme: Toggle dark mode
+    config_page:
+      dashboard: Dashboard
+      servers: Servers
     plugin_row:
       configure: Configure
       plugin:
@@ -32,11 +35,41 @@ en:
         enabled: Enabled
         needs_setup: Needs setup
       toggle: Toggle %{plugin}
+    welcomes:
+      config_form:
+        channel:
+          help: Where join and leave messages are posted.
+          label: Channel
+          none: No channels have synced yet. shrkbot needs to be in the server first.
+          placeholder: Choose a channel
+        enable:
+          help: Post a message when members join or leave.
+          label: Enable welcomes
+        join_message:
+          help: Sent when a member joins. Leave empty to send nothing.
+          label: Join message
+          placeholder: Welcome {user}, you're member {membercount}!
+        leave_message:
+          help: Sent when a member leaves. Leave empty to send nothing.
+          label: Leave message
+          placeholder: "{user} has left the server."
+        placeholders:
+          intro: 'Placeholders:'
+          membercount: the server's member count
+          user: the member
+        preview:
+          empty: This message is off.
+          join: A new member joined
+          label: Preview
+          leave: A member left
+        save: Save changes
   servers:
     not_found: That server isn't available to configure.
     plugin_disabled: "%{plugin} disabled."
     plugin_enabled: "%{plugin} enabled."
     unknown_plugin: That plugin doesn't exist.
+    welcomes:
+      saved: Welcomes settings saved.
   sessions:
     failed: Sign-in failed or was cancelled.
     signed_in: Signed in as %{name}.
@@ -82,3 +115,7 @@ en:
           one: "%{count} role"
           other: "%{count} roles"
         synced: "%{channels} and %{roles} synced"
+      welcomes:
+        show:
+          description: Greet new members and say goodbye when they leave.
+          title: Welcomes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,9 @@ Rails.application.routes.draw do
 
   resources :servers, only: [:index, :show], param: :id do
     resources :plugins, only: :update, param: :key, module: :servers
+    scope module: :servers do
+      resource :welcomes, only: [:show, :update]
+    end
   end
 
   # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)

--- a/spec/components/tom_select_spec.rb
+++ b/spec/components/tom_select_spec.rb
@@ -32,4 +32,18 @@ RSpec.describe Components::TomSelect do
   it "disables an option flagged disabled" do
     expect(html).to include('value="222"').and include("disabled")
   end
+
+  context "without a placeholder or blank option" do
+    subject(:plain) do
+      described_class.new(
+        name: "x",
+        options: [Components::TomSelect::Option.for(value: 1, label: "one")]
+      ).call
+    end
+
+    it "omits the blank option and the placeholder data attribute" do
+      expect(plain).to include("<select")
+      expect(plain).not_to include("tom-select-placeholder-value")
+    end
+  end
 end

--- a/spec/components/tom_select_spec.rb
+++ b/spec/components/tom_select_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe Components::TomSelect do
+  subject(:html) do
+    described_class.new(
+      name: "welcomes[channel_id]",
+      options: [
+        Components::TomSelect::Option.for(value: 111, label: "# general"),
+        Components::TomSelect::Option.for(value: 222, label: "# announcements", disabled: true)
+      ],
+      selected: 111,
+      placeholder: "Choose a channel",
+      include_blank: true
+    ).call
+  end
+
+  it "renders a select wired to the tom-select controller" do
+    expect(html).to include("<select")
+    expect(html).to include('name="welcomes[channel_id]"')
+    expect(html).to include('data-controller="tom-select"')
+    expect(html).to include('data-tom-select-placeholder-value="Choose a channel"')
+  end
+
+  it "renders a blank option for the placeholder" do
+    expect(html).to include('value=""')
+  end
+
+  it "marks the selected option" do
+    expect(html).to include('value="111"').and include("selected")
+  end
+
+  it "disables an option flagged disabled" do
+    expect(html).to include('value="222"').and include("disabled")
+  end
+end

--- a/spec/models/server_channel_spec.rb
+++ b/spec/models/server_channel_spec.rb
@@ -27,6 +27,22 @@ RSpec.describe ServerChannel do
     end
   end
 
+  describe ".text" do
+    subject(:names) { ServerChannel.text.pluck(:name) }
+
+    let(:server) { create(:server_configuration) }
+
+    before do
+      create(:server_channel, server_configuration: server, name: "general", channel_type: 0)
+      create(:server_channel, server_configuration: server, name: "announcements", channel_type: 5)
+      create(:server_channel, server_configuration: server, name: "lounge", channel_type: 2)
+    end
+
+    it "returns only text-capable channels, ordered by name" do
+      expect(names).to eq(%w[announcements general])
+    end
+  end
+
   describe "#everyone_visible?" do
     subject(:visible) { channel.everyone_visible? }
 

--- a/spec/operations/welcomes/configure_spec.rb
+++ b/spec/operations/welcomes/configure_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe Ops::Welcomes::Configure do
+  subject(:result) do
+    described_class.call(
+      server_configuration: config,
+      channel_id: channel_id,
+      join_message: "hi {user}",
+      leave_message: "bye",
+      enabled: enabled
+    )
+  end
+
+  let(:config) { create(:server_configuration) }
+  let!(:plugin) { create(:plugin, key: "welcomes", name: "Welcomes") }
+  let!(:settings) { config.create_welcome_settings! }
+  let(:channel_id) { 111 }
+  let(:enabled) { "1" }
+
+  context "with a channel, enabling the plugin" do
+    it "saves the settings and enables the plugin" do
+      expect(result).to be_success
+      expect(config.welcome_settings.reload.channel_id).to eq(111)
+      expect(config.welcome_settings.join_message).to eq("hi {user}")
+      expect(config.plugin_activations.find_by(plugin: plugin).enabled).to be(true)
+    end
+  end
+
+  context "when enabling without a channel" do
+    let(:channel_id) { "" }
+
+    it "fails with an error on the enabled field and persists nothing" do
+      expect(result).to be_failure
+      expect(result.value.errors[:enabled]).to be_present
+      expect(config.welcome_settings.reload.channel_id).to be_nil
+      expect(config.plugin_activations.reload).to be_empty
+    end
+  end
+
+  context "when saving messages without enabling" do
+    let(:enabled) { "0" }
+    let(:channel_id) { "" }
+
+    it "saves the messages and leaves the plugin disabled" do
+      expect(result).to be_success
+      expect(config.welcome_settings.reload.join_message).to eq("hi {user}")
+      expect(config.plugin_activations.find_by(plugin: plugin)&.enabled).to be_falsey
+    end
+  end
+end

--- a/spec/requests/welcomes_config_spec.rb
+++ b/spec/requests/welcomes_config_spec.rb
@@ -1,0 +1,112 @@
+require "rails_helper"
+
+RSpec.describe "Welcomes config", type: :request do
+  let(:auth) do
+    OmniAuth::AuthHash.new(
+      provider: "discord",
+      uid: "12345",
+      info: {name: "shrk"},
+      credentials: {token: "discord-access-token"}
+    )
+  end
+
+  let(:guild) { Discord::Guild.new(id: 900_000_001, name: "Dev Refuge", owner: true, permissions: 0, icon: nil, member_count: 5) }
+  let(:config) { ServerConfiguration.find_by(discord_id: guild.id) }
+  let(:turbo) { {headers: {"Accept" => "text/vnd.turbo-stream.html"}} }
+
+  before do
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:discord] = auth
+    Rails.application.env_config["omniauth.auth"] = auth
+  end
+
+  after do
+    OmniAuth.config.test_mode = false
+    OmniAuth.config.mock_auth[:discord] = nil
+    Rails.application.env_config.delete("omniauth.auth")
+  end
+
+  context "when signed out" do
+    it "redirects to the sign-in page" do
+      get server_welcomes_path(900_000_001)
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  context "when signed in" do
+    let!(:welcomes) { create(:plugin, key: "welcomes", name: "Welcomes") }
+
+    before do
+      post "/auth/discord/callback"
+      create(:server_configuration, discord_id: guild.id)
+      config.create_welcome_settings!
+      allow(Discord::UserGuilds).to receive(:call).and_return([guild])
+    end
+
+    context "without proving the server is manageable this session" do
+      it "redirects to the picker" do
+        get server_welcomes_path(guild.id)
+        expect(response).to redirect_to(servers_path)
+      end
+    end
+
+    context "after loading the dashboard authorizes the server" do
+      before { get server_path(guild.id) }
+
+      describe "GET /servers/:server_id/welcomes" do
+        it "renders the config page in the app shell" do
+          get server_welcomes_path(guild.id)
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include("Welcomes")
+          expect(response.body).to include("Join message")
+          expect(response.body).to include("Preview")
+        end
+
+        it "offers only text channels in the picker" do
+          create(:server_channel, server_configuration: config, name: "general", discord_id: 111, channel_type: 0)
+          create(:server_channel, server_configuration: config, name: "lounge", discord_id: 222, channel_type: 2)
+          get server_welcomes_path(guild.id)
+          expect(response.body).to include("# general")
+          expect(response.body).not_to include("# lounge")
+        end
+      end
+
+      describe "PATCH /servers/:server_id/welcomes" do
+        before { create(:server_channel, server_configuration: config, name: "general", discord_id: 111) }
+
+        it "saves the settings and enables the plugin in one request" do
+          patch server_welcomes_path(guild.id),
+            params: {welcomes: {channel_id: 111, join_message: "hi {user}", leave_message: "", enabled: "1"}},
+            **turbo
+          expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+          expect(config.welcome_settings.reload.channel_id).to eq(111)
+          expect(config.plugins.enabled.exists?(key: :welcomes)).to be(true)
+          expect(response.body).to include("saved")
+        end
+
+        it "re-renders the form with an inline error when enabling without a channel" do
+          patch server_welcomes_path(guild.id),
+            params: {welcomes: {channel_id: "", join_message: "", leave_message: "", enabled: "1"}},
+            **turbo
+          expect(config.plugins.enabled.exists?(key: :welcomes)).to be(false)
+          expect(response.body).to include("welcomes-config")
+          expect(response.body).to include("settings to be configured")
+        end
+
+        it "saves messages without enabling and reports success" do
+          patch server_welcomes_path(guild.id),
+            params: {welcomes: {channel_id: "", join_message: "hello", leave_message: "", enabled: "0"}},
+            **turbo
+          expect(config.welcome_settings.reload.join_message).to eq("hello")
+          expect(response.body).to include("saved")
+        end
+
+        it "falls back to a redirect without Turbo" do
+          patch server_welcomes_path(guild.id),
+            params: {welcomes: {channel_id: 111, join_message: "hi", leave_message: "", enabled: "1"}}
+          expect(response).to redirect_to(server_welcomes_path(guild.id))
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/welcomes_config_spec.rb
+++ b/spec/requests/welcomes_config_spec.rb
@@ -106,6 +106,13 @@ RSpec.describe "Welcomes config", type: :request do
             params: {welcomes: {channel_id: 111, join_message: "hi", leave_message: "", enabled: "1"}}
           expect(response).to redirect_to(server_welcomes_path(guild.id))
         end
+
+        it "redirects with an alert when a non-Turbo save fails" do
+          patch server_welcomes_path(guild.id),
+            params: {welcomes: {channel_id: "", join_message: "", leave_message: "", enabled: "1"}}
+          expect(response).to redirect_to(server_welcomes_path(guild.id))
+          expect(flash[:alert]).to be_present
+        end
       end
     end
   end


### PR DESCRIPTION
First of the Phase 7 chunk-5 plugin config pages (the chunk is split across three PRs: this one, then Logging, then Roles). This PR builds the shared config-page scaffolding and lands Welcomes, the simplest plugin, as its first consumer.

## Save model
Per the chunk-5 decision (supersedes design #21's blanket auto-save): config pages use **explicit Save**, not auto-save. One form per page commits all edits at once so a configuration can be staged before going live.

The enable/disable toggle lives **on the form** as a staged field (`Components::Toggle` in field mode), so setting the channel and enabling happen in one Save. Enabling without the required channel comes back as an **inline form error**, not a toast. A per-plugin `Ops::Welcomes::Configure` op commits the settings and the `PluginActivation` in one transaction, validating the activation against the staged (in-memory) channel so the prerequisite check sees the new value. `Plugins::Toggle` stays for the dashboard's instant on/off path.

## Reusable pieces (for Logging/Roles)
- `Components::ConfigPage` — breadcrumb + header scaffold.
- `Components::TomSelect` + `tom_select_controller.js` + a tokenized Tom Select skin (themes in dark mode). Channel mode here; the role colour-dot + disabled-with-reason rendering come with Roles.
- `ApplicationOperation#failure` now takes `value:` so a failed op can carry the record(s) for inline-error re-render.
- The dashboard's Configure link resolves to the real page (per key; Logging/Roles still `#` until their PRs).

## Welcomes specifics
Channel picker, join/leave message fields, placeholder help (`{user}`/`{membercount}`), and a live Discord-styled preview (`{user}` → mention pill on join / plain handle on leave; empty message → "off" hint).

## Deferred (build-with-the-caller)
The segmented control and enable-gate land with their first real consumers (Roles and Logging respectively), consistent with how chunk 2 deferred these controls.

## Notes / for review
- Config pages read DB data only — they intentionally don't re-fetch from Discord, so they don't show the live server name/icon (per the localized-reauth decision, the user token is used only at the guild-fetch seam). If we want the name here, we'd sync it in Phase 5.
- The enable-without-prereq error renders next to the toggle (where the user acted). Easy to move next to the channel field if you'd prefer.

Gates: `rspec` (456), `standardrb`, `active_record_doctor`, `undercover --compare origin/main`, `i18n-tasks missing` + `check-normalized` all green. Live browser verification (Tom Select, the preview, dark mode) is yours to run.
