### PR TITLE
Add the global save bar and plugin sidebar to config pages

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -3,6 +3,7 @@
 @import "./tokens.css";
 @import "./theme.css";
 @import "./utilities.css";
+@import "./save_bar.css";
 @import "./tom-select-base.css";
 @import "./tom-select.css";
 

--- a/app/assets/tailwind/save_bar.css
+++ b/app/assets/tailwind/save_bar.css
@@ -1,0 +1,40 @@
+.save-bar {
+  left: 50%;
+  transform: translateX(-50%);
+}
+@keyframes saveBarIn {
+  from { opacity: 0; transform: translateX(-50%) translateY(28px); }
+  65% { opacity: 1; transform: translateX(-50%) translateY(-7px); }
+  to { opacity: 1; transform: translateX(-50%) translateY(0); }
+}
+@keyframes saveBarOut {
+  0% { opacity: 1; transform: translateX(-50%) translateY(0); }
+  20% { transform: translateX(-50%) translateY(-6px); }
+  100% { opacity: 0; transform: translateX(-50%) translateY(28px); }
+}
+@keyframes saveBarShake {
+  0% { transform: translateX(-50%); }
+  13% { transform: translateX(calc(-50% - 9px)); }
+  29% { transform: translateX(calc(-50% + 9px)); }
+  45% { transform: translateX(calc(-50% - 7px)); }
+  61% { transform: translateX(calc(-50% + 7px)); }
+  77% { transform: translateX(calc(-50% - 4px)); }
+  90% { transform: translateX(calc(-50% + 4px)); }
+  100% { transform: translateX(-50%); }
+}
+@keyframes saveBarRingFade {
+  0%, 38% { box-shadow: 0 0 0 2.5px var(--accent-2); }
+  100% { box-shadow: 0 0 0 2.5px color-mix(in srgb, var(--accent-2), transparent 100%); }
+}
+.save-bar-anim { animation: saveBarIn 420ms cubic-bezier(0.34, 1.3, 0.64, 1) forwards; }
+.save-bar-out { animation: saveBarOut 300ms cubic-bezier(0.4, 0, 0.8, 0.8) forwards; }
+.save-bar-blocked { animation: saveBarShake 420ms var(--ease-standard), saveBarRingFade 1600ms ease-out; }
+
+/* lift toasts clear of the save bar on config pages, where both sit bottom-centre */
+body:has(.save-bar) #toasts { bottom: 6rem; }
+
+@media (prefers-reduced-motion: reduce) {
+  .save-bar-anim,
+  .save-bar-out,
+  .save-bar-blocked { animation: none; }
+}

