### PR TITLE
Add the Logging plugin config page

### DIFF
--- a/app/components/enable_gate.rb
+++ b/app/components/enable_gate.rb
@@ -1,0 +1,28 @@
+class Components::EnableGate < Components::Base
+  def initialize(enabled:, message:)
+    @enabled = enabled
+    @message = message
+  end
+
+  def view_template(&block)
+    div(class: "relative") do
+      overlay
+      div(
+        data: {enable_gate_target: "content"},
+        inert: (true unless @enabled),
+        class: "transition-opacity #{"opacity-40" unless @enabled}"
+      ) { yield }
+    end
+  end
+
+  private
+
+  def overlay
+    div(
+      data: {enable_gate_target: "overlay"},
+      class: "absolute inset-0 z-10 flex items-center justify-center rounded-lg bg-ink-0/70 #{"hidden" if @enabled}"
+    ) do
+      span(class: "max-w-xs px-4 text-center text-sm font-medium text-ink-600") { @message }
+    end
+  end
+end

--- a/app/components/logging/config_form.rb
+++ b/app/components/logging/config_form.rb
@@ -1,0 +1,139 @@
+class Components::Logging::ConfigForm < Components::Base
+  include Phlex::Rails::Helpers::FormWith
+
+  CARD = "rounded-lg border border-ink-200 bg-ink-0 p-5 shadow-sm"
+
+  def initialize(server_configuration:, enabled:, enable_error: nil)
+    @config = server_configuration
+    @settings = server_configuration.logging_setting
+    @enabled = enabled
+    @enable_error = enable_error
+  end
+
+  def view_template
+    div(id: "logging-config") do
+      form_with(url: server_logging_path(@config.discord_id), method: :patch, class: "flex flex-col gap-5", data: {controller: "enable-gate"}) do
+        enable_card
+        channel_card
+        events_card
+        save_bar
+      end
+    end
+  end
+
+  private
+
+  def enable_card
+    div(class: CARD) do
+      div(class: "flex items-center justify-between gap-4") do
+        div do
+          p(class: "font-semibold") { t(".enable.label") }
+          p(class: "mt-0.5 text-sm text-ink-600") { t(".enable.help") }
+        end
+        render Components::Toggle.new(
+          name: "logging[enabled]",
+          checked: @enabled,
+          label: t(".enable.label"),
+          data: {enable_gate_target: "toggle", action: "change->enable-gate#update"}
+        )
+      end
+      field_error(@enable_error)
+    end
+  end
+
+  def channel_card
+    div(class: CARD) do
+      label(class: "block text-sm font-semibold") { t(".channel.label") }
+      p(class: "mb-2 mt-0.5 text-sm text-ink-600") { t(".channel.help") }
+      if channels.empty?
+        p(class: "text-sm text-ink-500") { t(".channel.none") }
+      else
+        render Components::TomSelect.new(
+          name: "logging[channel_id]",
+          options: channels,
+          selected: @settings.channel_id,
+          placeholder: t(".channel.placeholder"),
+          include_blank: true
+        )
+      end
+      visibility_warning
+    end
+  end
+
+  def events_card
+    div(class: CARD) do
+      p(class: "text-sm font-semibold") { t(".events.label") }
+      p(class: "mb-3 mt-0.5 text-sm text-ink-600") { t(".events.help") }
+      render Components::EnableGate.new(enabled: @enabled, message: t(".events.gated")) do
+        div(class: "flex flex-col gap-5") do
+          LoggableEventCatalog.grouped_by_plugin.each do |plugin, definitions|
+            event_group(plugin, definitions)
+          end
+        end
+      end
+    end
+  end
+
+  def event_group(plugin, definitions)
+    div do
+      p(class: "mb-2 text-[11px] font-semibold uppercase tracking-widest text-ink-500") { t(".events.plugin.#{plugin}") }
+      div(class: "flex flex-col gap-2") do
+        definitions.each { |definition| event_row(definition) }
+      end
+    end
+  end
+
+  def event_row(definition)
+    name = t(".events.event.#{definition.plugin}.#{definition.event}")
+    div(class: "flex items-center justify-between gap-4 rounded-md border border-ink-200 px-3 py-2") do
+      span(class: "text-sm") { name }
+      render Components::Toggle.new(
+        name: "logging[actions][#{definition.key}]",
+        checked: @settings.action_enabled?(definition.key),
+        label: name
+      )
+    end
+  end
+
+  def visibility_warning
+    return unless visible_channel?
+
+    div(class: "mt-3 flex items-start gap-1.5 text-sm text-warning") do
+      render Components::Icon.new("exclamation-triangle", class: "mt-0.5 size-4 flex-none")
+      span { t(".channel.visible_warning") }
+    end
+  end
+
+  def save_bar
+    div(class: "flex justify-end") do
+      button(
+        type: "submit",
+        class: "btn-fill btn-fill-primary inline-flex h-10 items-center gap-2 rounded-md bg-brand-500 px-5 text-sm font-semibold text-white transition-colors"
+      ) do
+        render Components::Icon.new("check", class: "size-4")
+        span { t(".save") }
+      end
+    end
+  end
+
+  def field_error(message)
+    return unless message
+
+    p(class: "mt-3 flex items-center gap-1.5 text-sm text-danger") do
+      render Components::Icon.new("exclamation-triangle", class: "size-4 flex-none")
+      span { message }
+    end
+  end
+
+  def visible_channel?
+    return false unless @settings.channel_id
+
+    @config.server_channels.find_by(discord_id: @settings.channel_id)&.everyone_visible?
+  end
+
+  def channels
+    @channels ||= @config.server_channels.text.map do |channel|
+      Components::TomSelect::Option.for(value: channel.discord_id, label: "# #{channel.name}")
+    end
+  end
+end

