### PR TITLE
Redesign Welcomes and Logging config forms

### DIFF
--- a/app/assets/tailwind/tokens.css
+++ b/app/assets/tailwind/tokens.css
@@ -81,6 +81,13 @@
 
   --focus-ring: color-mix(in srgb, var(--brand-500) 45%, transparent);
 
+  --discord-surface: #ffffff;
+  --discord-text: #313338;
+  --discord-muted: #5c5e66;
+  --discord-divider: #e3e5e8;
+  --discord-mention-bg: #e7e9fd;
+  --discord-mention-fg: #444fcd;
+
   --chamfer: 12px;
   --chamfer-sm: 6px;
 
@@ -133,4 +140,11 @@
   --danger-soft: rgba(224, 83, 61, 0.14);
 
   --focus-ring: color-mix(in srgb, #46817a 42%, transparent);
+
+  --discord-surface: #313338;
+  --discord-text: #dbdee1;
+  --discord-muted: #949ba4;
+  --discord-divider: #3f4147;
+  --discord-mention-bg: rgba(88, 101, 242, 0.3);
+  --discord-mention-fg: #c9cdfb;
 }

--- a/app/assets/tailwind/tom-select.css
+++ b/app/assets/tailwind/tom-select.css
@@ -18,6 +18,7 @@
   padding: 0.375rem 0.625rem;
   box-shadow: none;
   gap: 0.375rem;
+  align-items: center;
 }
 .ts-wrapper.single .ts-control { cursor: pointer; }
 .ts-wrapper .ts-control::placeholder,