--- a/app/assets/tailwind/utilities.css
+++ b/app/assets/tailwind/utilities.css
@@ -109,6 +109,38 @@ details:has(.dropdown-menu.is-closing) .dropdown-chevron { transform: rotate(0de
 [data-theme="dark"] .theme-morph .theme-sun { opacity: 1; transform: rotate(0) scale(1); }
 [data-theme="dark"] .theme-morph .theme-moon { opacity: 0; transform: rotate(90deg) scale(0.4); }
 
+.save-bar {
+  left: 50%;
+  transform: translateX(-50%);
+}
+@keyframes saveBarIn {
+  from { opacity: 0; transform: translateX(-50%) translateY(28px); }
+  65% { opacity: 1; transform: translateX(-50%) translateY(-7px); }
+  to { opacity: 1; transform: translateX(-50%) translateY(0); }
+}
+@keyframes saveBarOut {
+  0% { opacity: 1; transform: translateX(-50%) translateY(0); }
+  20% { transform: translateX(-50%) translateY(-6px); }
+  100% { opacity: 0; transform: translateX(-50%) translateY(28px); }
+}
+@keyframes saveBarShake {
+  0% { transform: translateX(-50%); }
+  13% { transform: translateX(calc(-50% - 9px)); }
+  29% { transform: translateX(calc(-50% + 9px)); }
+  45% { transform: translateX(calc(-50% - 7px)); }
+  61% { transform: translateX(calc(-50% + 7px)); }
+  77% { transform: translateX(calc(-50% - 4px)); }
+  90% { transform: translateX(calc(-50% + 4px)); }
+  100% { transform: translateX(-50%); }
+}
+@keyframes saveBarRingFade {
+  0%, 38% { box-shadow: 0 0 0 2.5px var(--accent-2); }
+  100% { box-shadow: 0 0 0 2.5px color-mix(in srgb, var(--accent-2), transparent 100%); }
+}
+.save-bar-anim { animation: saveBarIn 420ms cubic-bezier(0.34, 1.3, 0.64, 1) forwards; }
+.save-bar-out { animation: saveBarOut 300ms cubic-bezier(0.4, 0, 0.8, 0.8) forwards; }
+.save-bar-blocked { animation: saveBarShake 600ms var(--ease-standard), saveBarRingFade 1600ms ease-out; }
+
 @media (prefers-reduced-motion: reduce) {
   .card-lift { transition: none; }
   .anim-menu,
@@ -117,6 +149,9 @@ details:has(.dropdown-menu.is-closing) .dropdown-chevron { transform: rotate(0de
   details[open] > .dropdown-menu,
   details[open] > .dropdown-menu.is-closing { animation: none; }
   .dropdown-chevron { transition: none; }
+  .save-bar-anim,
+  .save-bar-out,
+  .save-bar-blocked { animation: none; }
   .theme-switching,
   .theme-switching *,
   .theme-morph > * { transition: none; }

--- a/app/assets/tailwind/utilities.css
+++ b/app/assets/tailwind/utilities.css
@@ -139,7 +139,10 @@ details:has(.dropdown-menu.is-closing) .dropdown-chevron { transform: rotate(0de
 }
 .save-bar-anim { animation: saveBarIn 420ms cubic-bezier(0.34, 1.3, 0.64, 1) forwards; }
 .save-bar-out { animation: saveBarOut 300ms cubic-bezier(0.4, 0, 0.8, 0.8) forwards; }
-.save-bar-blocked { animation: saveBarShake 600ms var(--ease-standard), saveBarRingFade 1600ms ease-out; }
+.save-bar-blocked { animation: saveBarShake 420ms var(--ease-standard), saveBarRingFade 1600ms ease-out; }
+
+/* lift toasts clear of the save bar on config pages, where both sit bottom-centre */
+body:has(.save-bar) #toasts { bottom: 6rem; }
 
 @media (prefers-reduced-motion: reduce) {
   .card-lift { transition: none; }

--- a/app/assets/tailwind/utilities.css
+++ b/app/assets/tailwind/utilities.css
@@ -109,41 +109,6 @@ details:has(.dropdown-menu.is-closing) .dropdown-chevron { transform: rotate(0de
 [data-theme="dark"] .theme-morph .theme-sun { opacity: 1; transform: rotate(0) scale(1); }
 [data-theme="dark"] .theme-morph .theme-moon { opacity: 0; transform: rotate(90deg) scale(0.4); }
 
-.save-bar {
-  left: 50%;
-  transform: translateX(-50%);
-}
-@keyframes saveBarIn {
-  from { opacity: 0; transform: translateX(-50%) translateY(28px); }
-  65% { opacity: 1; transform: translateX(-50%) translateY(-7px); }
-  to { opacity: 1; transform: translateX(-50%) translateY(0); }
-}
-@keyframes saveBarOut {
-  0% { opacity: 1; transform: translateX(-50%) translateY(0); }
-  20% { transform: translateX(-50%) translateY(-6px); }
-  100% { opacity: 0; transform: translateX(-50%) translateY(28px); }
-}
-@keyframes saveBarShake {
-  0% { transform: translateX(-50%); }
-  13% { transform: translateX(calc(-50% - 9px)); }
-  29% { transform: translateX(calc(-50% + 9px)); }
-  45% { transform: translateX(calc(-50% - 7px)); }
-  61% { transform: translateX(calc(-50% + 7px)); }
-  77% { transform: translateX(calc(-50% - 4px)); }
-  90% { transform: translateX(calc(-50% + 4px)); }
-  100% { transform: translateX(-50%); }
-}
-@keyframes saveBarRingFade {
-  0%, 38% { box-shadow: 0 0 0 2.5px var(--accent-2); }
-  100% { box-shadow: 0 0 0 2.5px color-mix(in srgb, var(--accent-2), transparent 100%); }
-}
-.save-bar-anim { animation: saveBarIn 420ms cubic-bezier(0.34, 1.3, 0.64, 1) forwards; }
-.save-bar-out { animation: saveBarOut 300ms cubic-bezier(0.4, 0, 0.8, 0.8) forwards; }
-.save-bar-blocked { animation: saveBarShake 420ms var(--ease-standard), saveBarRingFade 1600ms ease-out; }
-
-/* lift toasts clear of the save bar on config pages, where both sit bottom-centre */
-body:has(.save-bar) #toasts { bottom: 6rem; }
-
 @media (prefers-reduced-motion: reduce) {
   .card-lift { transition: none; }
   .anim-menu,
@@ -152,9 +117,6 @@ body:has(.save-bar) #toasts { bottom: 6rem; }
   details[open] > .dropdown-menu,
   details[open] > .dropdown-menu.is-closing { animation: none; }
   .dropdown-chevron { transition: none; }
-  .save-bar-anim,
-  .save-bar-out,
-  .save-bar-blocked { animation: none; }
   .theme-switching,
   .theme-switching *,
   .theme-morph > * { transition: none; }

--- a/app/components/app_shell.rb
+++ b/app/components/app_shell.rb
@@ -4,17 +4,25 @@ class Components::AppShell < Components::Base
   include Phlex::Rails::Helpers::ImageTag
   include Phlex::Rails::Helpers::ButtonTo
 
-  def initialize(user:, current_server: nil, servers: [], plugin_counts: {})
+  def initialize(user:, current_server: nil, servers: [], plugin_counts: {}, sidebar: nil)
     @user = user
     @current_server = current_server
     @servers = servers
     @plugin_counts = plugin_counts
+    @sidebar = sidebar
   end
 
   def view_template(&block)
     div(class: "flex min-h-screen flex-col") do
       top_bar
-      main(class: "flex-1") { yield }
+      if @sidebar
+        div(class: "flex flex-1") do
+          render @sidebar
+          main(class: "min-w-0 flex-1") { yield }
+        end
+      else
+        main(class: "flex-1") { yield }
+      end
     end
   end
 

--- a/app/components/config_page.rb
+++ b/app/components/config_page.rb
@@ -20,7 +20,14 @@ class Components::ConfigPage < Components::Base
           {label: @title}
         ]
       )
-      form_with(url: @gate[:url], method: :patch, data: {controller: "enable-gate"}) do
+      form_with(
+        url: @gate[:url],
+        method: :patch,
+        data: {
+          controller: "enable-gate save-bar",
+          action: "input->save-bar#check change->save-bar#check turbo:submit-end->save-bar#saved"
+        }
+      ) do
         header
         render Components::EnableGate.new(
           enabled: @gate[:enabled],
@@ -28,7 +35,7 @@ class Components::ConfigPage < Components::Base
           message: @gate[:message],
           enable_label: t(".enable", plugin: @title)
         ) { yield }
-        save_bar
+        render Components::SaveBar.new
       end
     end
   end
@@ -58,12 +65,6 @@ class Components::ConfigPage < Components::Base
         label: t(".enable", plugin: @title),
         data: {enable_gate_target: "toggle", action: "change->enable-gate#update"}
       )
-    end
-  end
-
-  def save_bar
-    div(class: "mt-5 flex justify-end") do
-      render Components::Button.new(variant: :primary, size: :lg, type: "submit", icon: "check", label: t(".save"))
     end
   end
 end

--- a/app/components/logging/config_form.rb
+++ b/app/components/logging/config_form.rb
@@ -69,7 +69,7 @@ class Components::Logging::ConfigForm < Components::Base
     div(class: "relative border-b border-border-subtle last:border-b-0", data: {controller: "event-group"}) do
       details(
         open: true,
-        data: {controller: "dropdown", dropdown_dismiss_on_outside_value: false}
+        data: {controller: "dropdown", dropdown_dismiss_on_outside_value: "false"}
       ) do
         summary(
           class: "flex h-11 cursor-pointer list-none select-none items-center gap-3 bg-surface-sunken px-5 pr-36 [&::-webkit-details-marker]:hidden",

--- a/app/components/plugin_nav.rb
+++ b/app/components/plugin_nav.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Components::PluginNav
+  ICONS = {
+    roles: "users-three",
+    welcomes: "hand-waving",
+    logging: "scroll",
+    reminders: "bell-ringing"
+  }.freeze
+
+  def plugin_icon(key)
+    ICONS.fetch(key.to_sym)
+  end
+
+  def plugin_config_path(server_id, key)
+    case key.to_sym
+    when :welcomes then server_welcomes_path(server_id)
+    when :logging then server_logging_path(server_id)
+    end
+  end
+end

--- a/app/components/plugin_row.rb
+++ b/app/components/plugin_row.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Components::PluginRow < Components::Base
-  ICONS = {roles: "users-three", welcomes: "hand-waving", logging: "scroll", reminders: "bell-ringing"}.freeze
+  include Components::PluginNav
 
   STATUS_VARIANTS = {
     always_enabled: :success,
@@ -20,7 +20,7 @@ class Components::PluginRow < Components::Base
 
   def view_template
     render Components::Card.new(enabled: @enabled, id: "plugin-#{@key}", class: "flex items-center gap-4") do
-      render Components::PluginTile.new(icon: ICONS[@key], enabled: @enabled)
+      render Components::PluginTile.new(icon: plugin_icon(@key), enabled: @enabled)
       div(class: "min-w-0 flex-1") do
         div(class: "flex flex-wrap items-center gap-2") do
           span(class: "font-display font-semibold") { name }
@@ -86,10 +86,6 @@ class Components::PluginRow < Components::Base
   end
 
   def configure_href
-    case @key.to_sym
-    when :welcomes then server_welcomes_path(@server_id)
-    when :logging then server_logging_path(@server_id)
-    else "#"
-    end
+    plugin_config_path(@server_id, @key) || "#"
   end
 end

--- a/app/components/plugin_sidebar.rb
+++ b/app/components/plugin_sidebar.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+class Components::PluginSidebar < Components::Base
+  include Components::PluginNav
+
+  def initialize(server_configuration:, active_key:)
+    @config = server_configuration
+    @active_key = active_key.to_sym
+  end
+
+  def view_template
+    aside(class: "sticky top-16 hidden h-[calc(100vh-4rem)] w-56 flex-none overflow-y-auto border-r border-border-default bg-surface-sunken md:block") do
+      div(class: "p-4") do
+        back_link
+        div(class: "my-3 h-px bg-border-subtle")
+        p(class: "mb-2 px-2 text-[10px] font-semibold uppercase tracking-widest text-eyebrow") { t(".plugins") }
+        nav(class: "flex flex-col gap-0.5") do
+          items.each { |row| nav_item(row) }
+        end
+      end
+    end
+  end
+
+  private
+
+  def items
+    PluginStatus.rows(@config).select { |row| plugin_config_path(@config.discord_id, row.key) }
+  end
+
+  def back_link
+    a(
+      href: server_path(@config.discord_id),
+      class: "group flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors hover:bg-surface-card"
+    ) do
+      render Components::Icon.new("arrow-left", class: "size-4 flex-none text-text-muted")
+      span(class: "truncate text-sm font-medium text-text-secondary group-hover:text-text-primary") { t(".dashboard") }
+    end
+  end
+
+  def nav_item(row)
+    active = row.key == @active_key
+    tone = active ? "bg-accent-soft font-semibold text-accent-soft-fg" : "text-text-secondary hover:bg-surface-card"
+    a(
+      href: plugin_config_path(@config.discord_id, row.key),
+      aria_current: ("page" if active),
+      class: "flex items-center gap-2.5 rounded-md px-2.5 py-2 transition-colors #{tone}"
+    ) do
+      item_tile(row, active)
+      span(class: "flex-1 text-[13px]") { t("components.plugin_row.plugin.#{row.key}.name") }
+      status_dot(row)
+    end
+  end
+
+  def item_tile(row, active)
+    on = active || row.enabled
+    tone = on ? "bg-accent-fill text-white" : "bg-surface-card text-text-muted"
+    span(class: "flex size-7 flex-none items-center justify-center rounded-md #{tone}") do
+      render Components::Icon.new(plugin_icon(row.key), weight: (on ? :fill : :regular), class: "size-4")
+    end
+  end
+
+  def status_dot(row)
+    tone = row.enabled ? "bg-success" : "bg-border-strong"
+    span(class: "size-1.5 flex-none rounded-full #{tone}")
+  end
+end

--- a/app/components/save_bar.rb
+++ b/app/components/save_bar.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class Components::SaveBar < Components::Base
+  def view_template
+    div(
+      class: "save-bar fixed bottom-6 z-40 hidden w-[30rem] max-w-[calc(100vw-2.5rem)] rounded-xl",
+      data: {save_bar_target: "bar"}
+    ) do
+      div(class: "flex items-center justify-between gap-6 rounded-xl border border-border-default bg-surface-card px-5 py-3 shadow-lg") do
+        p(class: "flex items-center gap-2 text-sm text-text-secondary") do
+          span(class: "size-2 flex-none rounded-full bg-warning")
+          plain t(".unsaved")
+        end
+        div(class: "flex items-center gap-2") do
+          render Components::Button.new(
+            variant: :secondary,
+            size: :sm,
+            label: t(".discard"),
+            data: {action: "save-bar#discard"}
+          )
+          render Components::Button.new(
+            variant: :primary,
+            size: :sm,
+            type: "submit",
+            icon: "check",
+            label: t(".save")
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/components/save_bar.rb
+++ b/app/components/save_bar.rb
@@ -28,5 +28,8 @@ class Components::SaveBar < Components::Base
         end
       end
     end
+    template(data: {save_bar_target: "discardedToast"}) do
+      render Components::Toast.new(level: "notice", message: t(".discarded"))
+    end
   end
 end

--- a/app/controllers/servers/logging_controller.rb
+++ b/app/controllers/servers/logging_controller.rb
@@ -24,7 +24,7 @@ class Servers::LoggingController < ApplicationController
     @toast = {level: "notice", message: t("servers.logging.saved")} if result.success?
 
     respond_to do |format|
-      format.turbo_stream
+      format.turbo_stream { render status: result.success? ? :ok : :unprocessable_content }
       format.html { redirect_to server_logging_path(params[:server_id]), **flash_for(result) }
     end
   end

--- a/app/controllers/servers/welcomes_controller.rb
+++ b/app/controllers/servers/welcomes_controller.rb
@@ -25,7 +25,7 @@ class Servers::WelcomesController < ApplicationController
     @toast = {level: "notice", message: t("servers.welcomes.saved")} if result.success?
 
     respond_to do |format|
-      format.turbo_stream
+      format.turbo_stream { render status: result.success? ? :ok : :unprocessable_content }
       format.html { redirect_to server_welcomes_path(params[:server_id]), **flash_for(result) }
     end
   end

--- a/app/javascript/controllers/enable_gate_controller.js
+++ b/app/javascript/controllers/enable_gate_controller.js
@@ -19,6 +19,8 @@ export default class extends Controller {
 
   enable() {
     this.toggleTarget.checked = true
-    this.update()
+    // a programmatic .checked fires no change event; dispatch one so the gate
+    // and the save bar both react as they do to a real toggle click
+    this.toggleTarget.dispatchEvent(new Event("change", {bubbles: true}))
   }
 }

--- a/app/javascript/controllers/enable_gate_controller.js
+++ b/app/javascript/controllers/enable_gate_controller.js
@@ -5,6 +5,13 @@ export default class extends Controller {
 
   connect() {
     this.update()
+    // discard resets the form; re-veil once the toggle's checked state settles
+    this.onReset = () => requestAnimationFrame(() => this.update())
+    this.element.addEventListener("reset", this.onReset)
+  }
+
+  disconnect() {
+    this.element.removeEventListener("reset", this.onReset)
   }
 
   update() {

--- a/app/javascript/controllers/enable_gate_controller.js
+++ b/app/javascript/controllers/enable_gate_controller.js
@@ -5,7 +5,7 @@ export default class extends Controller {
 
   connect() {
     this.update()
-    // discard resets the form; re-veil once the toggle's checked state settles
+    // reset fires before the control's value updates, so re-veil on the next frame
     this.onReset = () => requestAnimationFrame(() => this.update())
     this.element.addEventListener("reset", this.onReset)
   }

--- a/app/javascript/controllers/save_bar_controller.js
+++ b/app/javascript/controllers/save_bar_controller.js
@@ -1,0 +1,108 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["bar"]
+
+  connect() {
+    this.baseline = this.snapshot()
+    this.dirty = false
+    this.blockVisit = (event) => {
+      if (!this.dirty) return
+      event.preventDefault()
+      this.shake()
+    }
+    this.warnUnload = (event) => {
+      if (!this.dirty) return
+      event.preventDefault()
+      event.returnValue = ""
+    }
+    document.addEventListener("turbo:before-visit", this.blockVisit)
+    window.addEventListener("beforeunload", this.warnUnload)
+  }
+
+  disconnect() {
+    document.removeEventListener("turbo:before-visit", this.blockVisit)
+    window.removeEventListener("beforeunload", this.warnUnload)
+  }
+
+  check() {
+    this.setDirty(this.snapshot() !== this.baseline)
+  }
+
+  saved(event) {
+    if (!event.detail.success) return // a 422 means validation failed — stay dirty
+
+    requestAnimationFrame(() => {
+      this.baseline = this.snapshot()
+      this.setDirty(false)
+    })
+  }
+
+  discard(event) {
+    event.preventDefault()
+    this.dirty = false // let the visit past the block-nav guard
+    window.Turbo.visit(window.location.href, {action: "replace"})
+  }
+
+  setDirty(value) {
+    if (value === this.dirty) return
+    this.dirty = value
+    value ? this.reveal() : this.hide()
+  }
+
+  reveal() {
+    this.barTarget.classList.remove("hidden", "save-bar-out")
+    if (this.reduceMotion) return
+
+    this.barTarget.classList.add("save-bar-anim")
+    this.barTarget.addEventListener(
+      "animationend",
+      () => this.barTarget.classList.remove("save-bar-anim"),
+      {once: true}
+    )
+  }
+
+  hide() {
+    if (this.barTarget.classList.contains("hidden")) return
+    if (this.reduceMotion) {
+      this.barTarget.classList.add("hidden")
+      return
+    }
+
+    this.barTarget.classList.remove("save-bar-anim")
+    this.barTarget.classList.add("save-bar-out")
+    this.barTarget.addEventListener(
+      "animationend",
+      () => {
+        this.barTarget.classList.add("hidden")
+        this.barTarget.classList.remove("save-bar-out")
+      },
+      {once: true}
+    )
+  }
+
+  shake() {
+    if (this.reduceMotion) return
+
+    const bar = this.barTarget
+    if (this.ringEnd) bar.removeEventListener("animationend", this.ringEnd)
+    bar.classList.remove("save-bar-blocked")
+    void bar.offsetWidth // reflow so the animation restarts cleanly
+    bar.classList.add("save-bar-blocked")
+    this.ringEnd = (event) => {
+      if (event.animationName !== "saveBarRingFade") return // wait for the longer ring-fade
+      bar.classList.remove("save-bar-blocked")
+      bar.removeEventListener("animationend", this.ringEnd)
+      this.ringEnd = null
+    }
+    bar.addEventListener("animationend", this.ringEnd)
+  }
+
+  snapshot() {
+    return new URLSearchParams(new FormData(this.element)).toString()
+  }
+
+  get reduceMotion() {
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  }
+}

--- a/app/javascript/controllers/save_bar_controller.js
+++ b/app/javascript/controllers/save_bar_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["bar"]
+  static targets = ["bar", "discardedToast"]
 
   connect() {
     this.baseline = this.snapshot()
@@ -40,8 +40,16 @@ export default class extends Controller {
 
   discard(event) {
     event.preventDefault()
-    this.dirty = false // let the visit past the block-nav guard
-    window.Turbo.visit(window.location.href, {action: "replace"})
+    this.element.reset() // restores saved values in place; tom-select + enable-gate repaint on the reset event
+    this.baseline = this.snapshot()
+    this.setDirty(false)
+    this.showDiscardedToast()
+  }
+
+  showDiscardedToast() {
+    if (!this.hasDiscardedToastTarget) return
+
+    document.getElementById("toasts")?.append(this.discardedToastTarget.content.cloneNode(true))
   }
 
   setDirty(value) {

--- a/app/javascript/controllers/save_bar_controller.js
+++ b/app/javascript/controllers/save_bar_controller.js
@@ -40,7 +40,7 @@ export default class extends Controller {
 
   discard(event) {
     event.preventDefault()
-    this.element.reset() // restores saved values in place; tom-select + enable-gate repaint on the reset event
+    this.element.reset() // tom-select + enable-gate repaint on the reset event
     this.baseline = this.snapshot()
     this.setDirty(false)
     this.showDiscardedToast()

--- a/app/javascript/controllers/tom_select_controller.js
+++ b/app/javascript/controllers/tom_select_controller.js
@@ -12,8 +12,7 @@ export default class extends Controller {
       plugins: ["dropdown_input"],
       render: this.prefixValue ? this.prefixRenderers() : {}
     })
-    // a form reset restores the underlying <select> but not Tom Select's UI;
-    // re-sync after the reset settles (the discard button resets the form)
+    // a form reset restores the <select> but not Tom Select's UI; re-sync once it settles
     this.form = this.element.form
     this.onReset = () => requestAnimationFrame(() => this.select?.sync())
     this.form?.addEventListener("reset", this.onReset)

--- a/app/javascript/controllers/tom_select_controller.js
+++ b/app/javascript/controllers/tom_select_controller.js
@@ -12,6 +12,11 @@ export default class extends Controller {
       plugins: ["dropdown_input"],
       render: this.prefixValue ? this.prefixRenderers() : {}
     })
+    // a form reset restores the underlying <select> but not Tom Select's UI;
+    // re-sync after the reset settles (the discard button resets the form)
+    this.form = this.element.form
+    this.onReset = () => requestAnimationFrame(() => this.select?.sync())
+    this.form?.addEventListener("reset", this.onReset)
   }
 
   prefixRenderers() {
@@ -25,6 +30,7 @@ export default class extends Controller {
   }
 
   disconnect() {
+    this.form?.removeEventListener("reset", this.onReset)
     this.select?.destroy()
   }
 }

--- a/app/views/servers/logging/show.rb
+++ b/app/views/servers/logging/show.rb
@@ -8,7 +8,10 @@ class Views::Servers::Logging::Show < Views::Base
   end
 
   def view_template
-    render Components::AppShell.new(user: @user) do
+    render Components::AppShell.new(
+      user: @user,
+      sidebar: Components::PluginSidebar.new(server_configuration: @config, active_key: :logging)
+    ) do
       render Components::ConfigPage.new(
         icon: "scroll",
         title: t(".title"),

--- a/app/views/servers/welcomes/show.rb
+++ b/app/views/servers/welcomes/show.rb
@@ -8,7 +8,10 @@ class Views::Servers::Welcomes::Show < Views::Base
   end
 
   def view_template
-    render Components::AppShell.new(user: @user) do
+    render Components::AppShell.new(
+      user: @user,
+      sidebar: Components::PluginSidebar.new(server_configuration: @config, active_key: :welcomes)
+    ) do
       render Components::ConfigPage.new(
         icon: "hand-waving",
         title: t(".title"),

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -62,6 +62,9 @@ en:
         enabled: Enabled
         needs_setup: Needs setup
       toggle: Toggle %{plugin}
+    plugin_sidebar:
+      dashboard: Dashboard
+      plugins: Plugins
     save_bar:
       discard: Discard
       discarded: Changes discarded

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -16,7 +16,6 @@ en:
       disabled_title: "%{plugin} is disabled"
       enable: Enable %{plugin}
       enabled: Enabled
-      save: Save changes
       servers: Servers
     logging:
       config_form:
@@ -63,6 +62,10 @@ en:
         enabled: Enabled
         needs_setup: Needs setup
       toggle: Toggle %{plugin}
+    save_bar:
+      discard: Discard
+      save: Save
+      unsaved: Unsaved changes
     welcomes:
       config_form:
         channel:

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -64,6 +64,7 @@ en:
       toggle: Toggle %{plugin}
     save_bar:
       discard: Discard
+      discarded: Changes discarded
       save: Save
       unsaved: Unsaved changes
     welcomes:

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -124,6 +124,15 @@ operation enforces the requirement server-side and the form re-renders with the
 inline error if it's missing. ConfigPage is gated-only today — the non-gated case
 (Reminders) will add the plain path when that page lands.
 
+On config pages the app shell also renders a left **`Components::PluginSidebar`**
+(passed to `AppShell` via `sidebar:`, which switches the shell to a sidebar+main
+layout). It lists the plugins that have a config page — resolved through the
+shared `Components::PluginNav` mixin (plugin→icon and plugin→config-path, shared
+with `PluginRow` so the two can't drift) — with a status dot, an active highlight
+(`aria-current="page"`), and a back-to-dashboard link. It's `hidden md:block`
+(the breadcrumb covers navigation on narrow screens). Roles/Reminders join the
+list automatically once they have config routes.
+
 `Components::SaveBar` is the commit affordance: a fixed bottom bar, hidden until
 the form differs from its initial state. The `save-bar` Stimulus controller (on
 the form alongside `enable-gate`) snapshots the form on connect and compares on

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -90,9 +90,9 @@ native tooltip is slow, tiny, and system-font. The reminders dashboard row uses
 it on its always-on (locked) toggle.
 
 That split is the save model: standalone settings save instantly; **the plugin
-config pages do not auto-save** — they batch all edits behind an explicit Save
-button so a configuration can be staged before going live (toggles there are
-`Components::Toggle` fields). Both paths render through a Turbo Stream view
+config pages do not auto-save** — they batch all edits behind an explicit save
+(the global `SaveBar`, below) so a configuration can be staged before going live
+(toggles there are `Components::Toggle` fields). Both paths render through a Turbo Stream view
 template (`action.turbo_stream.erb`, see architecture.md "Web"): the template's
 `turbo_stream.replace`/`append` lines render our Phlex components as the content, so
 the stream markup stays in the view layer. Success re-renders the control plus a
@@ -105,7 +105,7 @@ segmented control) ships with the Roles page that consumes it.
 A plugin config page is assembled by **`Components::ConfigPage`**, not by the
 per-plugin form. ConfigPage owns the single gated `form_with` and renders, in
 order: a header (`PluginTile` + title + description + an inline **enable
-`Toggle`**), an `EnableGate` wrapping the body, and the Save button. The
+`Toggle`**), an `EnableGate` wrapping the body, and the global `SaveBar`. The
 per-plugin `Components::<Plugin>::ConfigForm` is **body-only** — it renders just
 the cards, with no form tag and no enable control of its own — and its root `div`
 carries the `#<plugin>-config` id that the Turbo Stream replaces on a failed save,
@@ -123,6 +123,18 @@ picker on Welcomes/Logging) carries a danger `*` marker next to its label; the
 operation enforces the requirement server-side and the form re-renders with the
 inline error if it's missing. ConfigPage is gated-only today — the non-gated case
 (Reminders) will add the plain path when that page lands.
+
+`Components::SaveBar` is the commit affordance: a fixed bottom bar, hidden until
+the form differs from its initial state. The `save-bar` Stimulus controller (on
+the form alongside `enable-gate`) snapshots the form on connect and compares on
+every `input`/`change`, revealing or hiding the bar. Its Save button is a plain
+`type="submit"` — there's no JS save path; Discard reloads the saved state via a
+Turbo visit. A dirty form **blocks navigation**: `turbo:before-visit` is
+cancelled (the bar does a copper shake instead) and `beforeunload` warns, so
+edits can't be lost by clicking away. The bar re-baselines only on a **successful**
+save — config controllers return **422** (not 200) when a save fails validation,
+which is both the correct status and the signal (`turbo:submit-end` reports
+`success: false`) that tells the bar to stay dirty.
 
 ## Core components
 

--- a/spec/requests/logging_config_spec.rb
+++ b/spec/requests/logging_config_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe "Logging config", type: :request do
           patch server_logging_path(guild.id),
             params: {logging: {channel_id: "", enabled: "1", actions: {}}},
             **turbo
+          expect(response).to have_http_status(:unprocessable_content)
           expect(config.plugins.enabled.exists?(key: :logging)).to be(false)
           expect(response.body).to include("logging-config")
           expect(response.body).to include("settings to be configured")

--- a/spec/requests/welcomes_config_spec.rb
+++ b/spec/requests/welcomes_config_spec.rb
@@ -71,6 +71,13 @@ RSpec.describe "Welcomes config", type: :request do
           expect(response.body).to include("turbo:submit-end-&gt;save-bar#saved").or include("turbo:submit-end->save-bar#saved")
         end
 
+        it "renders the plugin sidebar with a link to the other config page" do
+          get server_welcomes_path(guild.id)
+          expect(response.body).to include("<aside").and include("Plugins")
+          expect(response.body).to include(server_logging_path(guild.id))
+          expect(response.body).to include('aria-current="page"')
+        end
+
         it "labels the live preview with the saved channel" do
           create(:server_channel, server_configuration: config, name: "general", discord_id: 111)
           config.welcome_settings.update!(channel_id: 111)

--- a/spec/requests/welcomes_config_spec.rb
+++ b/spec/requests/welcomes_config_spec.rb
@@ -64,6 +64,13 @@ RSpec.describe "Welcomes config", type: :request do
           expect(response.body).to include("Live preview")
         end
 
+        it "renders the save bar wired to the form" do
+          get server_welcomes_path(guild.id)
+          expect(response.body).to include("save-bar").and include("Unsaved changes")
+          expect(response.body).to include("save-bar#discard")
+          expect(response.body).to include("turbo:submit-end-&gt;save-bar#saved").or include("turbo:submit-end->save-bar#saved")
+        end
+
         it "labels the live preview with the saved channel" do
           create(:server_channel, server_configuration: config, name: "general", discord_id: 111)
           config.welcome_settings.update!(channel_id: 111)
@@ -103,6 +110,7 @@ RSpec.describe "Welcomes config", type: :request do
           patch server_welcomes_path(guild.id),
             params: {welcomes: {channel_id: "", join_message: "", leave_message: "", enabled: "1"}},
             **turbo
+          expect(response).to have_http_status(:unprocessable_content)
           expect(config.plugins.enabled.exists?(key: :welcomes)).to be(false)
           expect(response.body).to include("welcomes-config")
           expect(response.body).to include("settings to be configured")


### PR DESCRIPTION
Step 4 of the redesign (decisions #2 + #3): the global save bar and the plugin sidebar.

## Save bar (decision #2)
- **`Components::SaveBar`** — fixed bottom bar, hidden until the form is dirty. Replaces the inline Save button.
- **`save_bar` controller** snapshots the form on connect and diffs on input/change. Save is a plain `type="submit"`; **Discard resets the form in place** (no reload/scroll) and fires a "Changes discarded" toast (cloned from a hidden `<template>`), with Tom Select + enable-gate repainting on the form's `reset` event.
- **Lost-edit protection**: a dirty form cancels `turbo:before-visit` (copper shake) and warns on `beforeunload`.
- **422 on failed save** (`:unprocessable_content`): correct status + the signal that keeps the bar dirty; success re-baselines and hides it.
- Toasts lift clear of the bar on config pages; enable-gate's overlay button dispatches a real `change` so a programmatic enable is noticed.

## Plugin sidebar (decision #3)
- **`Components::PluginSidebar`** — left nav on config pages (passed to `AppShell` via `sidebar:`, which switches to a sidebar+main layout). Status dot, active highlight (`aria-current="page"`), back-to-dashboard link. `hidden md:block` (breadcrumb covers narrow screens).
- Lists the plugins that have a config page; Roles/Reminders join automatically when their routes land.
- **`Components::PluginNav`** mixin extracted (plugin→icon + plugin→config-path), shared by `PluginRow` and `PluginSidebar` so the "which plugins are configurable" mapping lives in one place.

## Notes
- No cached guild name exists, so the sidebar's back-link uses a generic "Dashboard" label (like the breadcrumb) rather than a Discord fetch.
- Docs: `docs/design-system.md` config-pages section documents both.
- **Out of scope (flagged separately):** the breadcrumb→dashboard "couldn't reach Discord" error is pre-existing — `servers#show` calls Discord live every load; recorded as a backend follow-up.

## Boyscouting
- Extracted `PluginNav`, removing the duplicated plugin-icon map and the duplicated welcomes/logging config-path `case` from `PluginRow`.

## Visual checks (no browser here)
- Save bar: dirty→reveal, revert→hide, save→toast+hide, 422→stays, blocked-nav shake, discard slides out + toast (no scroll).
- Sidebar: appears left on config pages ≥ md, active plugin highlighted, links to the other config page, back-to-dashboard; hidden below md. Both themes.

Gates green: rspec (527), standardrb, active_record_doctor, undercover, i18n missing + check-normalized.