--- a/app/components/plugin_row.rb
+++ b/app/components/plugin_row.rb
@@ -84,6 +84,7 @@ class Components::PluginRow < Components::Base
   def configure_href
     case @key.to_sym
     when :welcomes then server_welcomes_path(@server_id)
+    when :logging then server_logging_path(@server_id)
     else "#"
     end
   end

--- a/app/components/toggle.rb
+++ b/app/components/toggle.rb
@@ -8,7 +8,7 @@ class Components::Toggle < Components::Base
     "motion-safe:after:transition-transform peer-checked:bg-brand-500 peer-checked:after:translate-x-5 " \
     "peer-focus-visible:ring-3 peer-focus-visible:ring-[var(--focus-ring)]"
 
-  def initialize(name:, checked:, label:, url: nil, submit_on_change: false, dom_id: nil, disabled: false)
+  def initialize(name:, checked:, label:, url: nil, submit_on_change: false, dom_id: nil, disabled: false, data: {})
     @name = name.to_s
     @checked = checked
     @label = label
@@ -16,6 +16,7 @@ class Components::Toggle < Components::Base
     @submit_on_change = submit_on_change
     @dom_id = dom_id
     @disabled = disabled
+    @data = data
   end
 
   def view_template
@@ -48,8 +49,7 @@ class Components::Toggle < Components::Base
   end
 
   def switch_data
-    return {} unless @submit_on_change
-
-    {controller: "toggle", action: "change->toggle#submit"}
+    base = @submit_on_change ? {controller: "toggle", action: "change->toggle#submit"} : {}
+    base.merge(@data)
   end
 end

--- a/app/controllers/servers/logging_controller.rb
+++ b/app/controllers/servers/logging_controller.rb
@@ -1,0 +1,50 @@
+class Servers::LoggingController < ApplicationController
+  include RequiresManageableServer
+
+  def show
+    render Views::Servers::Logging::Show.new(
+      server_configuration: @server_configuration,
+      user: current_user,
+      enabled: plugin_enabled?
+    )
+  end
+
+  def update
+    result = Ops::Logging::Configure.call(
+      server_configuration: @server_configuration,
+      channel_id: logging_params[:channel_id],
+      enabled_actions: submitted_actions,
+      enabled: logging_params[:enabled]
+    )
+    activation = result.value
+    @enabled = activation.enabled?
+    @enable_error = activation.errors[:enabled].first
+    @toast = {level: "notice", message: t("servers.logging.saved")} if result.success?
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to server_logging_path(params[:server_id]), **flash_for(result) }
+    end
+  end
+
+  private
+
+  def plugin_enabled?
+    @server_configuration.plugins.enabled.exists?(key: :logging)
+  end
+
+  def submitted_actions
+    raw = logging_params[:actions] || {}
+    LoggableEventCatalog.all.to_h { |definition| [definition.key, ActiveModel::Type::Boolean.new.cast(raw[definition.key])] }
+  end
+
+  def logging_params
+    params.require(:logging).permit(:channel_id, :enabled, actions: {})
+  end
+
+  def flash_for(result)
+    return {notice: t("servers.logging.saved")} if result.success?
+
+    {alert: result.errors.to_sentence}
+  end
+end

