### PR TITLE
Add frozen_string_literal to all Ruby sources

### DIFF
--- a/.active_record_doctor.rb
+++ b/.active_record_doctor.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ActiveRecordDoctor.configure do
   global :ignore_tables, [
     "schema_migrations",

--- a/app/bot/activity_log.rb
+++ b/app/bot/activity_log.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ActivityLog
   module_function
 

--- a/app/bot/announce_modal.rb
+++ b/app/bot/announce_modal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AnnounceModal < BaseEvent
   on :modal_submit, custom_id: Commands::Announce::MODAL_ID
 

--- a/app/bot/base_command.rb
+++ b/app/bot/base_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class BaseCommand
   include WithConnection
 

--- a/app/bot/base_event.rb
+++ b/app/bot/base_event.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class BaseEvent
   include WithConnection
 

--- a/app/bot/bot_config.rb
+++ b/app/bot/bot_config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BotConfig
   ACCENT_COLOR = 0x39afe5
 

--- a/app/bot/bot_presence.rb
+++ b/app/bot/bot_presence.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BotPresence
   LISTENING = 2
 

--- a/app/bot/bot_registry.rb
+++ b/app/bot/bot_registry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BotRegistry
   module_function
 

--- a/app/bot/channel_cleanup.rb
+++ b/app/bot/channel_cleanup.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ChannelCleanup < BaseEvent
   on :channel_delete
 

--- a/app/bot/channel_sync.rb
+++ b/app/bot/channel_sync.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ChannelSync < BaseEvent
   on :channel_create, :channel_update, :channel_delete
 

--- a/app/bot/command_permissions.rb
+++ b/app/bot/command_permissions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module CommandPermissions
   module_function
 

--- a/app/bot/command_registrar.rb
+++ b/app/bot/command_registrar.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CommandRegistrar
   def initialize(bot, commands:, instant_global: false, define_commands: true)
     @bot = bot

--- a/app/bot/commands/announce.rb
+++ b/app/bot/commands/announce.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Commands
   class Announce < BaseCommand
     command_name :announce

--- a/app/bot/commands/donate.rb
+++ b/app/bot/commands/donate.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 module Commands
   class Donate < BaseCommand
     command_name :donate
     description "Find out what it costs to run shrkbot and how you can support the project."
     register_in :global
 
-    MESSAGE = <<~DONATE.freeze
+    MESSAGE = <<~DONATE
       Thank you for considering supporting the shrkbot project! For full transparency, here's what it currently costs to keep shrkbot running:
       • Hosting: 10.60€ / month
 

--- a/app/bot/commands/info.rb
+++ b/app/bot/commands/info.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Commands
   class Info < BaseCommand
     command_name :info

--- a/app/bot/commands/ping.rb
+++ b/app/bot/commands/ping.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Commands
   class Ping < BaseCommand
     command_name :ping

--- a/app/bot/config_bus.rb
+++ b/app/bot/config_bus.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ConfigBus
   CHANNEL = "shrkbot:config"
 

--- a/app/bot/config_subscriber.rb
+++ b/app/bot/config_subscriber.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ConfigSubscriber
   include WithConnection
 

--- a/app/bot/discord/components.rb
+++ b/app/bot/discord/components.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Discord
   module Components
     CONTAINER = 17

--- a/app/bot/discord/guild.rb
+++ b/app/bot/discord/guild.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Discord
   ADMINISTRATOR = 0x8
   MANAGE_GUILD = 0x20

--- a/app/bot/discord/truncate.rb
+++ b/app/bot/discord/truncate.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Discord
   module Truncate
     module_function

--- a/app/bot/discord/user_guilds.rb
+++ b/app/bot/discord/user_guilds.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "net/http"
 require "json"
 

--- a/app/bot/event_registrar.rb
+++ b/app/bot/event_registrar.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class EventRegistrar
   def initialize(bot, events:)
     @bot = bot

--- a/app/bot/guild_metadata.rb
+++ b/app/bot/guild_metadata.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GuildMetadata
   module_function
 

--- a/app/bot/owner_broadcast.rb
+++ b/app/bot/owner_broadcast.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OwnerBroadcast
   FOOTER = "-# You're receiving this because you own at least one server that shrkbot is in."
   Result = Data.define(:owner_count, :sent, :server_count)

--- a/app/bot/owner_notifier.rb
+++ b/app/bot/owner_notifier.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OwnerNotifier
   MAX_LENGTH = 1900
 

--- a/app/bot/role_sync.rb
+++ b/app/bot/role_sync.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RoleSync < BaseEvent
   on :server_role_create, :server_role_update, :server_role_delete
 

--- a/app/bot/server_backfill.rb
+++ b/app/bot/server_backfill.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ServerBackfill < BaseEvent
   on :ready
 

--- a/app/bot/server_onboarder.rb
+++ b/app/bot/server_onboarder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ServerOnboarder
   WELCOME_MESSAGE = <<~MSG.strip
     👋 Thanks for adding shrkbot!

--- a/app/bot/server_setup.rb
+++ b/app/bot/server_setup.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ServerSetup < BaseEvent
   on :server_create
 

--- a/app/bot/with_connection.rb
+++ b/app/bot/with_connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WithConnection
   def with_connection(&)
     ActiveRecord::Base.connection_pool.with_connection(&)

--- a/app/components/config_page.rb
+++ b/app/components/config_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Components::ConfigPage < Components::Base
   def initialize(icon:, title:, description:, dashboard_path:)
     @icon = icon

--- a/app/components/enable_gate.rb
+++ b/app/components/enable_gate.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Components::EnableGate < Components::Base
   def initialize(enabled:, message:)
     @enabled = enabled

--- a/app/components/logging/config_form.rb
+++ b/app/components/logging/config_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Components::Logging::ConfigForm < Components::Base
   include Phlex::Rails::Helpers::FormWith
 

--- a/app/components/tom_select.rb
+++ b/app/components/tom_select.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Components::TomSelect < Components::Base
   Option = Data.define(:value, :label, :disabled) do
     def self.for(value:, label:, disabled: false)

--- a/app/components/welcomes/config_form.rb
+++ b/app/components/welcomes/config_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Components::Welcomes::ConfigForm < Components::Base
   include Phlex::Rails::Helpers::FormWith
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
   allow_browser versions: :modern
   stale_when_importmap_changes

--- a/app/controllers/concerns/requires_manageable_server.rb
+++ b/app/controllers/concerns/requires_manageable_server.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RequiresManageableServer
   extend ActiveSupport::Concern
 

--- a/app/controllers/concerns/sets_manageable_servers.rb
+++ b/app/controllers/concerns/sets_manageable_servers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SetsManageableServers
   extend ActiveSupport::Concern
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PagesController < ApplicationController
   skip_before_action :require_login
 

--- a/app/controllers/servers/logging_controller.rb
+++ b/app/controllers/servers/logging_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Servers::LoggingController < ApplicationController
   include RequiresManageableServer
 

--- a/app/controllers/servers/plugins_controller.rb
+++ b/app/controllers/servers/plugins_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Servers::PluginsController < ApplicationController
   include RequiresManageableServer
 

--- a/app/controllers/servers/welcomes_controller.rb
+++ b/app/controllers/servers/welcomes_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Servers::WelcomesController < ApplicationController
   include RequiresManageableServer
 

--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ServersController < ApplicationController
   include SetsManageableServers
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class SessionsController < ApplicationController
   skip_before_action :require_login
 

--- a/app/errors/abstract_method_error.rb
+++ b/app/errors/abstract_method_error.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class AbstractMethodError < StandardError
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module ApplicationHelper
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class ApplicationJob < ActiveJob::Base
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationMailer < ActionMailer::Base
   default from: "from@example.com"
   layout "mailer"

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
 end

--- a/app/models/bot_setting.rb
+++ b/app/models/bot_setting.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class BotSetting < ApplicationRecord
   validates :key, presence: true, uniqueness: true
 

--- a/app/models/channel_overwrite.rb
+++ b/app/models/channel_overwrite.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ChannelOverwrite < ApplicationRecord
   belongs_to :server_channel
 

--- a/app/models/loggable_event_catalog.rb
+++ b/app/models/loggable_event_catalog.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class LoggableEventCatalog
   Definition = Data.define(:plugin, :event) do
     def key

--- a/app/models/logging_setting.rb
+++ b/app/models/logging_setting.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class LoggingSetting < ApplicationRecord
   belongs_to :server_configuration
 

--- a/app/models/plugin.rb
+++ b/app/models/plugin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Plugin < ApplicationRecord
   has_many :plugin_activations, dependent: :delete_all
 

--- a/app/models/plugin_activation.rb
+++ b/app/models/plugin_activation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PluginActivation < ApplicationRecord
   belongs_to :server_configuration
   belongs_to :plugin

--- a/app/models/plugin_catalog.rb
+++ b/app/models/plugin_catalog.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PluginCatalog
   Definition = Data.define(:key, :name, :description, :channel_setting) do
     def channel_backed?

--- a/app/models/server_channel.rb
+++ b/app/models/server_channel.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ServerChannel < ApplicationRecord
   belongs_to :server_configuration
   has_many :channel_overwrites, dependent: :delete_all

--- a/app/models/server_configuration.rb
+++ b/app/models/server_configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ServerConfiguration < ApplicationRecord
   has_many :plugin_activations, dependent: :delete_all
   has_many :plugins, through: :plugin_activations

--- a/app/models/server_role.rb
+++ b/app/models/server_role.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ServerRole < ApplicationRecord
   belongs_to :server_configuration
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class User < ApplicationRecord
   validates :discord_id, presence: true, uniqueness: true
   validates :username, presence: true

--- a/app/operations/application_operation.rb
+++ b/app/operations/application_operation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Ops
   class ApplicationOperation
     Result = Struct.new(:success, :value, :errors, :warnings) do

--- a/app/operations/logging/configure.rb
+++ b/app/operations/logging/configure.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Ops
   module Logging
     class Configure < ApplicationOperation

--- a/app/operations/logging/settings/update.rb
+++ b/app/operations/logging/settings/update.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Ops
   module Logging
     module Settings

--- a/app/operations/reminders/create.rb
+++ b/app/operations/reminders/create.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Ops
   module Reminders
     class Create < ApplicationOperation

--- a/app/operations/reminders/delete.rb
+++ b/app/operations/reminders/delete.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Ops
   module Reminders
     class Delete < ApplicationOperation

--- a/app/operations/roles/assignable_roles/add.rb
+++ b/app/operations/roles/assignable_roles/add.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Ops
   module Roles
     module AssignableRoles

--- a/app/operations/roles/assignable_roles/remove.rb
+++ b/app/operations/roles/assignable_roles/remove.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Ops
   module Roles
     module AssignableRoles

--- a/app/operations/roles/messages/repost.rb
+++ b/app/operations/roles/messages/repost.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Ops
   module Roles
     module Messages

--- a/app/operations/roles/sets/create.rb
+++ b/app/operations/roles/sets/create.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Ops
   module Roles
     module Sets

--- a/app/operations/roles/sets/delete.rb
+++ b/app/operations/roles/sets/delete.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Ops
   module Roles
     module Sets

--- a/app/operations/roles/sets/update.rb
+++ b/app/operations/roles/sets/update.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Ops
   module Roles
     module Sets

--- a/app/operations/roles/settings/update.rb
+++ b/app/operations/roles/settings/update.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Ops
   module Roles
     module Settings

--- a/app/operations/server_configuration/channels/disable_plugins.rb
+++ b/app/operations/server_configuration/channels/disable_plugins.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Ops
   module ServerConfiguration
     module Channels

--- a/app/operations/server_configuration/channels/reconcile.rb
+++ b/app/operations/server_configuration/channels/reconcile.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Ops
   module ServerConfiguration
     module Channels

--- a/app/operations/server_configuration/ensure.rb
+++ b/app/operations/server_configuration/ensure.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Ops
   module ServerConfiguration
     class Ensure < ApplicationOperation

--- a/app/operations/server_configuration/plugins/toggle.rb
+++ b/app/operations/server_configuration/plugins/toggle.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Ops
   module ServerConfiguration
     module Plugins

--- a/app/operations/server_configuration/server_channels/sync.rb
+++ b/app/operations/server_configuration/server_channels/sync.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Ops
   module ServerConfiguration
     module ServerChannels

--- a/app/operations/server_configuration/server_roles/sync.rb
+++ b/app/operations/server_configuration/server_roles/sync.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Ops
   module ServerConfiguration
     module ServerRoles

--- a/app/operations/welcomes/configure.rb
+++ b/app/operations/welcomes/configure.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Ops
   module Welcomes
     class Configure < ApplicationOperation

--- a/app/operations/welcomes/settings/update.rb
+++ b/app/operations/welcomes/settings/update.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Ops
   module Welcomes
     module Settings

--- a/app/plugins/reminders/commands/list.rb
+++ b/app/plugins/reminders/commands/list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Reminders
   class List < BaseCommand
     command_name :reminders

--- a/app/plugins/reminders/commands/remind.rb
+++ b/app/plugins/reminders/commands/remind.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Reminders
   class Remind < BaseCommand
     command_name :remind

--- a/app/plugins/reminders/commands/unremind.rb
+++ b/app/plugins/reminders/commands/unremind.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Reminders
   class Unremind < BaseCommand
     command_name :unremind

--- a/app/plugins/reminders/deliver_job.rb
+++ b/app/plugins/reminders/deliver_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Reminders
   class DeliverJob < ApplicationJob
     include ActionView::Helpers::DateHelper

--- a/app/plugins/reminders/duration.rb
+++ b/app/plugins/reminders/duration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Reminders
   module Duration
     UNITS = {"w" => :weeks, "d" => :days, "h" => :hours, "m" => :minutes, "s" => :seconds}.freeze

--- a/app/plugins/reminders/reminder.rb
+++ b/app/plugins/reminders/reminder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Reminders
   class Reminder < ApplicationRecord
     # Namespaced model would otherwise derive an ambiguous table name.

--- a/app/plugins/reminders/sanitizer.rb
+++ b/app/plugins/reminders/sanitizer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Reminders
   module Sanitizer
     ZERO_WIDTH = "​"

--- a/app/plugins/roles/assignable_role.rb
+++ b/app/plugins/roles/assignable_role.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Roles
   class AssignableRole < ApplicationRecord
     self.table_name = "assignable_roles"

--- a/app/plugins/roles/assignment.rb
+++ b/app/plugins/roles/assignment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Roles
   module Assignment
     module_function

--- a/app/plugins/roles/custom_id.rb
+++ b/app/plugins/roles/custom_id.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Roles
   module CustomId
     PREFIX = "roles"

--- a/app/plugins/roles/events/component_handler.rb
+++ b/app/plugins/roles/events/component_handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Roles
   class ComponentHandler < BaseEvent
     private

--- a/app/plugins/roles/events/manage.rb
+++ b/app/plugins/roles/events/manage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Roles
   class Manage < ComponentHandler
     on :button, custom_id: /\Aroles:manage:/

--- a/app/plugins/roles/events/pick.rb
+++ b/app/plugins/roles/events/pick.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Roles
   class Pick < ComponentHandler
     on :button, custom_id: /\Aroles:pick:/

--- a/app/plugins/roles/events/select.rb
+++ b/app/plugins/roles/events/select.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Roles
   class Select < ComponentHandler
     on :string_select, custom_id: /\Aroles:select:/

--- a/app/plugins/roles/message.rb
+++ b/app/plugins/roles/message.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Roles
   module Message
     SECTION = 9

--- a/app/plugins/roles/message_poster.rb
+++ b/app/plugins/roles/message_poster.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Roles
   # Until Phase 8 (Redis config-change trigger), callers invoke this on demand.
   class MessagePoster

--- a/app/plugins/roles/set.rb
+++ b/app/plugins/roles/set.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Roles
   class Set < ApplicationRecord
     self.table_name = "role_sets"

--- a/app/plugins/roles/settings.rb
+++ b/app/plugins/roles/settings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Roles
   class Settings < ApplicationRecord
     self.table_name = "role_settings"

--- a/app/plugins/welcomes/events/member_join.rb
+++ b/app/plugins/welcomes/events/member_join.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Welcomes
   class MemberJoin < BaseEvent
     on :member_join

--- a/app/plugins/welcomes/events/member_leave.rb
+++ b/app/plugins/welcomes/events/member_leave.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Welcomes
   class MemberLeave < BaseEvent
     on :member_leave

--- a/app/plugins/welcomes/message.rb
+++ b/app/plugins/welcomes/message.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Welcomes
   module Message
     module_function

--- a/app/plugins/welcomes/settings.rb
+++ b/app/plugins/welcomes/settings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Welcomes
   class Settings < ApplicationRecord
     self.table_name = "welcome_settings"

--- a/app/presenters/plugin_status.rb
+++ b/app/presenters/plugin_status.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PluginStatus
   Row = Data.define(:key, :enabled, :configured)
 

--- a/app/views/servers/logging/show.rb
+++ b/app/views/servers/logging/show.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Views::Servers::Logging::Show < Views::Base
   def initialize(server_configuration:, user:, enabled:)
     @config = server_configuration

--- a/app/views/servers/welcomes/show.rb
+++ b/app/views/servers/welcomes/show.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Views::Servers::Welcomes::Show < Views::Base
   def initialize(server_configuration:, user:, enabled:)
     @config = server_configuration

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "boot"
 
 require "rails"

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.

--- a/config/ci.rb
+++ b/config/ci.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Run using bin/ci
 
 CI.run do

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Load the Rails application.
 require_relative "application"
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # The test environment is used exclusively to run your application's
 # test suite. You never need to work with it otherwise. Remember that
 # your test database is "scratch space" for the test suite and is wiped

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Pin npm packages by running ./bin/importmap
 
 pin "application"

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Define an application-wide content security policy.

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Configure parameters to be partially matched (e.g. passw matches password) and filtered from the log file.

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :discord,
     ENV["DISCORD_CLIENT_ID"],

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 Rails.application.config.session_store :cookie_store, expire_after: 2.weeks

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This configuration file will be evaluated by Puma. The top-level methods that
 # are invoked here are part of Puma's configuration DSL. For more information
 # about methods provided by the DSL, see https://puma.io/puma/Puma/DSL.html.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/db/migrate/20260615120000_create_server_configurations.rb
+++ b/db/migrate/20260615120000_create_server_configurations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateServerConfigurations < ActiveRecord::Migration[8.1]
   def change
     create_table :server_configurations, id: false do |t|

--- a/db/migrate/20260615120001_create_plugins.rb
+++ b/db/migrate/20260615120001_create_plugins.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreatePlugins < ActiveRecord::Migration[8.1]
   def change
     create_table :plugins, id: false do |t|

--- a/db/migrate/20260615120002_create_plugin_activations.rb
+++ b/db/migrate/20260615120002_create_plugin_activations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreatePluginActivations < ActiveRecord::Migration[8.1]
   def change
     create_table :plugin_activations, id: false do |t|

--- a/db/migrate/20260615120003_create_logging_settings.rb
+++ b/db/migrate/20260615120003_create_logging_settings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateLoggingSettings < ActiveRecord::Migration[8.1]
   def change
     create_table :logging_settings, id: false do |t|

--- a/db/migrate/20260615120004_create_role_settings.rb
+++ b/db/migrate/20260615120004_create_role_settings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateRoleSettings < ActiveRecord::Migration[8.1]
   def change
     create_table :role_settings, id: false do |t|

--- a/db/migrate/20260615120005_create_assignable_roles.rb
+++ b/db/migrate/20260615120005_create_assignable_roles.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateAssignableRoles < ActiveRecord::Migration[8.1]
   def change
     create_table :assignable_roles, id: false do |t|

--- a/db/migrate/20260615120006_create_welcome_settings.rb
+++ b/db/migrate/20260615120006_create_welcome_settings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateWelcomeSettings < ActiveRecord::Migration[8.1]
   def change
     create_table :welcome_settings, id: false do |t|

--- a/db/migrate/20260615120007_create_reminders.rb
+++ b/db/migrate/20260615120007_create_reminders.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateReminders < ActiveRecord::Migration[8.1]
   def change
     create_table :reminders, id: false do |t|

--- a/db/migrate/20260615120008_create_bot_settings.rb
+++ b/db/migrate/20260615120008_create_bot_settings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateBotSettings < ActiveRecord::Migration[8.1]
   def change
     create_table :bot_settings, id: false do |t|

--- a/db/migrate/20260615140000_create_solid_queue_tables.rb
+++ b/db/migrate/20260615140000_create_solid_queue_tables.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateSolidQueueTables < ActiveRecord::Migration[8.1]
   def change
     create_table :solid_queue_blocked_executions do |t|

--- a/db/migrate/20260617191707_optimize_foreign_key_indexes.rb
+++ b/db/migrate/20260617191707_optimize_foreign_key_indexes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class OptimizeForeignKeyIndexes < ActiveRecord::Migration[8.1]
   def change
     add_index :reminders, :user_id

--- a/db/migrate/20260617200000_create_server_channels.rb
+++ b/db/migrate/20260617200000_create_server_channels.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateServerChannels < ActiveRecord::Migration[8.1]
   def change
     create_table :server_channels, id: false do |t|

--- a/db/migrate/20260617200001_create_server_roles.rb
+++ b/db/migrate/20260617200001_create_server_roles.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateServerRoles < ActiveRecord::Migration[8.1]
   def change
     create_table :server_roles, id: false do |t|

--- a/db/migrate/20260617200002_create_channel_overwrites.rb
+++ b/db/migrate/20260617200002_create_channel_overwrites.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateChannelOverwrites < ActiveRecord::Migration[8.1]
   def change
     create_table :channel_overwrites, id: false do |t|

--- a/db/migrate/20260617210000_restructure_roles_for_multiple_sets.rb
+++ b/db/migrate/20260617210000_restructure_roles_for_multiple_sets.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RestructureRolesForMultipleSets < ActiveRecord::Migration[8.1]
   def up
     remove_column :role_settings, :message_id

--- a/db/migrate/20260619120000_remove_plugin_default_enabled.rb
+++ b/db/migrate/20260619120000_remove_plugin_default_enabled.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemovePluginDefaultEnabled < ActiveRecord::Migration[8.1]
   def change
     remove_column :plugins, :default_enabled, :boolean, null: false, default: false

--- a/db/migrate/20260619120001_add_onboarded_at_to_server_configurations.rb
+++ b/db/migrate/20260619120001_add_onboarded_at_to_server_configurations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddOnboardedAtToServerConfigurations < ActiveRecord::Migration[8.1]
   def change
     add_column :server_configurations, :onboarded_at, :datetime

--- a/db/migrate/20260619214046_remove_notify_on_assign_from_role_settings.rb
+++ b/db/migrate/20260619214046_remove_notify_on_assign_from_role_settings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveNotifyOnAssignFromRoleSettings < ActiveRecord::Migration[8.1]
   def change
     remove_column :role_settings, :notify_on_assign, :boolean, null: false, default: false

--- a/db/migrate/20260619220209_remove_label_from_assignable_roles.rb
+++ b/db/migrate/20260619220209_remove_label_from_assignable_roles.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveLabelFromAssignableRoles < ActiveRecord::Migration[8.1]
   def change
     remove_column :assignable_roles, :label, :string

--- a/db/migrate/20260620170456_introduce_activity_log_toggles.rb
+++ b/db/migrate/20260620170456_introduce_activity_log_toggles.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class IntroduceActivityLogToggles < ActiveRecord::Migration[8.1]
   def change
     add_column :logging_settings, :enabled_actions, :jsonb, null: false, default: {}

--- a/db/migrate/20260620184029_add_role_hierarchy_metadata.rb
+++ b/db/migrate/20260620184029_add_role_hierarchy_metadata.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddRoleHierarchyMetadata < ActiveRecord::Migration[8.1]
   def change
     add_column :server_roles, :position, :integer

--- a/db/migrate/20260620185143_create_users.rb
+++ b/db/migrate/20260620185143_create_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateUsers < ActiveRecord::Migration[8.1]
   def change
     create_table :users, id: false do |t|

--- a/db/migrate/20260622120306_add_profile_fields_to_users.rb
+++ b/db/migrate/20260622120306_add_profile_fields_to_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddProfileFieldsToUsers < ActiveRecord::Migration[8.1]
   def change
     add_column :users, :display_name, :string

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 PluginCatalog.all.each do |definition|
   plugin = Plugin.find_or_initialize_by(key: definition.key)
   plugin.update!(name: definition.name, description: definition.description)

--- a/spec/bot/activity_log_spec.rb
+++ b/spec/bot/activity_log_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe ActivityLog do

--- a/spec/bot/announce_modal_spec.rb
+++ b/spec/bot/announce_modal_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe AnnounceModal do

--- a/spec/bot/base_command_spec.rb
+++ b/spec/bot/base_command_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe BaseCommand do

--- a/spec/bot/base_event_spec.rb
+++ b/spec/bot/base_event_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe BaseEvent do

--- a/spec/bot/bot_config_spec.rb
+++ b/spec/bot/bot_config_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe BotConfig do

--- a/spec/bot/bot_presence_spec.rb
+++ b/spec/bot/bot_presence_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe BotPresence do

--- a/spec/bot/bot_registry_spec.rb
+++ b/spec/bot/bot_registry_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe BotRegistry do

--- a/spec/bot/channel_cleanup_spec.rb
+++ b/spec/bot/channel_cleanup_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe ChannelCleanup do

--- a/spec/bot/channel_sync_spec.rb
+++ b/spec/bot/channel_sync_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe ChannelSync do

--- a/spec/bot/command_permissions_spec.rb
+++ b/spec/bot/command_permissions_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe CommandPermissions do

--- a/spec/bot/command_registrar_spec.rb
+++ b/spec/bot/command_registrar_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe CommandRegistrar do

--- a/spec/bot/commands/announce_spec.rb
+++ b/spec/bot/commands/announce_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Commands::Announce do

--- a/spec/bot/commands/donate_spec.rb
+++ b/spec/bot/commands/donate_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Commands::Donate do

--- a/spec/bot/commands/info_spec.rb
+++ b/spec/bot/commands/info_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Commands::Info do

--- a/spec/bot/commands/ping_spec.rb
+++ b/spec/bot/commands/ping_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Commands::Ping do

--- a/spec/bot/config_bus_spec.rb
+++ b/spec/bot/config_bus_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe ConfigBus do

--- a/spec/bot/config_subscriber_spec.rb
+++ b/spec/bot/config_subscriber_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe ConfigSubscriber do

--- a/spec/bot/discord/guild_spec.rb
+++ b/spec/bot/discord/guild_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Discord::Guild do

--- a/spec/bot/discord/truncate_spec.rb
+++ b/spec/bot/discord/truncate_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Discord::Truncate do

--- a/spec/bot/discord/user_guilds_spec.rb
+++ b/spec/bot/discord/user_guilds_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Discord::UserGuilds do

--- a/spec/bot/event_registrar_spec.rb
+++ b/spec/bot/event_registrar_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe EventRegistrar do

--- a/spec/bot/guild_metadata_spec.rb
+++ b/spec/bot/guild_metadata_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe GuildMetadata do

--- a/spec/bot/owner_broadcast_spec.rb
+++ b/spec/bot/owner_broadcast_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe OwnerBroadcast do

--- a/spec/bot/owner_notifier_spec.rb
+++ b/spec/bot/owner_notifier_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe OwnerNotifier do

--- a/spec/bot/role_sync_spec.rb
+++ b/spec/bot/role_sync_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe RoleSync do

--- a/spec/bot/server_backfill_spec.rb
+++ b/spec/bot/server_backfill_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe ServerBackfill do

--- a/spec/bot/server_onboarder_spec.rb
+++ b/spec/bot/server_onboarder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe ServerOnboarder do

--- a/spec/bot/server_setup_spec.rb
+++ b/spec/bot/server_setup_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe ServerSetup do

--- a/spec/bot/with_connection_spec.rb
+++ b/spec/bot/with_connection_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe WithConnection do

--- a/spec/components/badge_spec.rb
+++ b/spec/components/badge_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Components::Badge do

--- a/spec/components/button_spec.rb
+++ b/spec/components/button_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Components::Button do

--- a/spec/components/callout_spec.rb
+++ b/spec/components/callout_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Components::Callout do

--- a/spec/components/card_spec.rb
+++ b/spec/components/card_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Components::Card do

--- a/spec/components/icon_spec.rb
+++ b/spec/components/icon_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Components::Icon do

--- a/spec/components/plugin_tile_spec.rb
+++ b/spec/components/plugin_tile_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Components::PluginTile do

--- a/spec/components/toasts_spec.rb
+++ b/spec/components/toasts_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Components::Toasts do

--- a/spec/components/toggle_spec.rb
+++ b/spec/components/toggle_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Components::Toggle do

--- a/spec/components/tom_select_spec.rb
+++ b/spec/components/tom_select_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Components::TomSelect do

--- a/spec/database_config_spec.rb
+++ b/spec/database_config_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe "database configuration" do

--- a/spec/factories/assignable_roles.rb
+++ b/spec/factories/assignable_roles.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :assignable_role, class: "Roles::AssignableRole" do
     association :role_set

--- a/spec/factories/bot_settings.rb
+++ b/spec/factories/bot_settings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :bot_setting do
     sequence(:key) { |n| "bot_setting_#{n}" }

--- a/spec/factories/channel_overwrites.rb
+++ b/spec/factories/channel_overwrites.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :channel_overwrite do
     association :server_channel

--- a/spec/factories/logging_settings.rb
+++ b/spec/factories/logging_settings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :logging_setting do
     association :server_configuration

--- a/spec/factories/plugin_activations.rb
+++ b/spec/factories/plugin_activations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :plugin_activation do
     association :server_configuration

--- a/spec/factories/plugins.rb
+++ b/spec/factories/plugins.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :plugin do
     sequence(:key) { |n| "plugin_#{n}" }

--- a/spec/factories/reminders.rb
+++ b/spec/factories/reminders.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   # server_id stays nil by default (DM-style); set it explicitly for server reminders.
   factory :reminder, class: "Reminders::Reminder" do

--- a/spec/factories/role_sets.rb
+++ b/spec/factories/role_sets.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :role_set, class: "Roles::Set" do
     association :role_setting

--- a/spec/factories/role_settings.rb
+++ b/spec/factories/role_settings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :role_setting, class: "Roles::Settings" do
     association :server_configuration

--- a/spec/factories/server_channels.rb
+++ b/spec/factories/server_channels.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :server_channel do
     association :server_configuration

--- a/spec/factories/server_configurations.rb
+++ b/spec/factories/server_configurations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :server_configuration do
     sequence(:discord_id) { |n| 100_000 + n }

--- a/spec/factories/server_roles.rb
+++ b/spec/factories/server_roles.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :server_role do
     association :server_configuration

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :user do
     sequence(:discord_id) { |n| 700_000 + n }

--- a/spec/factories/welcome_settings.rb
+++ b/spec/factories/welcome_settings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :welcome_settings, class: "Welcomes::Settings" do
     association :server_configuration

--- a/spec/models/bot_setting_spec.rb
+++ b/spec/models/bot_setting_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe BotSetting do

--- a/spec/models/channel_overwrite_spec.rb
+++ b/spec/models/channel_overwrite_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe ChannelOverwrite do

--- a/spec/models/loggable_event_catalog_spec.rb
+++ b/spec/models/loggable_event_catalog_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe LoggableEventCatalog do

--- a/spec/models/logging_setting_spec.rb
+++ b/spec/models/logging_setting_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe LoggingSetting do

--- a/spec/models/plugin_activation_spec.rb
+++ b/spec/models/plugin_activation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe PluginActivation do

--- a/spec/models/plugin_catalog_spec.rb
+++ b/spec/models/plugin_catalog_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe PluginCatalog do

--- a/spec/models/plugin_spec.rb
+++ b/spec/models/plugin_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Plugin do

--- a/spec/models/server_channel_spec.rb
+++ b/spec/models/server_channel_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe ServerChannel do

--- a/spec/models/server_configuration_spec.rb
+++ b/spec/models/server_configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe ServerConfiguration do

--- a/spec/models/server_role_spec.rb
+++ b/spec/models/server_role_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe ServerRole do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe User do

--- a/spec/operations/application_operation_spec.rb
+++ b/spec/operations/application_operation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Ops::ApplicationOperation do

--- a/spec/operations/logging/configure_spec.rb
+++ b/spec/operations/logging/configure_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Ops::Logging::Configure do

--- a/spec/operations/logging/settings/update_spec.rb
+++ b/spec/operations/logging/settings/update_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Ops::Logging::Settings::Update do

--- a/spec/operations/reminders/create_spec.rb
+++ b/spec/operations/reminders/create_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Ops::Reminders::Create do

--- a/spec/operations/reminders/delete_spec.rb
+++ b/spec/operations/reminders/delete_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Ops::Reminders::Delete do

--- a/spec/operations/roles/assignable_roles/add_spec.rb
+++ b/spec/operations/roles/assignable_roles/add_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Ops::Roles::AssignableRoles::Add do

--- a/spec/operations/roles/assignable_roles/remove_spec.rb
+++ b/spec/operations/roles/assignable_roles/remove_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Ops::Roles::AssignableRoles::Remove do

--- a/spec/operations/roles/messages/repost_spec.rb
+++ b/spec/operations/roles/messages/repost_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Ops::Roles::Messages::Repost do

--- a/spec/operations/roles/sets/create_spec.rb
+++ b/spec/operations/roles/sets/create_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Ops::Roles::Sets::Create do

--- a/spec/operations/roles/sets/delete_spec.rb
+++ b/spec/operations/roles/sets/delete_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Ops::Roles::Sets::Delete do

--- a/spec/operations/roles/sets/update_spec.rb
+++ b/spec/operations/roles/sets/update_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Ops::Roles::Sets::Update do

--- a/spec/operations/roles/settings/update_spec.rb
+++ b/spec/operations/roles/settings/update_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Ops::Roles::Settings::Update do

--- a/spec/operations/server_configuration/channels/disable_plugins_spec.rb
+++ b/spec/operations/server_configuration/channels/disable_plugins_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Ops::ServerConfiguration::Channels::DisablePlugins do

--- a/spec/operations/server_configuration/channels/reconcile_spec.rb
+++ b/spec/operations/server_configuration/channels/reconcile_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Ops::ServerConfiguration::Channels::Reconcile do

--- a/spec/operations/server_configuration/ensure_spec.rb
+++ b/spec/operations/server_configuration/ensure_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Ops::ServerConfiguration::Ensure do

--- a/spec/operations/server_configuration/plugins/toggle_spec.rb
+++ b/spec/operations/server_configuration/plugins/toggle_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Ops::ServerConfiguration::Plugins::Toggle do

--- a/spec/operations/server_configuration/server_channels/sync_spec.rb
+++ b/spec/operations/server_configuration/server_channels/sync_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Ops::ServerConfiguration::ServerChannels::Sync do

--- a/spec/operations/server_configuration/server_roles/sync_spec.rb
+++ b/spec/operations/server_configuration/server_roles/sync_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Ops::ServerConfiguration::ServerRoles::Sync do

--- a/spec/operations/welcomes/configure_spec.rb
+++ b/spec/operations/welcomes/configure_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Ops::Welcomes::Configure do

--- a/spec/operations/welcomes/settings/update_spec.rb
+++ b/spec/operations/welcomes/settings/update_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Ops::Welcomes::Settings::Update do

--- a/spec/plugins/reminders/commands/list_spec.rb
+++ b/spec/plugins/reminders/commands/list_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Reminders::List do

--- a/spec/plugins/reminders/commands/remind_spec.rb
+++ b/spec/plugins/reminders/commands/remind_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Reminders::Remind do

--- a/spec/plugins/reminders/commands/unremind_spec.rb
+++ b/spec/plugins/reminders/commands/unremind_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Reminders::Unremind do

--- a/spec/plugins/reminders/deliver_job_spec.rb
+++ b/spec/plugins/reminders/deliver_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 require "discordrb" # the job sends over REST; load the client so we can stub it
 

--- a/spec/plugins/reminders/duration_spec.rb
+++ b/spec/plugins/reminders/duration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Reminders::Duration do

--- a/spec/plugins/reminders/sanitizer_spec.rb
+++ b/spec/plugins/reminders/sanitizer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Reminders::Sanitizer do

--- a/spec/plugins/roles/assignable_role_spec.rb
+++ b/spec/plugins/roles/assignable_role_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Roles::AssignableRole do

--- a/spec/plugins/roles/assignment_spec.rb
+++ b/spec/plugins/roles/assignment_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Roles::Assignment do

--- a/spec/plugins/roles/custom_id_spec.rb
+++ b/spec/plugins/roles/custom_id_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Roles::CustomId do

--- a/spec/plugins/roles/events/manage_spec.rb
+++ b/spec/plugins/roles/events/manage_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Roles::Manage do

--- a/spec/plugins/roles/events/pick_spec.rb
+++ b/spec/plugins/roles/events/pick_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Roles::Pick do

--- a/spec/plugins/roles/events/select_spec.rb
+++ b/spec/plugins/roles/events/select_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Roles::Select do

--- a/spec/plugins/roles/message_poster_spec.rb
+++ b/spec/plugins/roles/message_poster_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Roles::MessagePoster do

--- a/spec/plugins/roles/message_spec.rb
+++ b/spec/plugins/roles/message_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Roles::Message do

--- a/spec/plugins/roles/set_spec.rb
+++ b/spec/plugins/roles/set_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Roles::Set do

--- a/spec/plugins/roles/settings_spec.rb
+++ b/spec/plugins/roles/settings_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Roles::Settings do

--- a/spec/plugins/welcomes/events/member_join_spec.rb
+++ b/spec/plugins/welcomes/events/member_join_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Welcomes::MemberJoin do

--- a/spec/plugins/welcomes/events/member_leave_spec.rb
+++ b/spec/plugins/welcomes/events/member_leave_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Welcomes::MemberLeave do

--- a/spec/plugins/welcomes/message_spec.rb
+++ b/spec/plugins/welcomes/message_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Welcomes::Message do

--- a/spec/plugins/welcomes/settings_spec.rb
+++ b/spec/plugins/welcomes/settings_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe Welcomes::Settings do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require "spec_helper"
 ENV["RAILS_ENV"] ||= "test"

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe "Authentication", type: :request do

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe "Home", type: :request do

--- a/spec/requests/logging_config_spec.rb
+++ b/spec/requests/logging_config_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe "Logging config", type: :request do

--- a/spec/requests/server_dashboard_spec.rb
+++ b/spec/requests/server_dashboard_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe "Server dashboard", type: :request do

--- a/spec/requests/server_picker_spec.rb
+++ b/spec/requests/server_picker_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe "Server picker", type: :request do

--- a/spec/requests/welcomes_config_spec.rb
+++ b/spec/requests/welcomes_config_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe "Welcomes config", type: :request do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "simplecov"
 require "simplecov-lcov"
 


### PR DESCRIPTION
## Why

In **Ruby 4.0.5** string literals are still *chilled*, not frozen by default — confirmed against the interpreter in-repo:

- `"x".frozen?` → `false`; `str << y` succeeds, only warning under `-W:deprecated` (`literal string will be frozen in the future`).
- With `# frozen_string_literal: true`: `frozen?` → `true`, mutation raises `FrozenError`.

So the magic comment is **not** a no-op yet — it genuinely freezes literals (immutability + allocation savings) and silences the forward-looking deprecation warning. standardrb has no opinion either way (`Style/FrozenStringLiteralComment: Enabled: false`), so the codebase had drifted: a handful of files carried it, most didn't.

This opts in everywhere and makes it uniform.

## What

- Added `# frozen_string_literal: true` (+ the blank line standard's `Layout/EmptyLineAfterMagicComment` wants) to all 258 tracked `.rb` files that lacked it.
- **Excluded** the generated schema dumps (`db/schema.rb`, `db/{cable,cache,queue}_schema.rb`) — the schema dumper rewrites them without the comment on the next migration, so adding it there is self-reverting churn.

## Gates

`rspec` (504 examples, 0 failures — no `FrozenError` fallout), `standardrb`, `active_record_doctor`, `undercover` all green.