### PR TITLE
Extract core view components (Button, Card, Badge, PluginTile, Callout)

### DIFF
--- a/app/assets/tailwind/utilities.css
+++ b/app/assets/tailwind/utilities.css
@@ -32,22 +32,6 @@
   to   { opacity: 1; }
 }
 
-.btn-fill { position: relative; overflow: hidden; }
-.btn-fill::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  transform: scaleX(0);
-  transform-origin: left center;
-  transition: transform var(--dur-base) var(--ease-standard);
-  pointer-events: none;
-}
-.btn-fill:hover::after { transform: scaleX(1); }
-.btn-fill > * { position: relative; z-index: 1; }
-.btn-fill-primary::after { background: var(--accent-hover); }
-.btn-fill-secondary::after { background: var(--surface-sunken); }
-.btn-fill-ghost::after { background: var(--surface-sunken); }
-
 .card-lift {
   transition: transform var(--dur-base) var(--ease-standard),
     box-shadow var(--dur-base) var(--ease-standard),
@@ -95,7 +79,6 @@ details:has(.dropdown-menu.is-closing) .dropdown-chevron { transform: rotate(0de
 [data-theme="dark"] .theme-morph .theme-moon { opacity: 0; transform: rotate(90deg) scale(0.4); }
 
 @media (prefers-reduced-motion: reduce) {
-  .btn-fill::after { transition: none; transform: scaleX(1); }
   .card-lift { transition: none; }
   .anim-menu,
   .anim-toast,

--- a/app/components/badge.rb
+++ b/app/components/badge.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# A small status pill or tag. variant sets the colour, dot: adds a leading
+# status dot, and shape: chooses a full pill (default) or the sharper chip.
+# Copper is a valid variant for wayfinding/personality tags — never for status.
+class Components::Badge < Components::Base
+  VARIANTS = {
+    success: {tone: "bg-success-soft text-success", dot: "bg-success"},
+    warning: {tone: "bg-warning-soft text-warning", dot: "bg-warning"},
+    danger: {tone: "bg-danger-soft text-danger", dot: "bg-danger"},
+    neutral: {tone: "bg-surface-sunken text-text-secondary", dot: "bg-text-muted"},
+    brand: {tone: "bg-accent-soft text-accent-soft-fg", dot: "bg-accent"},
+    copper: {tone: "bg-accent-2-soft text-accent-2-text", dot: "bg-accent-2"}
+  }.freeze
+
+  SHAPES = {pill: "rounded-full", chip: "rounded-chip"}.freeze
+
+  def initialize(variant: :neutral, dot: false, shape: :pill, **attrs)
+    @variant = VARIANTS.fetch(variant)
+    @dot = dot
+    @shape = shape
+    @extra = attrs.delete(:class)
+    @attrs = attrs
+  end
+
+  def view_template(&block)
+    span(class: css, **@attrs) do
+      span(class: "size-1.5 flex-none rounded-full #{@variant[:dot]}") if @dot
+      yield
+    end
+  end
+
+  private
+
+  def css
+    [
+      "inline-flex items-center gap-1.5 px-2 py-0.5 text-xs font-semibold",
+      SHAPES.fetch(@shape),
+      @variant[:tone],
+      @extra
+    ].compact.join(" ")
+  end
+end

--- a/app/components/badge.rb
+++ b/app/components/badge.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-# A small status pill or tag. variant sets the colour, dot: adds a leading
-# status dot, and shape: chooses a full pill (default) or the sharper chip.
-# Copper is a valid variant for wayfinding/personality tags — never for status.
 class Components::Badge < Components::Base
   VARIANTS = {
     success: {tone: "bg-success-soft text-success", dot: "bg-success"},

--- a/app/components/button.rb
+++ b/app/components/button.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-# A button or link in the design system's button taxonomy. Renders an <a> when
-# href: is given, else a <button>. The primary variant carries the chamfered CTA
-# edge; the rest keep the rounded-control radius. Hover darkens (the fill-wipe is
-# gone). A form helper that needs the same look (button_to for a POST sign-in)
-# can borrow the class string via the .css class method.
 class Components::Button < Components::Base
   BASE = "inline-flex items-center justify-center transition-colors"
 

--- a/app/components/button.rb
+++ b/app/components/button.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+# A button or link in the design system's button taxonomy. Renders an <a> when
+# href: is given, else a <button>. The primary variant carries the chamfered CTA
+# edge; the rest keep the rounded-control radius. Hover darkens (the fill-wipe is
+# gone). A form helper that needs the same look (button_to for a POST sign-in)
+# can borrow the class string via the .css class method.
+class Components::Button < Components::Base
+  BASE = "inline-flex items-center justify-center transition-colors"
+
+  VARIANTS = {
+    primary: "chamfer-cta bg-accent-fill text-white hover:bg-accent-fill-hover font-semibold",
+    secondary: "rounded-control border border-border-strong bg-surface-card hover:bg-surface-sunken font-semibold",
+    ghost: "rounded-control text-text-secondary hover:bg-surface-sunken font-semibold",
+    danger: "rounded-control bg-danger text-white hover:bg-danger/90 font-semibold"
+  }.freeze
+
+  SIZES = {
+    sm: "h-8 gap-1.5 px-3 text-xs",
+    md: "h-9 gap-1.5 px-3.5 text-sm",
+    lg: "h-10 gap-2 px-5 text-sm"
+  }.freeze
+
+  def self.css(variant: :primary, size: :md, full: false, disabled: false, extra: nil)
+    [
+      BASE,
+      SIZES.fetch(size),
+      VARIANTS.fetch(variant),
+      (full ? "w-full" : nil),
+      (disabled ? "pointer-events-none cursor-not-allowed opacity-50" : nil),
+      extra
+    ].compact.join(" ")
+  end
+
+  def initialize(
+    label: nil,
+    variant: :primary,
+    size: :md,
+    href: nil,
+    type: "button",
+    icon: nil,
+    trailing_icon: nil,
+    disabled: false,
+    full: false,
+    **attrs
+  )
+    @label = label
+    @variant = variant
+    @size = size
+    @href = href
+    @type = type
+    @icon = icon
+    @trailing_icon = trailing_icon
+    @disabled = disabled
+    @full = full
+    @extra = attrs.delete(:class)
+    @attrs = attrs
+  end
+
+  def view_template(&block)
+    if @href
+      a(href: @href, class: css, **@attrs) { content(&block) }
+    else
+      button(type: @type, class: css, disabled: @disabled, **@attrs) { content(&block) }
+    end
+  end
+
+  private
+
+  def content(&block)
+    render Components::Icon.new(@icon, class: icon_size) if @icon
+    if block
+      yield
+    elsif @label
+      span { @label }
+    end
+    render Components::Icon.new(@trailing_icon, class: icon_size) if @trailing_icon
+  end
+
+  def css
+    self.class.css(variant: @variant, size: @size, full: @full, disabled: @disabled, extra: @extra)
+  end
+
+  def icon_size
+    (@size == :sm) ? "size-3.5" : "size-4"
+  end
+end

--- a/app/components/callout.rb
+++ b/app/components/callout.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# A tinted, bordered notice with a leading icon. variant sets the colour and a
+# default icon (overridable); the body is yielded. Used for inline warnings,
+# info notes, and confirmations across the config pages.
+class Components::Callout < Components::Base
+  VARIANTS = {
+    info: {box: "bg-accent-soft border-accent-soft-bd", color: "text-accent", icon: "info"},
+    neutral: {box: "bg-surface-sunken border-border-default", color: "text-text-muted", icon: "info"},
+    warning: {box: "bg-warning-soft border-warning/30", color: "text-warning", icon: "warning"},
+    danger: {box: "bg-danger-soft border-danger/30", color: "text-danger", icon: "warning"},
+    success: {box: "bg-success-soft border-success/30", color: "text-success", icon: "check"}
+  }.freeze
+
+  def initialize(variant: :info, icon: nil, **attrs)
+    @variant = VARIANTS.fetch(variant)
+    @icon = icon
+    @extra = attrs.delete(:class)
+    @attrs = attrs
+  end
+
+  def view_template(&block)
+    div(class: css, **@attrs) do
+      render Components::Icon.new(@icon || @variant[:icon], class: "mt-0.5 size-[18px] flex-none #{@variant[:color]}")
+      div(class: "text-sm leading-relaxed") { yield }
+    end
+  end
+
+  private
+
+  def css
+    ["flex gap-3 rounded-md border px-4 py-3", @variant[:box], @extra].compact.join(" ")
+  end
+end

--- a/app/components/callout.rb
+++ b/app/components/callout.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-# A tinted, bordered notice with a leading icon. variant sets the colour and a
-# default icon (overridable); the body is yielded. Used for inline warnings,
-# info notes, and confirmations across the config pages.
 class Components::Callout < Components::Base
   VARIANTS = {
     info: {box: "bg-accent-soft border-accent-soft-bd", color: "text-accent", icon: "info"},

--- a/app/components/card.rb
+++ b/app/components/card.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# A warm bordered surface — the standard content card. Renders a <div>, or an
+# <a> when href: is given (the clickable server-picker cards). Enabled cards
+# swap the neutral border for a faint teal one; lift: adds the hover-raise.
+class Components::Card < Components::Base
+  PADDING = {none: "", sm: "p-4", md: "p-5", lg: "p-8"}.freeze
+
+  def initialize(enabled: false, padding: :md, href: nil, lift: false, dashed: false, **attrs)
+    @enabled = enabled
+    @padding = padding
+    @href = href
+    @lift = lift
+    @dashed = dashed
+    @extra = attrs.delete(:class)
+    @attrs = attrs
+  end
+
+  def view_template(&block)
+    if @href
+      a(href: @href, class: css, **@attrs) { yield }
+    else
+      div(class: css, **@attrs) { yield }
+    end
+  end
+
+  private
+
+  # Dashed is the "placeholder / add" affordance (invite a bot, add a set): a
+  # dashed border and no shadow. Solid is the standard raised card.
+  def css
+    [
+      "rounded-card border bg-surface-card",
+      (@dashed ? "border-dashed border-border-strong" : "shadow-sm"),
+      (@enabled ? "border-accent-soft-bd" : ("border-border-default" unless @dashed)),
+      PADDING.fetch(@padding),
+      (@lift ? "card-lift" : nil),
+      @extra
+    ].compact.join(" ")
+  end
+end

--- a/app/components/card.rb
+++ b/app/components/card.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-# A warm bordered surface — the standard content card. Renders a <div>, or an
-# <a> when href: is given (the clickable server-picker cards). Enabled cards
-# swap the neutral border for a faint teal one; lift: adds the hover-raise.
 class Components::Card < Components::Base
   PADDING = {none: "", sm: "p-4", md: "p-5", lg: "p-8"}.freeze
 
@@ -26,8 +23,6 @@ class Components::Card < Components::Base
 
   private
 
-  # Dashed is the "placeholder / add" affordance (invite a bot, add a set): a
-  # dashed border and no shadow. Solid is the standard raised card.
   def css
     [
       "rounded-card border bg-surface-card",

--- a/app/components/config_page.rb
+++ b/app/components/config_page.rb
@@ -28,9 +28,7 @@ class Components::ConfigPage < Components::Base
 
   def header
     div(class: "mb-6 flex items-start gap-4") do
-      span(class: "flex size-12 flex-none items-center justify-center rounded-xl bg-accent-soft text-accent-soft-fg") do
-        render Components::Icon.new(@icon, class: "size-6")
-      end
+      render Components::PluginTile.new(icon: @icon, size: :lg)
       div do
         h1(class: "font-display text-2xl font-bold tracking-tight") { @title }
         p(class: "mt-1 text-sm text-text-secondary") { @description }

--- a/app/components/logging/config_form.rb
+++ b/app/components/logging/config_form.rb
@@ -1,8 +1,6 @@
 class Components::Logging::ConfigForm < Components::Base
   include Phlex::Rails::Helpers::FormWith
 
-  CARD = "rounded-lg border border-border-default bg-surface-card p-5 shadow-sm"
-
   def initialize(server_configuration:, enabled:, enable_error: nil)
     @config = server_configuration
     @settings = server_configuration.logging_setting
@@ -24,7 +22,7 @@ class Components::Logging::ConfigForm < Components::Base
   private
 
   def enable_card
-    div(class: CARD) do
+    render Components::Card.new do
       div(class: "flex items-center justify-between gap-4") do
         div do
           p(class: "font-semibold") { t(".enable.label") }
@@ -42,7 +40,7 @@ class Components::Logging::ConfigForm < Components::Base
   end
 
   def channel_card
-    div(class: CARD) do
+    render Components::Card.new do
       label(class: "block text-sm font-semibold") { t(".channel.label") }
       p(class: "mb-2 mt-0.5 text-sm text-text-secondary") { t(".channel.help") }
       if channels.empty?
@@ -61,7 +59,7 @@ class Components::Logging::ConfigForm < Components::Base
   end
 
   def events_card
-    div(class: CARD) do
+    render Components::Card.new do
       p(class: "text-sm font-semibold") { t(".events.label") }
       p(class: "mb-3 mt-0.5 text-sm text-text-secondary") { t(".events.help") }
       render Components::EnableGate.new(enabled: @enabled, message: t(".events.gated")) do
@@ -98,21 +96,14 @@ class Components::Logging::ConfigForm < Components::Base
   def visibility_warning
     return unless visible_channel?
 
-    div(class: "mt-3 flex items-start gap-1.5 text-sm text-warning") do
-      render Components::Icon.new("warning", class: "mt-0.5 size-4 flex-none")
-      span { t(".channel.visible_warning") }
+    render Components::Callout.new(variant: :warning, class: "mt-3") do
+      plain t(".channel.visible_warning")
     end
   end
 
   def save_bar
     div(class: "flex justify-end") do
-      button(
-        type: "submit",
-        class: "btn-fill btn-fill-primary inline-flex h-10 items-center gap-2 rounded-md bg-accent-fill px-5 text-sm font-semibold text-white transition-colors"
-      ) do
-        render Components::Icon.new("check", class: "size-4")
-        span { t(".save") }
-      end
+      render Components::Button.new(variant: :primary, size: :lg, type: "submit", icon: "check", label: t(".save"))
     end
   end
 

--- a/app/components/plugin_row.rb
+++ b/app/components/plugin_row.rb
@@ -3,6 +3,13 @@
 class Components::PluginRow < Components::Base
   ICONS = {roles: "users-three", welcomes: "hand-waving", logging: "scroll", reminders: "bell-ringing"}.freeze
 
+  STATUS_VARIANTS = {
+    always_enabled: :success,
+    enabled: :success,
+    needs_setup: :warning,
+    disabled: :neutral
+  }.freeze
+
   def initialize(server_id:, key:, enabled:, configured:, locked: false)
     @server_id = server_id
     @key = key
@@ -12,9 +19,8 @@ class Components::PluginRow < Components::Base
   end
 
   def view_template
-    border = @enabled ? "border-accent-soft-bd" : "border-border-default"
-    div(id: "plugin-#{@key}", class: "flex items-center gap-4 rounded-lg border #{border} bg-surface-card p-5 shadow-sm") do
-      icon
+    render Components::Card.new(enabled: @enabled, id: "plugin-#{@key}", class: "flex items-center gap-4") do
+      render Components::PluginTile.new(icon: ICONS[@key], enabled: @enabled)
       div(class: "min-w-0 flex-1") do
         div(class: "flex flex-wrap items-center gap-2") do
           span(class: "font-display font-semibold") { t(".plugin.#{@key}.name") }
@@ -46,39 +52,30 @@ class Components::PluginRow < Components::Base
     end
   end
 
-  def icon
-    tone = @enabled ? "bg-accent-fill text-white" : "bg-surface-sunken text-text-muted"
-    span(class: "flex size-11 flex-none items-center justify-center rounded-md #{tone}") do
-      render Components::Icon.new(ICONS[@key], class: "size-5")
-    end
+  def status_badge
+    render Components::Badge.new(variant: STATUS_VARIANTS.fetch(status), dot: true) { t(".status.#{status}") }
   end
 
-  def status_badge
-    state, tone, dot =
-      if @locked
-        [:always_enabled, "bg-success-soft text-success", "bg-success"]
-      elsif !@enabled
-        [:disabled, "bg-surface-sunken text-text-secondary", "bg-text-muted"]
-      elsif @configured
-        [:enabled, "bg-success-soft text-success", "bg-success"]
-      else
-        [:needs_setup, "bg-warning-soft text-warning", "bg-warning"]
-      end
-
-    span(class: "inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-xs font-semibold #{tone}") do
-      span(class: "size-1.5 rounded-full #{dot}")
-      plain t(".status.#{state}")
+  def status
+    if @locked
+      :always_enabled
+    elsif !@enabled
+      :disabled
+    elsif @configured
+      :enabled
+    else
+      :needs_setup
     end
   end
 
   def configure_link
-    a(
+    render Components::Button.new(
+      variant: :secondary,
       href: configure_href,
-      class: "btn-fill btn-fill-ghost inline-flex h-9 flex-none items-center gap-1.5 rounded-md border border-border-default px-3.5 text-sm font-semibold transition-colors hover:bg-surface-sunken"
-    ) do
-      span { t(".configure") }
-      render Components::Icon.new("arrow-right", class: "size-4")
-    end
+      label: t(".configure"),
+      trailing_icon: "arrow-right",
+      class: "flex-none"
+    )
   end
 
   def configure_href

--- a/app/components/plugin_tile.rb
+++ b/app/components/plugin_tile.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# The chamfered plugin-identity tile: a Phosphor glyph on a filled teal field
+# when enabled (Fill weight, per the one-tone rule), or a muted sand field when
+# not. Carries the chamfer geometry reserved for brand-forward surfaces.
+class Components::PluginTile < Components::Base
+  SIZES = {
+    sm: {box: "size-9", icon: "size-4"},
+    md: {box: "size-11", icon: "size-5"},
+    lg: {box: "size-12", icon: "size-6"}
+  }.freeze
+
+  def initialize(icon:, enabled: true, size: :md)
+    @icon = icon
+    @enabled = enabled
+    @size = SIZES.fetch(size)
+  end
+
+  def view_template
+    span(class: "chamfer-tile flex flex-none items-center justify-center #{box}") do
+      render Components::Icon.new(@icon, weight: weight, class: @size[:icon])
+    end
+  end
+
+  private
+
+  def box
+    tone = @enabled ? "bg-accent-fill text-white" : "bg-surface-sunken text-text-muted"
+    "#{@size[:box]} #{tone}"
+  end
+
+  def weight
+    @enabled ? :fill : :regular
+  end
+end

--- a/app/components/plugin_tile.rb
+++ b/app/components/plugin_tile.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-# The chamfered plugin-identity tile: a Phosphor glyph on a filled teal field
-# when enabled (Fill weight, per the one-tone rule), or a muted sand field when
-# not. Carries the chamfer geometry reserved for brand-forward surfaces.
 class Components::PluginTile < Components::Base
   SIZES = {
     sm: {box: "size-9", icon: "size-4"},

--- a/app/components/welcomes/config_form.rb
+++ b/app/components/welcomes/config_form.rb
@@ -1,9 +1,8 @@
 class Components::Welcomes::ConfigForm < Components::Base
   include Phlex::Rails::Helpers::FormWith
 
-  FIELD = "w-full rounded-md border border-border-default bg-surface-card px-3 py-2 text-sm text-text-primary " \
+  FIELD = "w-full rounded-control border border-border-default bg-surface-card px-3 py-2 text-sm text-text-primary " \
     "placeholder:text-text-secondary focus:border-accent focus:outline-none focus:ring-3 focus:ring-[var(--focus-ring)]"
-  CARD = "rounded-lg border border-border-default bg-surface-card p-5 shadow-sm"
 
   def initialize(server_configuration:, enabled:, enable_error: nil)
     @config = server_configuration
@@ -26,7 +25,7 @@ class Components::Welcomes::ConfigForm < Components::Base
   private
 
   def enable_card
-    div(class: CARD) do
+    render Components::Card.new do
       div(class: "flex items-center justify-between gap-4") do
         div do
           p(class: "font-semibold") { t(".enable.label") }
@@ -39,7 +38,7 @@ class Components::Welcomes::ConfigForm < Components::Base
   end
 
   def channel_card
-    div(class: CARD) do
+    render Components::Card.new do
       label(class: "block text-sm font-semibold") { t(".channel.label") }
       p(class: "mb-2 mt-0.5 text-sm text-text-secondary") { t(".channel.help") }
       if channels.empty?
@@ -57,7 +56,7 @@ class Components::Welcomes::ConfigForm < Components::Base
   end
 
   def messages_card
-    div(class: CARD) do
+    render Components::Card.new do
       message_field(:join_message, @settings.join_message)
       div(class: "my-5 border-t border-border-default")
       message_field(:leave_message, @settings.leave_message)
@@ -120,13 +119,7 @@ class Components::Welcomes::ConfigForm < Components::Base
 
   def save_bar
     div(class: "flex justify-end") do
-      button(
-        type: "submit",
-        class: "btn-fill btn-fill-primary inline-flex h-10 items-center gap-2 rounded-md bg-accent-fill px-5 text-sm font-semibold text-white transition-colors"
-      ) do
-        render Components::Icon.new("check", class: "size-4")
-        span { t(".save") }
-      end
+      render Components::Button.new(variant: :primary, size: :lg, type: "submit", icon: "check", label: t(".save"))
     end
   end
 

--- a/app/views/home.rb
+++ b/app/views/home.rb
@@ -5,7 +5,7 @@ class Views::Home < Views::Base
 
   def view_template
     div(class: "mx-auto flex min-h-screen max-w-md flex-col justify-center px-5") do
-      div(class: "rounded-lg border border-border-default bg-surface-card p-8 shadow-sm") do
+      render Components::Card.new(padding: :lg) do
         h1(class: "mb-2 font-display text-2xl font-bold tracking-tight text-text-primary") do
           span(class: "text-accent") { "shrk" }
           plain "bot"
@@ -17,9 +17,9 @@ class Views::Home < Views::Base
           "/auth/discord",
           method: :post,
           data: {turbo: false},
-          class: "btn-fill btn-fill-primary inline-flex w-full items-center justify-center gap-2 rounded-md bg-accent-fill px-4 py-3 font-semibold text-white"
+          class: Components::Button.css(variant: :primary, size: :lg, full: true)
         ) do
-          render Components::Icon.new("sign-in", class: "size-5")
+          render Components::Icon.new("sign-in", class: "size-4")
           span { t(".sign_in") }
         end
       end

--- a/app/views/servers/index.rb
+++ b/app/views/servers/index.rb
@@ -44,14 +44,14 @@ class Views::Servers::Index < Views::Base
   end
 
   def present_card(guild)
-    a(href: server_path(guild.id), class: "card-lift flex flex-col gap-3 rounded-lg border border-border-default bg-surface-card p-5 shadow-sm") do
+    render Components::Card.new(href: server_path(guild.id), lift: true, class: "flex flex-col gap-3") do
       identity(guild)
       plugins_badge(@plugin_counts[guild.id].to_i)
     end
   end
 
   def invite_card(guild)
-    div(class: "flex flex-col gap-3 rounded-lg border border-dashed border-border-strong bg-surface-card p-5") do
+    render Components::Card.new(dashed: true, class: "flex flex-col gap-3") do
       identity(guild, muted: true)
       invite_button(invite_url(guild))
     end
@@ -77,8 +77,7 @@ class Views::Servers::Index < Views::Base
   end
 
   def plugins_badge(count)
-    tone = count.positive? ? "bg-accent-soft text-accent-soft-fg" : "bg-surface-sunken text-text-secondary"
-    span(class: "self-start rounded-full px-2.5 py-1 text-xs font-semibold #{tone}") do
+    render Components::Badge.new(variant: count.positive? ? :brand : :neutral, class: "self-start") do
       t(".plugins_enabled", count:)
     end
   end
@@ -88,17 +87,17 @@ class Views::Servers::Index < Views::Base
   end
 
   def invite_button(url)
-    a(
+    render Components::Button.new(
+      variant: :secondary,
       href: url,
-      class: "btn-fill btn-fill-ghost inline-flex items-center gap-1.5 self-start rounded-md border border-border-strong px-3 py-1.5 text-sm font-semibold transition-colors hover:bg-surface-sunken"
-    ) do
-      render Components::Icon.new("plus", class: "size-4")
-      span { t(".invite") }
-    end
+      icon: "plus",
+      label: t(".invite"),
+      class: "self-start"
+    )
   end
 
   def missing_server_prompt
-    div(class: "mt-8 rounded-lg border border-dashed border-border-default bg-surface-card p-8 text-center") do
+    render Components::Card.new(dashed: true, padding: :lg, class: "mt-8 text-center") do
       p(class: "text-sm font-semibold") { t(".missing_title") }
       p(class: "mx-auto mt-1 max-w-md text-sm text-text-secondary") { t(".missing_body") }
       div(class: "mt-4 flex justify-center") { invite_button(generic_invite_url) }
@@ -111,20 +110,8 @@ class Views::Servers::Index < Views::Base
       h2(class: "mb-2 font-display text-xl font-bold tracking-tight") { t(".empty_title") }
       p(class: "mb-6 max-w-sm text-sm leading-relaxed text-text-secondary") { t(".empty_body") }
       div(class: "flex flex-wrap justify-center gap-3") do
-        a(
-          href: generic_invite_url,
-          class: "btn-fill btn-fill-primary inline-flex h-10 items-center gap-2 rounded-md bg-accent-fill px-5 text-sm font-semibold text-white"
-        ) do
-          render Components::Icon.new("plus", class: "size-4")
-          span { t(".invite") }
-        end
-        a(
-          href: servers_path,
-          class: "btn-fill btn-fill-ghost inline-flex h-10 items-center gap-2 rounded-md border border-border-default px-5 text-sm font-semibold transition-colors hover:bg-surface-sunken"
-        ) do
-          render Components::Icon.new("arrows-clockwise", class: "size-4")
-          span { t(".refresh") }
-        end
+        render Components::Button.new(variant: :primary, size: :lg, href: generic_invite_url, icon: "plus", label: t(".invite"))
+        render Components::Button.new(variant: :secondary, size: :lg, href: servers_path, icon: "arrows-clockwise", label: t(".refresh"))
       end
     end
   end

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -97,6 +97,28 @@ more `turbo_stream.*` lines. The remaining config-form controls
 (segmented control, enable-gate, Tom Select wrapper) are built with the pages that
 consume them.
 
+## Core components
+
+Reach for these before hand-rolling markup — more small components beats
+duplicated class strings:
+
+- **`Components::Button`** — `variant:` (`:primary` chamfered CTA, `:secondary`
+  bordered, `:ghost`, `:danger`), `size:` (`:sm`/`:md`/`:lg`), `icon:` /
+  `trailing_icon:`, `full:`. Renders an `<a>` when `href:` is given, else a
+  `<button>` (`type:` defaults to `"button"`; pass `"submit"` for forms). A form
+  helper that needs the look without the component (the OAuth `button_to`) borrows
+  `Components::Button.css(...)`.
+- **`Components::Card`** — the standard warm surface. `enabled:` swaps to the teal
+  border, `padding:` (`:none`/`:sm`/`:md`/`:lg`), `href:` renders a link card,
+  `lift:` adds the hover-raise, `dashed:` is the placeholder/add affordance.
+- **`Components::Badge`** — status pill or tag. `variant:` (`:success`/`:warning`/
+  `:danger`/`:neutral`/`:brand`/`:copper`), `dot:`, `shape:` (`:pill`/`:chip`).
+  Copper is for wayfinding/personality, never status.
+- **`Components::PluginTile`** — the chamfered identity tile (icon on teal when
+  `enabled:`, muted sand otherwise). `size:` (`:sm`/`:md`/`:lg`).
+- **`Components::Callout`** — tinted bordered notice. `variant:` (`:info`/
+  `:neutral`/`:warning`/`:danger`/`:success`) sets colour + default icon.
+
 ## Where it lives
 
 - `app/assets/tailwind/` — the stylesheet, split into focused partials that
@@ -182,10 +204,9 @@ theme-morph choreography, and the chamfer geometry helpers (`chamfer-tile`,
 `chamfer-tile-sm`, `chamfer-cta`, `chamfer-bar` — for brand-forward surfaces
 only). Durations 120/180/260ms; `--ease-standard cubic-bezier(.2,0,0,1)` for
 entering, `--ease-exit cubic-bezier(.4,0,1,1)` for leaving. A
-`prefers-reduced-motion: reduce` block neutralises them — keep it. `btn-fill`
-(hover fill via a `::after`) is still present but **transitional**: the design
-retires it for plain darken-on-hover, to be removed when the Button component
-lands.
+`prefers-reduced-motion: reduce` block neutralises them — keep it. Buttons
+darken on hover (`hover:bg-accent-fill-hover` for primary, a sand wash for the
+rest) rather than the old fill-wipe, which has been removed.
 
 ## Layout: flex, not grid
 

--- a/spec/components/badge_spec.rb
+++ b/spec/components/badge_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe Components::Badge do
+  subject(:html) { described_class.new(**options).call { "Enabled" } }
+
+  let(:options) { {variant: :success} }
+
+  it "renders the label in the variant's tone" do
+    expect(html).to include("Enabled").and include("bg-success-soft").and include("text-success")
+  end
+
+  it "is a pill by default with no dot" do
+    expect(html).to include("rounded-full")
+    expect(html).not_to include("size-1.5")
+  end
+
+  context "with a dot" do
+    let(:options) { {variant: :success, dot: true} }
+
+    it "renders a leading status dot" do
+      expect(html).to include("size-1.5").and include("bg-success")
+    end
+  end
+
+  context "as a chip" do
+    let(:options) { {variant: :brand, shape: :chip} }
+
+    it "uses the sharper chip radius and brand tone" do
+      expect(html).to include("rounded-chip").and include("bg-accent-soft")
+      expect(html).not_to include("rounded-full")
+    end
+  end
+
+  context "copper variant" do
+    let(:options) { {variant: :copper} }
+
+    it "uses the copper wayfinding tone" do
+      expect(html).to include("bg-accent-2-soft").and include("text-accent-2-text")
+    end
+  end
+end

--- a/spec/components/button_spec.rb
+++ b/spec/components/button_spec.rb
@@ -72,6 +72,22 @@ RSpec.describe Components::Button do
     end
   end
 
+  context "with a label instead of a block" do
+    subject(:html) { described_class.new(label: "Save").call }
+
+    it "renders the label in a span" do
+      expect(html).to include("<span>Save</span>")
+    end
+  end
+
+  context "at the small size with an icon" do
+    subject(:html) { described_class.new(icon: "plus", size: :sm).call }
+
+    it "shrinks the glyph" do
+      expect(html).to include("size-3.5")
+    end
+  end
+
   describe ".css" do
     it "exposes the class string for form helpers to borrow" do
       expect(described_class.css(variant: :primary, full: true))

--- a/spec/components/button_spec.rb
+++ b/spec/components/button_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+
+RSpec.describe Components::Button do
+  subject(:html) { described_class.new(**options).call { "Save" } }
+
+  let(:options) { {} }
+
+  it "renders a button by default" do
+    expect(html).to include("<button").and include("Save")
+    expect(html).not_to include("<a")
+  end
+
+  it "defaults to a non-submitting button" do
+    expect(html).to include('type="button"')
+  end
+
+  context "as a submit button" do
+    let(:options) { {type: "submit"} }
+
+    it "submits" do
+      expect(html).to include('type="submit"')
+    end
+  end
+
+  context "with an href" do
+    let(:options) { {href: "/servers"} }
+
+    it "renders a link, not a button" do
+      expect(html).to include("<a").and include('href="/servers"')
+      expect(html).not_to include("<button")
+    end
+  end
+
+  context "primary variant" do
+    let(:options) { {variant: :primary} }
+
+    it "carries the chamfered CTA edge and the fill colour" do
+      expect(html).to include("chamfer-cta").and include("bg-accent-fill")
+    end
+  end
+
+  context "ghost variant" do
+    let(:options) { {variant: :ghost} }
+
+    it "is rounded, not chamfered" do
+      expect(html).to include("rounded-control")
+      expect(html).not_to include("chamfer-cta")
+    end
+  end
+
+  context "when disabled" do
+    let(:options) { {disabled: true} }
+
+    it "sets the attribute and dims" do
+      expect(html).to include("disabled").and include("opacity-50")
+    end
+  end
+
+  context "when full-width" do
+    let(:options) { {full: true} }
+
+    it "spans the row" do
+      expect(html).to include("w-full")
+    end
+  end
+
+  context "with leading and trailing icons" do
+    subject(:html) { described_class.new(icon: "plus", trailing_icon: "arrow-right").call { "Add" } }
+
+    it "renders both glyphs around the label" do
+      expect(html.scan("<svg").size).to eq(2)
+    end
+  end
+
+  describe ".css" do
+    it "exposes the class string for form helpers to borrow" do
+      expect(described_class.css(variant: :primary, full: true))
+        .to include("bg-accent-fill").and include("w-full")
+    end
+  end
+end

--- a/spec/components/callout_spec.rb
+++ b/spec/components/callout_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe Components::Callout do
+  subject(:html) { described_class.new(**options).call { "Heads up." } }
+
+  let(:options) { {variant: :warning} }
+
+  it "renders a tinted bordered box with the body and default icon" do
+    expect(html).to include("Heads up.").and include("bg-warning-soft").and include("border-warning/30")
+    expect(html).to include(PhosphorIcons::Icon.new("warning", style: :regular, class: "mt-0.5 size-[18px] flex-none text-warning").to_svg)
+  end
+
+  context "info variant" do
+    let(:options) { {variant: :info} }
+
+    it "uses the teal tint and the info glyph" do
+      expect(html).to include("bg-accent-soft").and include("border-accent-soft-bd")
+      expect(html).to include(PhosphorIcons::Icon.new("info", style: :regular, class: "mt-0.5 size-[18px] flex-none text-accent").to_svg)
+    end
+  end
+
+  context "with an icon override" do
+    let(:options) { {variant: :success, icon: "lock"} }
+
+    it "renders the chosen glyph instead of the default" do
+      expect(html).to include(PhosphorIcons::Icon.new("lock", style: :regular, class: "mt-0.5 size-[18px] flex-none text-success").to_svg)
+    end
+  end
+end

--- a/spec/components/card_spec.rb
+++ b/spec/components/card_spec.rb
@@ -46,4 +46,14 @@ RSpec.describe Components::Card do
       expect(html).not_to include("p-5")
     end
   end
+
+  context "when dashed" do
+    let(:options) { {dashed: true} }
+
+    it "is a borderless-looking placeholder: dashed border, no shadow" do
+      expect(html).to include("border-dashed").and include("border-border-strong")
+      expect(html).not_to include("shadow-sm")
+      expect(html).not_to include("border-border-default")
+    end
+  end
 end

--- a/spec/components/card_spec.rb
+++ b/spec/components/card_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe Components::Card do
+  subject(:html) { described_class.new(**options).call { "body" } }
+
+  let(:options) { {} }
+
+  it "renders a bordered warm surface as a div" do
+    expect(html).to include("<div").and include("rounded-card").and include("bg-surface-card")
+    expect(html).to include("border-border-default").and include("body")
+  end
+
+  it "uses medium padding by default" do
+    expect(html).to include("p-5")
+  end
+
+  context "when enabled" do
+    let(:options) { {enabled: true} }
+
+    it "swaps to the faint teal border" do
+      expect(html).to include("border-accent-soft-bd")
+      expect(html).not_to include("border-border-default")
+    end
+  end
+
+  context "with an href" do
+    let(:options) { {href: "/servers/1"} }
+
+    it "renders a link" do
+      expect(html).to include("<a").and include('href="/servers/1"')
+    end
+  end
+
+  context "when lifted" do
+    let(:options) { {lift: true} }
+
+    it "adds the hover-raise" do
+      expect(html).to include("card-lift")
+    end
+  end
+
+  context "with no padding" do
+    let(:options) { {padding: :none} }
+
+    it "omits the padding utility" do
+      expect(html).not_to include("p-5")
+    end
+  end
+end

--- a/spec/components/plugin_tile_spec.rb
+++ b/spec/components/plugin_tile_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe Components::PluginTile do
+  subject(:html) { described_class.new(**options).call }
+
+  let(:options) { {icon: "users-three"} }
+
+  it "is always chamfered and renders the glyph" do
+    expect(html).to include("chamfer-tile").and include("<svg")
+  end
+
+  context "when enabled" do
+    let(:options) { {icon: "users-three", enabled: true} }
+
+    it "fills with teal and uses the fill-weight glyph" do
+      expect(html).to include("bg-accent-fill").and include("text-white")
+      expect(html).to eq(described_class.new(icon: "users-three", enabled: true).call)
+      expect(html).to include(PhosphorIcons::Icon.new("users-three", style: :fill, class: "size-5").to_svg)
+    end
+  end
+
+  context "when disabled" do
+    let(:options) { {icon: "scroll", enabled: false} }
+
+    it "is muted sand with a regular-weight glyph" do
+      expect(html).to include("bg-surface-sunken").and include("text-text-muted")
+      expect(html).to include(PhosphorIcons::Icon.new("scroll", style: :regular, class: "size-5").to_svg)
+    end
+  end
+
+  context "at a larger size" do
+    let(:options) { {icon: "users-three", size: :lg} }
+
+    it "scales the box and glyph" do
+      expect(html).to include("size-12").and include("size-6")
+    end
+  end
+end


### PR DESCRIPTION
**Stacked on #66** (base = `redesign/foundation-tokens`) — review/merge that one first; this diff only shows once it's in, or view against the foundation branch.

Second chunk of the rework: extract the five most-duplicated UI patterns into single-purpose Phlex components and migrate the existing views/forms onto them. No new screens — this is a refactor that removes duplication and establishes the component vocabulary the later chunks build from.

## New components
- **`Button`** — `variant:` (`:primary` chamfered CTA / `:secondary` / `:ghost` / `:danger`), `size:` (`:sm`/`:md`/`:lg`), `icon:`/`trailing_icon:`, `full:`. Renders `<a>` (with `href:`) or `<button>`. The OAuth `button_to` on the login page borrows the look via the pure `Components::Button.css(...)` class method, so styling stays in one place without forcing form semantics into the component.
- **`Card`** — `enabled:` (teal border), `padding:`, `href:` (link card), `lift:` (hover-raise), `dashed:` (the invite/placeholder affordance).
- **`Badge`** — `variant:` (success/warning/danger/neutral/brand/copper), `dot:`, `shape:` (pill/chip).
- **`PluginTile`** — the chamfered identity tile (Fill glyph on teal when enabled, muted sand otherwise).
- **`Callout`** — tinted bordered notice (info/neutral/warning/danger/success).

## Migrated onto them
`plugin_row` (Card + PluginTile + Badge + Button), `config_page` header (PluginTile), `servers/index` (Card/Badge/Button incl. the dashed invite cards), `home` (Card + Button.css), and both config forms (Card, Button, logging's visibility warning → Callout).

## Cleanup
- **`btn-fill` retired** — buttons now darken on hover (the design dropped the fill-wipe); the CSS and all usages are gone.
- Net **−110/+78** lines across the migrated views.
- `docs/design-system.md` gains a "Core components" section + the darken-on-hover note.

## Notes
- `Button`/`Card`/`Badge` deliberately own their padding, so I standardised a couple of badges/buttons to the component scale rather than pixel-matching the throwaway mock (e.g. the server-card count badge is now the compact pill). Flag if any feels off once rendered.
- Plugin tiles are now **chamfered** (the design's identity-tile treatment) where they were plain rounded squares before.

## Gates
`rspec` **500/0** (28 new component specs) · `standardrb` clean · `active_record_doctor` clean · `undercover` no missing coverage · Tailwind builds, `btn-fill` gone. No locale/copy changed.