--- a/app/javascript/controllers/enable_gate_controller.js
+++ b/app/javascript/controllers/enable_gate_controller.js
@@ -1,0 +1,16 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["toggle", "content", "overlay"]
+
+  connect() {
+    this.update()
+  }
+
+  update() {
+    const on = this.toggleTarget.checked
+    this.contentTarget.inert = !on
+    this.contentTarget.classList.toggle("opacity-40", !on)
+    if (this.hasOverlayTarget) this.overlayTarget.classList.toggle("hidden", on)
+  }
+}

--- a/app/operations/logging/configure.rb
+++ b/app/operations/logging/configure.rb
@@ -1,0 +1,31 @@
+module Ops
+  module Logging
+    class Configure < ApplicationOperation
+      receives :server_configuration, :channel_id, :enabled_actions, :enabled
+
+      def call
+        settings = server_configuration.logging_setting
+        settings.assign_attributes(channel_id: channel_id, enabled_actions: enabled_actions)
+        activation = staged_activation
+
+        return failure(messages(settings, activation), value: activation) unless settings.valid? && activation.valid?
+
+        settings.save!
+        activation.save!
+        ok(activation)
+      end
+
+      private
+
+      def staged_activation
+        activation = server_configuration.plugin_activations.find_or_initialize_by(plugin: Plugin.find_by!(key: :logging))
+        activation.enabled = enabled
+        activation
+      end
+
+      def messages(*records)
+        records.flat_map { |record| record.errors.full_messages }
+      end
+    end
+  end
+end

--- a/app/views/servers/logging/show.rb
+++ b/app/views/servers/logging/show.rb
@@ -1,0 +1,20 @@
+class Views::Servers::Logging::Show < Views::Base
+  def initialize(server_configuration:, user:, enabled:)
+    @config = server_configuration
+    @user = user
+    @enabled = enabled
+  end
+
+  def view_template
+    render Components::AppShell.new(user: @user) do
+      render Components::ConfigPage.new(
+        icon: "document-text",
+        title: t(".title"),
+        description: t(".description"),
+        dashboard_path: server_path(@config.discord_id)
+      ) do
+        render Components::Logging::ConfigForm.new(server_configuration: @config, enabled: @enabled)
+      end
+    end
+  end
+end

--- a/app/views/servers/logging/update.turbo_stream.erb
+++ b/app/views/servers/logging/update.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%= turbo_stream.replace "logging-config", html: render(Components::Logging::ConfigForm.new(server_configuration: @server_configuration, enabled: @enabled, enable_error: @enable_error)) %>
+<%= turbo_stream.append "toasts", html: render(Components::Toast.new(**@toast)) if @toast %>

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -13,6 +13,29 @@ en:
     config_page:
       dashboard: Dashboard
       servers: Servers
+    logging:
+      config_form:
+        channel:
+          help: Where moderation events are recorded.
+          label: Channel
+          none: No channels have synced yet. shrkbot needs to be in the server first.
+          placeholder: Choose a channel
+          visible_warning: Everyone can see this channel, so the moderation log would
+            be public.
+        enable:
+          help: Record moderation events to a channel.
+          label: Enable logging
+        events:
+          event:
+            roles:
+              role_gained: Member gained a role
+              role_lost: Member lost a role
+          gated: Enable logging to choose which events are recorded.
+          help: Pick which events shrkbot writes to the log channel.
+          label: Logged events
+          plugin:
+            roles: Roles
+        save: Save changes
     plugin_row:
       configure: Configure
       plugin:
@@ -64,6 +87,8 @@ en:
           leave: A member left
         save: Save changes
   servers:
+    logging:
+      saved: Logging settings saved.
     not_found: That server isn't available to configure.
     plugin_disabled: "%{plugin} disabled."
     plugin_enabled: "%{plugin} enabled."
@@ -102,6 +127,10 @@ en:
         refresh: Refresh
         subtitle: Pick a server to configure shrkbot.
         title: Your servers
+      logging:
+        show:
+          description: Record moderation events to a channel of your choice.
+          title: Logging
       show:
         breadcrumb_servers: Servers
         channels:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
     resources :plugins, only: :update, param: :key, module: :servers
     scope module: :servers do
       resource :welcomes, only: [:show, :update]