@@ -37,6 +38,8 @@
   padding: 0.0625rem 0.375rem;
 }
 .ts-wrapper.single .ts-control > .item {
+  display: flex;
+  align-items: center;
   background: none;
   border: none;
   padding: 0;
@@ -63,6 +66,8 @@
 .ts-dropdown .dropdown-input::placeholder { color: var(--text-muted); }
 .ts-dropdown .dropdown-input:focus { outline: none; border-color: var(--accent); }
 .ts-dropdown .option {
+  display: flex;
+  align-items: center;
   padding: 0.5rem 0.75rem;
   border-radius: var(--radius-sm);
   color: var(--text-secondary);

--- a/app/assets/tailwind/tom-select.css
+++ b/app/assets/tailwind/tom-select.css
@@ -13,18 +13,25 @@
 .ts-wrapper.single .ts-control { cursor: pointer; }
 .ts-wrapper .ts-control::placeholder,
 .ts-wrapper .ts-control input::placeholder { color: var(--text-muted); }
-.ts-wrapper.focus .ts-control {
+.ts-wrapper.focus .ts-control,
+.ts-wrapper.plugin-dropdown_input.focus.dropdown-active .ts-control {
   border-color: var(--accent);
   box-shadow: 0 0 0 3px var(--focus-ring);
 }
 .ts-wrapper.disabled .ts-control { opacity: 0.6; cursor: not-allowed; }
 .ts-control input { color: var(--text-primary); }
-.ts-control > .item {
+.ts-wrapper.multi .ts-control > .item {
   background: var(--accent-soft);
   color: var(--accent-soft-fg);
   border: 1px solid var(--accent-soft-bd);
   border-radius: var(--radius-chip);
   padding: 0.0625rem 0.375rem;
+}
+.ts-wrapper.single .ts-control > .item {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--text-primary);
 }
 .ts-dropdown {
   margin-top: 0.25rem;
@@ -35,6 +42,17 @@
   box-shadow: var(--shadow-lg);
   overflow: hidden;
 }
+.ts-dropdown .dropdown-input {
+  margin: 0.375rem;
+  width: calc(100% - 0.75rem);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  background: var(--surface-sunken);
+  color: var(--text-primary);
+  padding: 0.375rem 0.625rem;
+}
+.ts-dropdown .dropdown-input::placeholder { color: var(--text-muted); }
+.ts-dropdown .dropdown-input:focus { outline: none; border-color: var(--accent); }
 .ts-dropdown .option {
   padding: 0.5rem 0.75rem;
   border-radius: var(--radius-sm);

--- a/app/assets/tailwind/tom-select.css
+++ b/app/assets/tailwind/tom-select.css
@@ -1,4 +1,13 @@
 .ts-wrapper { font: inherit; }
+.ts-control,
+.ts-control input,
+.ts-dropdown { font-size: 0.875rem; }
+.ts-prefix {
+  margin-right: 0.3125rem;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 1rem;
+}
 .ts-wrapper.single .ts-control,
 .ts-wrapper.multi .ts-control {
   min-height: 2.5rem;

--- a/app/assets/tailwind/utilities.css
+++ b/app/assets/tailwind/utilities.css
@@ -15,6 +15,18 @@
   clip-path: polygon(0 0, 100% 0, 100% calc(100% - var(--chamfer)), calc(100% - var(--chamfer)) 100%, var(--chamfer) 100%, 0 calc(100% - var(--chamfer)));
 }
 
+.discord-mention {
+  border-radius: 3px;
+  padding: 0 2px;
+  font-weight: 500;
+  background: var(--discord-mention-bg);
+  color: var(--discord-mention-fg);
+}
+.discord-empty-hint {
+  font-style: italic;
+  color: var(--discord-muted);
+}
+
 .app-bar {
   position: relative;
   background: transparent;

--- a/app/assets/tailwind/utilities.css
+++ b/app/assets/tailwind/utilities.css
@@ -28,7 +28,8 @@
 }
 
 .app-bar {
-  position: relative;
+  position: sticky;
+  top: 0;
   background: transparent;
 }
 .app-bar::before {

--- a/app/components/app_shell.rb
+++ b/app/components/app_shell.rb
@@ -21,7 +21,7 @@ class Components::AppShell < Components::Base
   private
 
   def top_bar
-    header(class: "app-bar sticky top-0 z-30 flex h-16 flex-none items-center gap-3 px-5") do
+    header(class: "app-bar z-30 flex h-16 flex-none items-center gap-3 px-5") do
       wordmark
       server_switcher if @current_server
       div(class: "flex-1")

--- a/app/components/discord_message_preview.rb
+++ b/app/components/discord_message_preview.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class Components::DiscordMessagePreview < Components::Base
+  def initialize(label:, channel: nil, bot_name: "shrkbot", messages: [])
+    @label = label
+    @channel = channel
+    @bot_name = bot_name
+    @messages = messages
+  end
+
+  def view_template
+    div(class: "overflow-hidden rounded-lg bg-[var(--discord-surface)] shadow-md") do
+      header
+      @messages.each_with_index do |message, index|
+        div(class: "mx-4 h-px bg-[var(--discord-divider)]") if index.positive?
+        message_row(message)
+      end
+    end
+  end
+
+  private
+
+  def header
+    div(class: "flex items-center gap-2 border-b border-[color:var(--discord-divider)] px-4 py-2.5") do
+      span(class: "text-xs font-semibold text-[color:var(--discord-muted)]") { @label }
+      span(class: "text-xs text-[color:var(--discord-muted)]") { "· #{@channel}" } if @channel
+    end
+  end
+
+  def message_row(message)
+    div(class: "flex items-start gap-3 p-4") do
+      span(class: "size-10 flex-none rounded-full bg-accent-fill")
+      div(class: "min-w-0") do
+        div(class: "mb-1 flex items-center gap-2") do
+          span(class: "text-sm font-semibold text-[color:var(--discord-text)]") { @bot_name }
+          span(class: "rounded bg-accent-fill px-1.5 py-0.5 text-[10px] font-semibold text-white") { "BOT" }
+          span(class: "text-[11px] text-[color:var(--discord-muted)]") { message[:timestamp] } if message[:timestamp]
+        end
+        p(class: "text-sm leading-relaxed text-[color:var(--discord-text)]", data: message[:body_data] || {})
+      end
+    end
+  end
+end

--- a/app/components/logging/config_form.rb
+++ b/app/components/logging/config_form.rb
@@ -31,7 +31,10 @@ class Components::Logging::ConfigForm < Components::Base
         channel_warning_visible_ids_value: visible_channel_ids.to_json
       }
     ) do
-      label(class: "block text-sm font-semibold") { t(".channel.label") }
+      label(class: "block text-sm font-semibold") do
+        plain t(".channel.label")
+        required_marker
+      end
       p(class: "mb-2 mt-0.5 text-sm text-text-secondary") { t(".channel.help") }
       if channels.empty?
         p(class: "text-sm text-text-secondary") { t(".channel.none") }
@@ -49,34 +52,52 @@ class Components::Logging::ConfigForm < Components::Base
   end
 
   def events_card
-    render Components::Card.new do
-      p(class: "text-sm font-semibold") { t(".events.label") }
-      p(class: "mb-3 mt-0.5 text-sm text-text-secondary") { t(".events.help") }
-      div(class: "flex flex-col gap-5") do
-        LoggableEventCatalog.grouped_by_plugin.each do |plugin, definitions|
-          event_group(plugin, definitions)
-        end
+    render Components::Card.new(padding: :none, class: "overflow-hidden") do
+      div(class: "border-b border-border-subtle px-5 py-4") do
+        p(class: "text-sm font-semibold") { t(".events.label") }
+        p(class: "mt-0.5 text-sm text-text-secondary") { t(".events.help") }
+      end
+      LoggableEventCatalog.grouped_by_plugin.each do |plugin, definitions|
+        event_group(plugin, definitions)
       end
     end
   end
 
   def event_group(plugin, definitions)
-    div do
-      p(class: "mb-2 text-[11px] font-semibold uppercase tracking-widest text-text-secondary") { t(".events.plugin.#{plugin}") }
-      div(class: "flex flex-col gap-2") do
+    details(class: "relative border-b border-border-subtle last:border-b-0", open: true, data: {controller: "event-group"}) do
+      summary(class: "flex h-11 cursor-pointer list-none select-none items-center gap-3 bg-surface-sunken px-5 pr-32 [&::-webkit-details-marker]:hidden") do
+        render Components::Icon.new("caret-down", class: "dropdown-chevron size-4 flex-none text-text-muted")
+        span(class: "text-[11px] font-semibold uppercase tracking-widest text-text-secondary") { t(".events.plugin.#{plugin}") }
+      end
+      toggle_all(plugin, definitions)
+      div(class: "divide-y divide-border-subtle") do
         definitions.each { |definition| event_row(definition) }
       end
     end
   end
 
+  def toggle_all(plugin, definitions)
+    label_text = t(".events.toggle_all_label", plugin: t(".events.plugin.#{plugin}"))
+    div(class: "absolute end-5 top-0 flex h-11 items-center gap-2") do
+      span(class: "text-xs text-text-muted") { t(".events.toggle_all") }
+      render Components::Toggle.new(
+        checked: definitions.all? { |definition| @settings.action_enabled?(definition.key) },
+        label: label_text,
+        size: :mini,
+        data: {event_group_target: "all", action: "change->event-group#toggleAll"}
+      )
+    end
+  end
+
   def event_row(definition)
     name = t(".events.event.#{definition.plugin}.#{definition.event}")
-    div(class: "flex items-center justify-between gap-4 rounded-md border border-border-default px-3 py-2") do
-      span(class: "text-sm") { name }
+    div(class: "flex items-center justify-between gap-4 px-5 py-3.5") do
+      span(class: "text-sm font-medium") { name }
       render Components::Toggle.new(
         name: "logging[actions][#{definition.key}]",
         checked: @settings.action_enabled?(definition.key),
-        label: name
+        label: name,
+        data: {event_group_target: "event", action: "change->event-group#sync"}
       )
     end
   end
@@ -89,6 +110,10 @@ class Components::Logging::ConfigForm < Components::Base
     ) do
       plain t(".channel.visible_warning")
     end
+  end
+
+  def required_marker
+    span(class: "ml-1 text-xs font-semibold text-danger", title: t(".channel.required")) { "*" }
   end
 
   def visible_channel?

--- a/app/components/logging/config_form.rb
+++ b/app/components/logging/config_form.rb
@@ -44,7 +44,8 @@ class Components::Logging::ConfigForm < Components::Base
           options: channels,
           selected: @settings.channel_id,
           placeholder: t(".channel.placeholder"),
-          include_blank: true
+          include_blank: true,
+          prefix: "#"
         )
       end
       visibility_warning
@@ -146,7 +147,7 @@ class Components::Logging::ConfigForm < Components::Base
 
   def channels
     @channels ||= @config.server_channels.text.map do |channel|
-      Components::TomSelect::Option.for(value: channel.discord_id, label: "# #{channel.name}")
+      Components::TomSelect::Option.for(value: channel.discord_id, label: channel.name)
     end
   end
 end

--- a/app/components/logging/config_form.rb
+++ b/app/components/logging/config_form.rb
@@ -64,13 +64,20 @@ class Components::Logging::ConfigForm < Components::Base
   end
 
   def event_group(plugin, definitions)
-    details(class: "relative border-b border-border-subtle last:border-b-0", open: true, data: {controller: "event-group"}) do
-      summary(class: "flex h-11 cursor-pointer list-none select-none items-center gap-3 bg-surface-sunken px-5 pr-32 [&::-webkit-details-marker]:hidden") do
+    details(
+      class: "relative border-b border-border-subtle last:border-b-0",
+      open: true,
+      data: {controller: "dropdown event-group", dropdown_dismiss_on_outside_value: false}
+    ) do
+      summary(
+        class: "flex h-11 cursor-pointer list-none select-none items-center gap-3 bg-surface-sunken px-5 pr-32 [&::-webkit-details-marker]:hidden",
+        data: {action: "click->dropdown#toggle"}
+      ) do
         render Components::Icon.new("caret-down", class: "dropdown-chevron size-4 flex-none text-text-muted")
         span(class: "text-[11px] font-semibold uppercase tracking-widest text-text-secondary") { t(".events.plugin.#{plugin}") }
       end
       toggle_all(plugin, definitions)
-      div(class: "divide-y divide-border-subtle") do
+      div(class: "dropdown-menu divide-y divide-border-subtle", data: {dropdown_target: "menu"}) do
         definitions.each { |definition| event_row(definition) }
       end
     end

--- a/app/components/logging/config_form.rb
+++ b/app/components/logging/config_form.rb
@@ -64,31 +64,42 @@ class Components::Logging::ConfigForm < Components::Base
   end
 
   def event_group(plugin, definitions)
-    details(
-      class: "relative border-b border-border-subtle last:border-b-0",
-      open: true,
-      data: {controller: "dropdown event-group", dropdown_dismiss_on_outside_value: false}
-    ) do
-      summary(
-        class: "flex h-11 cursor-pointer list-none select-none items-center gap-3 bg-surface-sunken px-5 pr-32 [&::-webkit-details-marker]:hidden",
-        data: {action: "click->dropdown#toggle"}
+    enabled = definitions.count { |definition| @settings.action_enabled?(definition.key) }
+    div(class: "relative border-b border-border-subtle last:border-b-0", data: {controller: "event-group"}) do
+      details(
+        open: true,
+        data: {controller: "dropdown", dropdown_dismiss_on_outside_value: false}
       ) do
-        render Components::Icon.new("caret-down", class: "dropdown-chevron size-4 flex-none text-text-muted")
-        span(class: "text-[11px] font-semibold uppercase tracking-widest text-text-secondary") { t(".events.plugin.#{plugin}") }
+        summary(
+          class: "flex h-11 cursor-pointer list-none select-none items-center gap-3 bg-surface-sunken px-5 pr-36 [&::-webkit-details-marker]:hidden",
+          data: {action: "click->dropdown#toggle"}
+        ) do
+          render Components::Icon.new("caret-down", class: "dropdown-chevron size-4 flex-none text-text-muted")
+          span(class: "text-[11px] font-semibold uppercase tracking-widest text-text-secondary") { t(".events.plugin.#{plugin}") }
+          event_count(enabled, definitions.size)
+        end
+        div(class: "dropdown-menu divide-y divide-border-subtle", data: {dropdown_target: "menu"}) do
+          definitions.each { |definition| event_row(definition) }
+        end
       end
-      toggle_all(plugin, definitions)
-      div(class: "dropdown-menu divide-y divide-border-subtle", data: {dropdown_target: "menu"}) do
-        definitions.each { |definition| event_row(definition) }
-      end
+      toggle_all(plugin, enabled == definitions.size)
     end
   end
 
-  def toggle_all(plugin, definitions)
+  def event_count(enabled, total)
+    span(class: "ml-auto whitespace-nowrap text-xs text-text-muted") do
+      span(data: {event_group_target: "count"}) { "#{enabled}/#{total}" }
+      whitespace
+      plain t(".events.enabled_count")
+    end
+  end
+
+  def toggle_all(plugin, all_enabled)
     label_text = t(".events.toggle_all_label", plugin: t(".events.plugin.#{plugin}"))
     div(class: "absolute end-5 top-0 flex h-11 items-center gap-2") do
       span(class: "text-xs text-text-muted") { t(".events.toggle_all") }
       render Components::Toggle.new(
-        checked: definitions.all? { |definition| @settings.action_enabled?(definition.key) },
+        checked: all_enabled,
         label: label_text,
         size: :mini,
         data: {event_group_target: "all", action: "change->event-group#toggleAll"}

--- a/app/components/toggle.rb
+++ b/app/components/toggle.rb
@@ -12,8 +12,8 @@ class Components::Toggle < Components::Base
     mini: "relative h-[18px] w-8 after:size-3.5 peer-checked:after:translate-x-3.5"
   }.freeze
 
-  def initialize(name:, checked:, label:, size: :md, url: nil, submit_on_change: false, dom_id: nil, disabled: false, data: {})
-    @name = name.to_s
+  def initialize(checked:, label:, name: nil, size: :md, url: nil, submit_on_change: false, dom_id: nil, disabled: false, data: {})
+    @name = name&.to_s
     @checked = checked
     @label = label
     @size = size
@@ -37,7 +37,7 @@ class Components::Toggle < Components::Base
   private
 
   def switch
-    input(type: "hidden", name: @name, value: "0", autocomplete: "off") unless @disabled
+    input(type: "hidden", name: @name, value: "0", autocomplete: "off") if @name && !@disabled
     label(class: "inline-flex items-center #{@disabled ? "cursor-not-allowed opacity-60" : "cursor-pointer"}", aria_label: @label) do
       input(
         type: "checkbox",

--- a/app/components/tom_select.rb
+++ b/app/components/tom_select.rb
@@ -7,12 +7,13 @@ class Components::TomSelect < Components::Base
     end
   end
 
-  def initialize(name:, options:, selected: nil, placeholder: nil, include_blank: false, dom_id: nil)
+  def initialize(name:, options:, selected: nil, placeholder: nil, include_blank: false, prefix: nil, dom_id: nil)
     @name = name
     @options = options
     @selected = selected
     @placeholder = placeholder
     @include_blank = include_blank
+    @prefix = prefix
     @dom_id = dom_id
   end
 
@@ -30,6 +31,7 @@ class Components::TomSelect < Components::Base
   def data
     attrs = {controller: "tom-select"}
     attrs[:tom_select_placeholder_value] = @placeholder if @placeholder
+    attrs[:tom_select_prefix_value] = @prefix if @prefix
     attrs
   end
 

--- a/app/components/welcomes/config_form.rb
+++ b/app/components/welcomes/config_form.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class Components::Welcomes::ConfigForm < Components::Base
-  FIELD = "w-full rounded-control border border-border-default bg-surface-card px-3 py-2 text-sm text-text-primary " \
-    "placeholder:text-text-secondary focus:border-accent focus:outline-none focus:ring-3 focus:ring-[var(--focus-ring)]"
+  FIELD = "w-full resize-none rounded-control border-[1.5px] border-border-strong bg-surface-card px-3 py-2 " \
+    "text-sm text-text-primary placeholder:text-text-secondary focus:border-accent focus:outline-none " \
+    "focus:ring-3 focus:ring-[var(--focus-ring)]"
 
   def initialize(server_configuration:, enable_error: nil)
     @config = server_configuration
@@ -14,7 +15,9 @@ class Components::Welcomes::ConfigForm < Components::Base
     div(id: "welcomes-config", class: "flex flex-col gap-5", data: {controller: "welcome-preview"}) do
       enable_error_callout
       channel_card
-      messages_card
+      message_cards
+      placeholder_help
+      preview
     end
   end
 
@@ -28,7 +31,10 @@ class Components::Welcomes::ConfigForm < Components::Base
 
   def channel_card
     render Components::Card.new do
-      label(class: "block text-sm font-semibold") { t(".channel.label") }
+      label(class: "block text-sm font-semibold") do
+        plain t(".channel.label")
+        required_marker
+      end
       p(class: "mb-2 mt-0.5 text-sm text-text-secondary") { t(".channel.help") }
       if channels.empty?
         p(class: "text-sm text-text-secondary") { t(".channel.none") }
@@ -44,18 +50,15 @@ class Components::Welcomes::ConfigForm < Components::Base
     end
   end
 
-  def messages_card
-    render Components::Card.new do
-      message_field(:join_message, @settings.join_message)
-      div(class: "my-5 border-t border-border-default")
-      message_field(:leave_message, @settings.leave_message)
-      placeholder_help
-      preview
+  def message_cards
+    div(class: "grid gap-5 sm:grid-cols-2") do
+      message_card(:join_message, @settings.join_message)
+      message_card(:leave_message, @settings.leave_message)
     end
   end
 
-  def message_field(name, value)
-    div do
+  def message_card(name, value)
+    render Components::Card.new do
       label(class: "block text-sm font-semibold") { t(".#{name}.label") }
       p(class: "mb-2 mt-0.5 text-sm text-text-secondary") { t(".#{name}.help") }
       textarea(
@@ -65,45 +68,59 @@ class Components::Welcomes::ConfigForm < Components::Base
         placeholder: t(".#{name}.placeholder"),
         data: {welcome_preview_target: camel(name), action: "input->welcome-preview#render"}
       ) { value }
+      info_line(name)
+    end
+  end
+
+  def info_line(name)
+    p(class: "mt-1.5 flex items-start gap-1 text-xs text-text-secondary") do
+      render Components::Icon.new("info", class: "mt-0.5 size-3 flex-none text-accent")
+      span do
+        code(class: "font-mono") { "{user}" }
+        whitespace
+        plain t(".#{name}.info")
+      end
     end
   end
 
   def placeholder_help
-    div(class: "mt-4 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-text-secondary") do
-      span { t(".placeholders.intro") }
-      placeholder_chip("{user}", t(".placeholders.user"))
-      placeholder_chip("{membercount}", t(".placeholders.membercount"))
+    render Components::Callout.new(variant: :neutral) do
+      span(class: "font-semibold") { t(".placeholders.intro") }
+      whitespace
+      placeholder_chip("{user}")
+      whitespace
+      placeholder_chip("{membercount}")
     end
   end
 
-  def placeholder_chip(token, description)
-    span(class: "inline-flex items-center gap-1.5") do
-      code(class: "rounded bg-surface-sunken px-1.5 py-0.5 font-mono text-accent-soft-fg") { token }
-      span { description }
-    end
+  def placeholder_chip(token)
+    code(class: "rounded bg-surface-sunken px-1.5 py-0.5 font-mono text-xs text-accent-soft-fg") { token }
   end
 
   def preview
-    div(class: "mt-5") do
-      p(class: "mb-2 text-[11px] font-semibold uppercase tracking-widest text-text-secondary") { t(".preview.label") }
-      div(class: "flex flex-col gap-3 rounded-md bg-surface-sunken p-4") do
-        preview_row(:join)
-        preview_row(:leave)
-      end
-    end
+    render Components::DiscordMessagePreview.new(
+      label: t(".preview.label"),
+      channel: preview_channel,
+      messages: [
+        {timestamp: t(".preview.timestamp"), body_data: preview_body_data(:join)},
+        {body_data: preview_body_data(:leave)}
+      ]
+    )
   end
 
-  def preview_row(kind)
-    div(class: "flex items-start gap-3") do
-      span(class: "flex size-9 flex-none items-center justify-center rounded-full bg-accent-fill text-xs font-bold text-white") { "n" }
-      div(class: "min-w-0") do
-        p(class: "text-xs font-semibold text-text-secondary") { t(".preview.#{kind}") }
-        p(
-          class: "text-sm text-text-primary",
-          data: {welcome_preview_target: "#{kind}Output", empty_hint: t(".preview.empty")}
-        )
-      end
-    end
+  def preview_body_data(kind)
+    {welcome_preview_target: "#{kind}Output", empty_hint: t(".preview.empty")}
+  end
+
+  def required_marker
+    span(class: "ml-1 text-xs font-semibold text-danger", title: t(".channel.required")) { "*" }
+  end
+
+  def preview_channel
+    return unless @settings.channel_id
+
+    name = @config.server_channels.find_by(discord_id: @settings.channel_id)&.name
+    "# #{name}" if name
   end
 
   def channels

--- a/app/components/welcomes/config_form.rb
+++ b/app/components/welcomes/config_form.rb
@@ -44,7 +44,8 @@ class Components::Welcomes::ConfigForm < Components::Base
           options: channels,
           selected: @settings.channel_id,
           placeholder: t(".channel.placeholder"),
-          include_blank: true
+          include_blank: true,
+          prefix: "#"
         )
       end
     end
@@ -131,7 +132,7 @@ class Components::Welcomes::ConfigForm < Components::Base
 
   def channels
     @channels ||= @config.server_channels.text.map do |channel|
-      Components::TomSelect::Option.for(value: channel.discord_id, label: "# #{channel.name}")
+      Components::TomSelect::Option.for(value: channel.discord_id, label: channel.name)
     end
   end
 

--- a/app/components/welcomes/config_form.rb
+++ b/app/components/welcomes/config_form.rb
@@ -87,14 +87,20 @@ class Components::Welcomes::ConfigForm < Components::Base
     render Components::Callout.new(variant: :neutral) do
       span(class: "font-semibold") { t(".placeholders.intro") }
       whitespace
-      placeholder_chip("{user}")
+      placeholder_chip("{user}", t(".placeholders.user"))
       whitespace
-      placeholder_chip("{membercount}")
+      placeholder_chip("{membercount}", t(".placeholders.membercount"))
     end
   end
 
-  def placeholder_chip(token)
-    code(class: "rounded bg-surface-sunken px-1.5 py-0.5 font-mono text-xs text-accent-soft-fg") { token }
+  def placeholder_chip(token, description)
+    render Components::Tooltip.new(text: description) do
+      code(
+        tabindex: "0",
+        class: "cursor-help rounded bg-surface-sunken px-1.5 py-0.5 font-mono text-xs text-accent-soft-fg " \
+          "focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]"
+      ) { token }
+    end
   end
 
   def preview

--- a/app/javascript/controllers/dropdown_controller.js
+++ b/app/javascript/controllers/dropdown_controller.js
@@ -7,10 +7,8 @@ import { Controller } from "@hotwired/stimulus"
 //     <summary data-action="click->dropdown#toggle">…</summary>
 //     <div data-dropdown-target="menu" class="dropdown-menu">…</div>
 //   </details>
-// A transient menu dismisses on outside-click/Escape (the default); a
-// persistent disclosure (e.g. an accordion section) sets
-// data-dropdown-dismiss-on-outside-value="false" so it only closes via its own
-// summary.
+// dismissOnOutside=false keeps a persistent disclosure (an accordion section)
+// open until its own summary closes it, unlike a transient menu.
 export default class extends Controller {
   static targets = ["menu"]
   static values = {dismissOnOutside: {type: Boolean, default: true}}

--- a/app/javascript/controllers/dropdown_controller.js
+++ b/app/javascript/controllers/dropdown_controller.js
@@ -1,16 +1,23 @@
 import { Controller } from "@hotwired/stimulus"
 
-// A <details> dropdown that animates open and closed. The panel fades in via
-// CSS on [open]; closing is intercepted here so the exit animation can finish
-// before the panel is removed. Wire it up as:
+// A <details> that animates open and closed. The panel fades in via CSS on
+// [open]; closing is intercepted here so the exit animation can finish before
+// the panel is removed. Wire it up as:
 //   <details data-controller="dropdown">
 //     <summary data-action="click->dropdown#toggle">…</summary>
 //     <div data-dropdown-target="menu" class="dropdown-menu">…</div>
 //   </details>
+// A transient menu dismisses on outside-click/Escape (the default); a
+// persistent disclosure (e.g. an accordion section) sets
+// data-dropdown-dismiss-on-outside-value="false" so it only closes via its own
+// summary.
 export default class extends Controller {
   static targets = ["menu"]
+  static values = {dismissOnOutside: {type: Boolean, default: true}}
 
   connect() {
+    if (!this.dismissOnOutsideValue) return
+
     this.closeOutside = (e) => {
       if (!this.element.contains(e.target)) this.close()
     }
@@ -22,6 +29,8 @@ export default class extends Controller {
   }
 
   disconnect() {
+    if (!this.closeOutside) return
+
     document.removeEventListener("click", this.closeOutside)
     document.removeEventListener("keydown", this.closeOnEscape)
   }

--- a/app/javascript/controllers/event_group_controller.js
+++ b/app/javascript/controllers/event_group_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["all", "event"]
+
+  toggleAll() {
+    this.eventTargets.forEach((checkbox) => {
+      checkbox.checked = this.allTarget.checked
+    })
+  }
+
+  sync() {
+    this.allTarget.checked = this.eventTargets.every((checkbox) => checkbox.checked)
+  }
+}

--- a/app/javascript/controllers/event_group_controller.js
+++ b/app/javascript/controllers/event_group_controller.js
@@ -1,15 +1,27 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["all", "event"]
+  static targets = ["all", "event", "count"]
+
+  connect() {
+    this.refresh()
+  }
 
   toggleAll() {
     this.eventTargets.forEach((checkbox) => {
       checkbox.checked = this.allTarget.checked
     })
+    this.refresh()
   }
 
   sync() {
-    this.allTarget.checked = this.eventTargets.every((checkbox) => checkbox.checked)
+    this.refresh()
+  }
+
+  refresh() {
+    const total = this.eventTargets.length
+    const enabled = this.eventTargets.filter((checkbox) => checkbox.checked).length
+    this.allTarget.checked = enabled === total
+    if (this.hasCountTarget) this.countTarget.textContent = `${enabled}/${total}`
   }
 }

--- a/app/javascript/controllers/tom_select_controller.js
+++ b/app/javascript/controllers/tom_select_controller.js
@@ -8,7 +8,8 @@ export default class extends Controller {
     this.select = new TomSelect(this.element, {
       placeholder: this.placeholderValue || undefined,
       allowEmptyOption: false,
-      maxOptions: null
+      maxOptions: null,
+      plugins: ["dropdown_input"]
     })
   }
 

--- a/app/javascript/controllers/tom_select_controller.js
+++ b/app/javascript/controllers/tom_select_controller.js
@@ -2,15 +2,26 @@ import { Controller } from "@hotwired/stimulus"
 import TomSelect from "tom-select"
 
 export default class extends Controller {
-  static values = { placeholder: String }
+  static values = { placeholder: String, prefix: String }
 
   connect() {
     this.select = new TomSelect(this.element, {
       placeholder: this.placeholderValue || undefined,
       allowEmptyOption: false,
       maxOptions: null,
-      plugins: ["dropdown_input"]
+      plugins: ["dropdown_input"],
+      render: this.prefixValue ? this.prefixRenderers() : {}
     })
+  }
+
+  prefixRenderers() {
+    const prefix = this.prefixValue
+    const row = (data, escape) => {
+      const label = escape(data.text)
+      if (!data.value) return `<div>${label}</div>`
+      return `<div><span class="ts-prefix">${escape(prefix)}</span>${label}</div>`
+    }
+    return { option: row, item: row }
   }
 
   disconnect() {

--- a/app/javascript/controllers/welcome_preview_controller.js
+++ b/app/javascript/controllers/welcome_preview_controller.js
@@ -19,7 +19,7 @@ export default class extends Controller {
 
     if (!input.value.trim()) {
       const hint = document.createElement("span")
-      hint.className = "italic text-ink-500"
+      hint.className = "discord-empty-hint"
       hint.textContent = output.dataset.emptyHint
       output.append(hint)
       return
@@ -47,7 +47,7 @@ export default class extends Controller {
 
     if (kind === "join") {
       const pill = document.createElement("span")
-      pill.className = "rounded bg-brand-100 px-1 font-medium text-accent-soft-fg"
+      pill.className = "discord-mention"
       pill.textContent = "@" + SAMPLE.user
       return pill
     }

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -83,6 +83,8 @@ en:
           placeholder: "{user} has left the server."
         placeholders:
           intro: 'Placeholders:'
+          membercount: Expands to the server's current member count.
+          user: Expands to the member who joined or left.
         preview:
           empty: This message is off.
           label: Live preview

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -29,6 +29,7 @@ en:
           visible_warning: Everyone can see this channel, so the moderation log would
             be public.
         events:
+          enabled_count: enabled
           event:
             roles:
               role_gained: Member gained a role

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -25,6 +25,7 @@ en:
           label: Channel
           none: No channels have synced yet. shrkbot needs to be in the server first.
           placeholder: Choose a channel
+          required: This setting is required to enable the plugin.
           visible_warning: Everyone can see this channel, so the moderation log would
             be public.
         events:
@@ -36,6 +37,8 @@ en:
           label: Logged events
           plugin:
             roles: Roles
+          toggle_all: Toggle all
+          toggle_all_label: Toggle all %{plugin} events
     plugin_row:
       configure: Configure
       needs_setup_hint: Complete setup before enabling this plugin.
@@ -66,23 +69,23 @@ en:
           label: Channel
           none: No channels have synced yet. shrkbot needs to be in the server first.
           placeholder: Choose a channel
+          required: This setting is required to enable the plugin.
         join_message:
           help: Sent when a member joins. Leave empty to send nothing.
+          info: is a Discord mention in join messages.
           label: Join message
           placeholder: Welcome {user}, you're member {membercount}!
         leave_message:
           help: Sent when a member leaves. Leave empty to send nothing.
+          info: is a plain @username in leave messages.
           label: Leave message
           placeholder: "{user} has left the server."
         placeholders:
           intro: 'Placeholders:'
-          membercount: the server's member count
-          user: the member
         preview:
           empty: This message is off.
-          join: A new member joined
-          label: Preview
-          leave: A member left
+          label: Live preview
+          timestamp: Today
   servers:
     logging:
       saved: Logging settings saved.

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -97,9 +97,32 @@ template (`action.turbo_stream.erb`, see architecture.md "Web"): the template's
 `turbo_stream.replace`/`append` lines render our Phlex components as the content, so
 the stream markup stays in the view layer. Success re-renders the control plus a
 toast; a config-form failure re-renders the form region with inline errors — just
-more `turbo_stream.*` lines. The remaining config-form controls
-(segmented control, enable-gate, Tom Select wrapper) are built with the pages that
-consume them.
+more `turbo_stream.*` lines. The one config-form control still unbuilt (the
+segmented control) ships with the Roles page that consumes it.
+
+## Config pages (the gated layout)
+
+A plugin config page is assembled by **`Components::ConfigPage`**, not by the
+per-plugin form. ConfigPage owns the single gated `form_with` and renders, in
+order: a header (`PluginTile` + title + description + an inline **enable
+`Toggle`**), an `EnableGate` wrapping the body, and the Save button. The
+per-plugin `Components::<Plugin>::ConfigForm` is **body-only** — it renders just
+the cards, with no form tag and no enable control of its own — and its root `div`
+carries the `#<plugin>-config` id that the Turbo Stream replaces on a failed save,
+so inline errors re-render in place. Keep that split when adding a page: layout in
+ConfigPage, fields in the body form.
+
+The enable toggle is **staged, not instant**: flipping it stages an `enabled`
+field in the same batch as the rest of the form, and nothing persists until Save —
+unlike the dashboard's standalone plugin toggle. The `enable-gate` Stimulus
+controller reveals or re-veils the body client-side as the toggle flips.
+`Components::EnableGate` is the full-page overlay (translucent blurred scrim +
+centred card with a lock icon and an "Enable …" button) shown over the body while
+the plugin is off. A setting the plugin can't be enabled without (the channel
+picker on Welcomes/Logging) carries a danger `*` marker next to its label; the
+operation enforces the requirement server-side and the form re-renders with the
+inline error if it's missing. ConfigPage is gated-only today — the non-gated case
+(Reminders) will add the plain path when that page lands.
 
 ## Core components
 

--- a/spec/components/discord_message_preview_spec.rb
+++ b/spec/components/discord_message_preview_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::DiscordMessagePreview do
+  subject(:html) { described_class.new(**options).call }
+
+  let(:options) do
+    {
+      label: "Live preview",
+      channel: "# welcome",
+      messages: [
+        {timestamp: "Today", body_data: {welcome_preview_target: "joinOutput", empty_hint: "off"}},
+        {body_data: {welcome_preview_target: "leaveOutput", empty_hint: "off"}}
+      ]
+    }
+  end
+
+  it "drives its colours off theme-aware Discord variables, never hardcoded hex" do
+    expect(html).to include("bg-[var(--discord-surface)]").and include("text-[color:var(--discord-text)]")
+    expect(html).not_to include("#313338")
+  end
+
+  it "renders the channel header and one row per message with the bot identity" do
+    expect(html).to include("Live preview").and include("· # welcome")
+    expect(html.scan("BOT").size).to eq(2)
+    expect(html).to include("shrkbot")
+  end
+
+  it "passes each message's body data through to its output paragraph" do
+    expect(html).to include('data-welcome-preview-target="joinOutput"')
+    expect(html).to include('data-welcome-preview-target="leaveOutput"')
+    expect(html).to include('data-empty-hint="off"')
+  end
+
+  it "shows a timestamp only where one is given" do
+    expect(html.scan("Today").size).to eq(1)
+  end
+
+  context "without a channel" do
+    let(:options) { {label: "Live preview", messages: []} }
+
+    it "omits the channel suffix" do
+      expect(html).not_to include("·")
+    end
+  end
+end

--- a/spec/components/toggle_spec.rb
+++ b/spec/components/toggle_spec.rb
@@ -26,6 +26,16 @@ RSpec.describe Components::Toggle do
     end
   end
 
+  context "as a nameless control (a toggle-all that drives other fields, not a field itself)" do
+    subject(:html) { Components::Toggle.new(checked: false, label: "Toggle all Roles events").call }
+
+    it "renders no name attribute and no hidden fallback, so it never posts a stray param" do
+      expect(html).not_to include("name=")
+      expect(html).not_to include('type="hidden"')
+      expect(html).to include('aria-label="Toggle all Roles events"')
+    end
+  end
+
   context "at the mini size" do
     subject(:html) { Components::Toggle.new(name: "logging[all][roles]", checked: false, label: "Toggle all Roles events", size: :mini).call }
 

--- a/spec/components/tom_select_spec.rb
+++ b/spec/components/tom_select_spec.rb
@@ -35,6 +35,22 @@ RSpec.describe Components::TomSelect do
     expect(html).to include('value="222"').and include("disabled")
   end
 
+  context "with a prefix adornment (the channel picker's #)" do
+    subject(:prefixed) do
+      described_class.new(
+        name: "welcomes[channel_id]",
+        options: [Components::TomSelect::Option.for(value: 111, label: "general")],
+        prefix: "#"
+      ).call
+    end
+
+    it "passes the prefix to the controller and keeps it out of the option label" do
+      expect(prefixed).to include('data-tom-select-prefix-value="#"')
+      expect(prefixed).to include(">general<")
+      expect(prefixed).not_to include("# general")
+    end
+  end
+
   context "without a placeholder or blank option" do
     subject(:plain) do
       described_class.new(

--- a/spec/requests/welcomes_config_spec.rb
+++ b/spec/requests/welcomes_config_spec.rb
@@ -81,8 +81,8 @@ RSpec.describe "Welcomes config", type: :request do
           create(:server_channel, server_configuration: config, name: "general", discord_id: 111, channel_type: 0)
           create(:server_channel, server_configuration: config, name: "lounge", discord_id: 222, channel_type: 2)
           get server_welcomes_path(guild.id)
-          expect(response.body).to include("# general")
-          expect(response.body).not_to include("# lounge")
+          expect(response.body).to include(">general<")
+          expect(response.body).not_to include("lounge")
         end
       end
 

--- a/spec/requests/welcomes_config_spec.rb
+++ b/spec/requests/welcomes_config_spec.rb
@@ -61,7 +61,20 @@ RSpec.describe "Welcomes config", type: :request do
           expect(response).to have_http_status(:ok)
           expect(response.body).to include("Welcomes")
           expect(response.body).to include("Join message")
-          expect(response.body).to include("Preview")
+          expect(response.body).to include("Live preview")
+        end
+
+        it "labels the live preview with the saved channel" do
+          create(:server_channel, server_configuration: config, name: "general", discord_id: 111)
+          config.welcome_settings.update!(channel_id: 111)
+          get server_welcomes_path(guild.id)
+          expect(response.body).to include("# general")
+        end
+
+        it "renders without a preview channel label when the saved channel no longer exists" do
+          config.welcome_settings.update!(channel_id: 999)
+          get server_welcomes_path(guild.id)
+          expect(response).to have_http_status(:ok)
         end
 
         it "offers only text channels in the picker" do

--- a/spec/vendor/tom_select_bundle_spec.rb
+++ b/spec/vendor/tom_select_bundle_spec.rb
@@ -24,4 +24,8 @@ RSpec.describe "Vendored Tom Select bundle" do
   it "exposes Tom Select as a default export" do
     expect(Rails.root.join("vendor/javascript/tom-select.js").read).to include("as default}")
   end
+
+  it "bundles the dropdown_input plugin the channel picker relies on for its search field" do
+    expect(Rails.root.join("vendor/javascript/tom-select.js").read).to include("dropdown_input")
+  end
 end


### PR DESCRIPTION
Step 3 "part 2" of the design-system redesign — the existing-screen polish for the two config forms.

## Welcomes (`app/components/welcomes/config_form.rb`)
- Join/leave message cards now sit **side-by-side** (`grid sm:grid-cols-2`).
- The channel field carries a danger `*` **required marker** (the op already enforces it server-side; the form shows the inline error if it's missing).
- **Per-field info lines** spell out the `{user}` difference: a Discord mention on join, a plain `@username` on leave.
- The preview is now `Components::DiscordMessagePreview` — a real-Discord-message look (avatar, BOT badge, channel header) that **flips with our light/dark theme** using Discord's own values, driven by new `--discord-*` tokens. No Discord hex is hardcoded in a view or in JS; the `welcome_preview` controller's old `text-ink-500`/`bg-brand-100` are re-tokened to `.discord-empty-hint`/`.discord-mention` utility classes.

## Logging (`app/components/logging/config_form.rb`)
- Events are grouped into **collapsible per-plugin sections** using native `<details>` (no JS for the disclosure; the caret reuses the existing reduced-motion-guarded `dropdown-chevron`).
- Each group header has a `Toggle(size: :mini)` **"toggle all"**. It's a *nameless* control (so it posts no stray param); a small `event-group` Stimulus controller flips all rows and keeps the header switch in sync.

## Docs
- Documented the **gated-ConfigPage** convention in `docs/design-system.md` (ConfigPage owns the form + header + gate + save; body-only ConfigForms are the Turbo target; staged enable; required-setting marker).

## Boyscouting
- `Components::Toggle` gained an optional `name:` (control-only toggles render no hidden fallback / name attr) — small, but it removes the need for a bespoke mini-switch.
- Placeholder help now reuses `Callout(:neutral)` instead of bespoke inline box markup; the caret reuses `dropdown-chevron` rather than new CSS. The rest of the touched code was already clean, so incidental cleanup was light.

## Visual checks for you (no browser in the sandbox)
- DiscordMessagePreview legibility in **both** light and dark.
- Logging group **collapse/expand** + caret rotation.
- **Toggle-all** flips its rows and re-syncs when a row is changed individually; clicking it does not collapse the section.

Gates green locally: `rspec` (523), `standardrb`, `active_record_doctor`, `undercover --compare origin/main`, `i18n-tasks missing` + `check-normalized`.