+      resource :logging, only: [:show, :update], controller: "logging"
     end
   end
 

--- a/spec/operations/logging/configure_spec.rb
+++ b/spec/operations/logging/configure_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe Ops::Logging::Configure do
+  subject(:result) do
+    described_class.call(
+      server_configuration: config,
+      channel_id: channel_id,
+      enabled_actions: enabled_actions,
+      enabled: enabled
+    )
+  end
+
+  let(:config) { create(:server_configuration) }
+  let!(:plugin) { create(:plugin, key: "logging", name: "Logging") }
+  let!(:settings) { config.create_logging_setting! }
+  let(:channel_id) { 200 }
+  let(:enabled_actions) { {"roles.role_gained" => true, "roles.role_lost" => false} }
+  let(:enabled) { "1" }
+
+  context "with a channel, enabling the plugin" do
+    it "saves the channel, event toggles, and enables the plugin" do
+      expect(result).to be_success
+      expect(config.logging_setting.reload.channel_id).to eq(200)
+      expect(config.logging_setting.action_enabled?("roles.role_gained")).to be(true)
+      expect(config.logging_setting.action_enabled?("roles.role_lost")).to be(false)
+      expect(config.plugin_activations.find_by(plugin: plugin).enabled).to be(true)
+    end
+  end
+
+  context "when enabling without a channel" do
+    let(:channel_id) { "" }
+
+    it "fails with an error on the enabled field and persists nothing" do
+      expect(result).to be_failure
+      expect(result.value.errors[:enabled]).to be_present
+      expect(config.plugin_activations.reload).to be_empty
+    end
+  end
+
+  context "when saving event toggles without enabling" do
+    let(:enabled) { "0" }
+    let(:channel_id) { "" }
+
+    it "stores the toggles and leaves the plugin disabled" do
+      expect(result).to be_success
+      expect(config.logging_setting.reload.action_enabled?("roles.role_gained")).to be(true)
+      expect(config.plugin_activations.find_by(plugin: plugin)&.enabled).to be_falsey
+    end
+  end
+end

--- a/spec/requests/logging_config_spec.rb
+++ b/spec/requests/logging_config_spec.rb
@@ -1,0 +1,126 @@
+require "rails_helper"
+
+RSpec.describe "Logging config", type: :request do
+  let(:auth) do
+    OmniAuth::AuthHash.new(
+      provider: "discord",
+      uid: "12345",
+      info: {name: "shrk"},
+      credentials: {token: "discord-access-token"}
+    )
+  end
+
+  let(:guild) { Discord::Guild.new(id: 900_000_001, name: "Dev Refuge", owner: true, permissions: 0, icon: nil, member_count: 5) }
+  let(:config) { ServerConfiguration.find_by(discord_id: guild.id) }
+  let(:turbo) { {headers: {"Accept" => "text/vnd.turbo-stream.html"}} }
+
+  before do
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:discord] = auth
+    Rails.application.env_config["omniauth.auth"] = auth
+  end
+
+  after do
+    OmniAuth.config.test_mode = false
+    OmniAuth.config.mock_auth[:discord] = nil
+    Rails.application.env_config.delete("omniauth.auth")
+  end
+
+  context "when signed out" do
+    it "redirects to the sign-in page" do
+      get server_logging_path(900_000_001)
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  context "when signed in" do
+    let!(:logging) { create(:plugin, key: "logging", name: "Logging") }
+
+    before do
+      post "/auth/discord/callback"
+      create(:server_configuration, discord_id: guild.id)
+      config.create_logging_setting!
+      allow(Discord::UserGuilds).to receive(:call).and_return([guild])
+    end
+
+    context "without proving the server is manageable this session" do
+      it "redirects to the picker" do
+        get server_logging_path(guild.id)
+        expect(response).to redirect_to(servers_path)
+      end
+    end
+
+    context "after loading the dashboard authorizes the server" do
+      before { get server_path(guild.id) }
+
+      describe "GET /servers/:server_id/logging" do
+        it "renders the config page with the event matrix" do
+          get server_logging_path(guild.id)
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include("Logging")
+          expect(response.body).to include("Logged events")
+          expect(response.body).to include("Member gained a role")
+          expect(response.body).to include("Member lost a role")
+        end
+
+        context "when the plugin is already enabled" do
+          before do
+            config.logging_setting.update!(channel_id: 200)
+            create(:plugin_activation, server_configuration: config, plugin: logging, enabled: true)
+            get server_path(guild.id)
+          end
+
+          it "renders the matrix without the disabled overlay gating it" do
+            get server_logging_path(guild.id)
+            expect(response).to have_http_status(:ok)
+            expect(response.body).to include("Member gained a role")
+          end
+        end
+      end
+
+      describe "PATCH /servers/:server_id/logging" do
+        before { create(:server_channel, server_configuration: config, name: "mod-log", discord_id: 200) }
+
+        it "saves the channel, event toggles, and enables the plugin" do
+          patch server_logging_path(guild.id),
+            params: {logging: {channel_id: 200, enabled: "1", actions: {"roles.role_gained" => "1", "roles.role_lost" => "0"}}},
+            **turbo
+          expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+          expect(config.logging_setting.reload.channel_id).to eq(200)
+          expect(config.logging_setting.action_enabled?("roles.role_gained")).to be(true)
+          expect(config.plugins.enabled.exists?(key: :logging)).to be(true)
+          expect(response.body).to include("saved")
+        end
+
+        it "warns when the chosen channel is visible to everyone" do
+          patch server_logging_path(guild.id),
+            params: {logging: {channel_id: 200, enabled: "1", actions: {}}},
+            **turbo
+          expect(response.body).to include("public")
+        end
+
+        it "re-renders with an inline error when enabling without a channel" do
+          patch server_logging_path(guild.id),
+            params: {logging: {channel_id: "", enabled: "1", actions: {}}},
+            **turbo
+          expect(config.plugins.enabled.exists?(key: :logging)).to be(false)
+          expect(response.body).to include("logging-config")
+          expect(response.body).to include("settings to be configured")
+        end
+
+        it "falls back to a redirect without Turbo" do
+          patch server_logging_path(guild.id),
+            params: {logging: {channel_id: 200, enabled: "1", actions: {}}}
+          expect(response).to redirect_to(server_logging_path(guild.id))
+        end
+
+        it "redirects with an alert when a non-Turbo save fails" do
+          patch server_logging_path(guild.id),
+            params: {logging: {channel_id: "", enabled: "1", actions: {}}}
+          expect(response).to redirect_to(server_logging_path(guild.id))
+          expect(flash[:alert]).to be_present
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Second of the Phase 7 chunk-5 plugin config pages, building on the shared scaffolding from the Welcomes page.

**Stacked on #64** (`feat/config-pages-welcomes`) — it reuses `Components::ConfigPage`, `Components::TomSelect`, and `ApplicationOperation#failure(value:)` from that PR, so its base is the welcomes branch, not `main`. Review #64 first; once it merges, GitHub will retarget this to `main` (the diff is logging-only).

## What it adds
- **Channel picker** (Tom Select) with an **@everyone-visibility warning** when the chosen channel is publicly visible (computed from synced `ChannelOverwrite`s; shown inline on load and after save).
- **Event-toggle matrix** driven by `LoggableEventCatalog.grouped_by_plugin` — events grouped by plugin, each an independent toggle keyed `<plugin>.<event>`, all off by default. Currently that's the two Roles events; new loggable events appear here automatically as the catalog grows.
- **The enable-gate** (`Components::EnableGate` + `enable_gate_controller.js`, first consumer): the matrix is dimmed and made `inert` while logging is off, and flipping the enable toggle un-gates it live in the same form — so you can pick events and enable the plugin in one Save.

## Backend
`Ops::Logging::Configure` commits the channel, the `enabled_actions` jsonb, and the `PluginActivation` in one transaction, validating the activation against the staged channel (mirrors `Ops::Welcomes::Configure`). The controller whitelists submitted event keys against the catalog before casting. `Components::Toggle` gained a `data:` passthrough so the enable toggle can carry the gate's Stimulus target/action.

## Notes / for review
- The standalone `Ops::Logging::Settings::Update` (Phase 3) is now superseded by `Configure` and unused (only its own spec references it). I left it in place rather than delete Phase-3 code mid-chunk; same goes for the other per-plugin `Settings::Update` ops. Flagging as a small follow-up cleanup if you want them gone.
- Event labels are web copy in `web.en.yml` (the `activity_log` strings are the bot's log templates, not UI labels).

Gates: `rspec` (468), `standardrb`, `active_record_doctor`, `undercover --compare origin/main`, `i18n-tasks missing` + `check-normalized` all green. Live browser verification (the gate's live behaviour, Tom Select, the @everyone warning) is yours.
