### PR TITLE
Add the Roles config page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,7 @@ GEM
       thor (~> 1.0)
     concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
-    crass (1.0.6)
+    crass (1.0.7)
     date (3.5.1)
     debug (1.11.1)
       irb (~> 1.10)
@@ -581,7 +581,7 @@ CHECKSUMS
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
   concurrent-ruby (1.3.7) sha256=4412caec3a5ea2e5fdc52076724c071a81f2c0593d83b2ac8cbb8ca63b3151b0
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
-  crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
+  crass (1.0.7) sha256=94868719948664c89ddcaf0a37c65048413dfcb1c869470a5f7a7ceb5390b295
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962

--- a/app/assets/tailwind/tom-select.css
+++ b/app/assets/tailwind/tom-select.css
@@ -76,3 +76,19 @@
 .ts-dropdown .option[data-selectable].disabled,
 .ts-dropdown .option.disabled { color: var(--text-muted); cursor: not-allowed; opacity: 0.7; }
 .ts-dropdown .no-results { padding: 0.5rem 0.75rem; color: var(--text-muted); }
+.ts-dot {
+  width: 0.625rem;
+  height: 0.625rem;
+  flex: none;
+  margin-right: 0.5rem;
+  border-radius: 9999px;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--text-primary) 18%, transparent);
+}
+.ts-wrapper.multi .ts-control > .item .ts-dot { margin-right: 0.3125rem; }
+.ts-lock {
+  display: inline-flex;
+  margin-left: auto;
+  padding-left: 0.5rem;
+  color: var(--text-muted);
+}
+.ts-lock svg { width: 0.875rem; height: 0.875rem; }

--- a/app/bot/guild_metadata.rb
+++ b/app/bot/guild_metadata.rb
@@ -24,7 +24,7 @@ module GuildMetadata
 
   def roles(server)
     server.roles.map do |role|
-      {discord_id: role.id, name: role.name, position: role.position, managed: role.managed?}
+      {discord_id: role.id, name: role.name, position: role.position, managed: role.managed?, color: role.color.combined}
     end
   end
 

--- a/app/components/channel_select.rb
+++ b/app/components/channel_select.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Components::ChannelSelect < Components::Base
+  def initialize(name:, options:, placeholder:, selected: nil, include_blank: false)
+    @name = name
+    @options = options
+    @placeholder = placeholder
+    @selected = selected
+    @include_blank = include_blank
+  end
+
+  def view_template
+    render Components::TomSelect.new(
+      name: @name,
+      options: @options,
+      selected: @selected,
+      include_blank: @include_blank,
+      controller_data: {tom_select_prefix_value: "#", tom_select_placeholder_value: @placeholder}
+    )
+  end
+end

--- a/app/components/config_page.rb
+++ b/app/components/config_page.rb
@@ -12,7 +12,7 @@ class Components::ConfigPage < Components::Base
   end
 
   def view_template(&block)
-    div(class: "mx-auto max-w-3xl px-6 py-8") do
+    div(class: "mx-auto max-w-3xl px-6 pb-28 pt-8") do
       render Components::Breadcrumb.new(
         [
           {label: t(".servers"), href: servers_path},

--- a/app/components/logging/config_form.rb
+++ b/app/components/logging/config_form.rb
@@ -39,13 +39,12 @@ class Components::Logging::ConfigForm < Components::Base
       if channels.empty?
         p(class: "text-sm text-text-secondary") { t(".channel.none") }
       else
-        render Components::TomSelect.new(
+        render Components::ChannelSelect.new(
           name: "logging[channel_id]",
           options: channels,
           selected: @settings.channel_id,
           placeholder: t(".channel.placeholder"),
-          include_blank: true,
-          prefix: "#"
+          include_blank: true
         )
       end
       visibility_warning

--- a/app/components/logging/config_form.rb
+++ b/app/components/logging/config_form.rb
@@ -145,8 +145,6 @@ class Components::Logging::ConfigForm < Components::Base
   end
 
   def channels
-    @channels ||= @config.server_channels.text.map do |channel|
-      Components::TomSelect::Option.for(value: channel.discord_id, label: channel.name)
-    end
+    @channels ||= ChannelOptions.new(@config).options
   end
 end

--- a/app/components/plugin_nav.rb
+++ b/app/components/plugin_nav.rb
@@ -14,6 +14,7 @@ module Components::PluginNav
 
   def plugin_config_path(server_id, key)
     case key.to_sym
+    when :roles then server_roles_path(server_id)
     when :welcomes then server_welcomes_path(server_id)
     when :logging then server_logging_path(server_id)
     end

--- a/app/components/role_select.rb
+++ b/app/components/role_select.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class Components::RoleSelect < Components::Base
+  def initialize(name:, options:, placeholder:, selected: [])
+    @name = name
+    @options = options
+    @placeholder = placeholder
+    @selected = selected
+  end
+
+  def view_template
+    render Components::TomSelect.new(
+      name: @name,
+      options: @options,
+      selected: @selected,
+      multiple: true,
+      controller_data: {tom_select_color_dots_value: true, tom_select_placeholder_value: @placeholder}
+    )
+  end
+end

--- a/app/components/role_select.rb
+++ b/app/components/role_select.rb
@@ -14,7 +14,11 @@ class Components::RoleSelect < Components::Base
       options: @options,
       selected: @selected,
       multiple: true,
-      controller_data: {tom_select_color_dots_value: true, tom_select_placeholder_value: @placeholder}
+      controller_data: {
+        tom_select_color_dots_value: true,
+        tom_select_placeholder_value: @placeholder,
+        tom_select_lock_icon_value: Components::Icon.new("lock", class: "size-3.5").call
+      }
     )
   end
 end

--- a/app/components/roles/config_form.rb
+++ b/app/components/roles/config_form.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+class Components::Roles::ConfigForm < Components::Base
+  def initialize(server_configuration:)
+    @config = server_configuration
+    @setting = server_configuration.role_setting
+  end
+
+  def view_template
+    div(id: "roles-config", class: "flex flex-col gap-5", data: {controller: "role-sets"}) do
+      default_channel_card
+      role_sets_section
+    end
+  end
+
+  private
+
+  def default_channel_card
+    render Components::Card.new do
+      label(class: "block text-sm font-semibold") { t(".channel.label") }
+      p(class: "mb-2 mt-0.5 text-sm text-text-secondary") { t(".channel.help") }
+      if channels.empty?
+        p(class: "text-sm text-text-secondary") { t(".channel.none") }
+      else
+        render Components::TomSelect.new(
+          name: "roles[channel_id]",
+          options: channels,
+          selected: @setting.channel_id,
+          placeholder: t(".channel.placeholder"),
+          include_blank: true,
+          prefix: "#"
+        )
+      end
+    end
+  end
+
+  def role_sets_section
+    div do
+      p(class: "mb-3 text-[11px] font-semibold uppercase tracking-widest text-eyebrow") { t(".sets.label") }
+      div(class: "flex flex-col gap-3", data: {role_sets_target: "list"}) do
+        @setting.role_sets.each_with_index { |set, index| render card_for(set, index) }
+      end
+      template(data: {role_sets_target: "template"}) { render new_card }
+      add_button
+    end
+  end
+
+  def card_for(set, index)
+    card(
+      index: index,
+      set_id: set.id,
+      name: set.name,
+      selection_mode: set.selection_mode,
+      channel_override: set.channel_override,
+      selected_role_ids: set.assignable_roles.map(&:role_id)
+    )
+  end
+
+  def new_card
+    card(index: "NEW_RECORD", open: true)
+  end
+
+  def card(**attrs)
+    Components::Roles::RoleSetCard.new(
+      channels: channels,
+      role_options: role_options,
+      channels_by_id: channels_by_id,
+      default_channel_id: @setting.channel_id,
+      any_unassignable: assignable_options.any_unassignable?,
+      **attrs
+    )
+  end
+
+  def add_button
+    button(
+      type: "button",
+      data: {action: "role-sets#add"},
+      class: "mt-3 flex h-11 w-full items-center justify-center gap-2 rounded-card border border-dashed " \
+        "border-border-strong text-sm font-semibold text-text-secondary transition-colors " \
+        "hover:border-accent hover:bg-accent-soft hover:text-accent-soft-fg"
+    ) do
+      render Components::Icon.new("plus", class: "size-4")
+      span { t(".sets.add") }
+    end
+  end
+
+  def channels
+    @channels ||= @config.server_channels.text.map do |channel|
+      Components::TomSelect::Option.for(value: channel.discord_id, label: channel.name)
+    end
+  end
+
+  def channels_by_id
+    @channels_by_id ||= @config.server_channels.text.pluck(:discord_id, :name).to_h
+  end
+
+  def assignable_options
+    @assignable_options ||= AssignableRoleOptions.new(@config)
+  end
+
+  def role_options
+    @role_options ||= assignable_options.options
+  end
+end

--- a/app/components/roles/config_form.rb
+++ b/app/components/roles/config_form.rb
@@ -84,9 +84,7 @@ class Components::Roles::ConfigForm < Components::Base
   end
 
   def channels
-    @channels ||= @config.server_channels.text.map do |channel|
-      Components::TomSelect::Option.for(value: channel.discord_id, label: channel.name)
-    end
+    @channels ||= ChannelOptions.new(@config).options
   end
 
   def channels_by_id

--- a/app/components/roles/config_form.rb
+++ b/app/components/roles/config_form.rb
@@ -22,13 +22,12 @@ class Components::Roles::ConfigForm < Components::Base
       if channels.empty?
         p(class: "text-sm text-text-secondary") { t(".channel.none") }
       else
-        render Components::TomSelect.new(
+        render Components::ChannelSelect.new(
           name: "roles[channel_id]",
           options: channels,
           selected: @setting.channel_id,
           placeholder: t(".channel.placeholder"),
-          include_blank: true,
-          prefix: "#"
+          include_blank: true
         )
       end
     end

--- a/app/components/roles/config_form.rb
+++ b/app/components/roles/config_form.rb
@@ -90,7 +90,7 @@ class Components::Roles::ConfigForm < Components::Base
   end
 
   def channels_by_id
-    @channels_by_id ||= @config.server_channels.text.pluck(:discord_id, :name).to_h
+    @channels_by_id ||= channels.to_h { |option| [option.value.to_i, option.label] }
   end
 
   def assignable_options

--- a/app/components/roles/role_set_card.rb
+++ b/app/components/roles/role_set_card.rb
@@ -122,13 +122,12 @@ class Components::Roles::RoleSetCard < Components::Base
         plain t(".channel.label")
         span(class: "font-normal text-text-muted") { " #{t(".channel.optional")}" }
       end
-      render Components::TomSelect.new(
+      render Components::ChannelSelect.new(
         name: field(:channel_override),
         options: @channels,
         selected: @channel_override,
         placeholder: t(".channel.placeholder", channel: default_channel_label),
-        include_blank: true,
-        prefix: "#"
+        include_blank: true
       )
     end
   end
@@ -136,13 +135,11 @@ class Components::Roles::RoleSetCard < Components::Base
   def roles_field
     div do
       label(class: "mb-1.5 block text-sm font-semibold") { t(".roles.label") }
-      render Components::TomSelect.new(
+      render Components::RoleSelect.new(
         name: "#{field(:role_ids)}[]",
         options: @role_options,
         selected: @selected_role_ids,
-        placeholder: t(".roles.placeholder"),
-        multiple: true,
-        color_dots: true
+        placeholder: t(".roles.placeholder")
       )
       unassignable_callout
     end

--- a/app/components/roles/role_set_card.rb
+++ b/app/components/roles/role_set_card.rb
@@ -35,11 +35,10 @@ class Components::Roles::RoleSetCard < Components::Base
     details(
       open: @open,
       data: {role_set: true},
-      class: "group relative overflow-hidden rounded-card border border-border-default bg-surface-card shadow-sm"
+      class: "rounded-card border border-border-default bg-surface-card shadow-sm"
     ) do
       hidden_fields
       summary_row
-      delete_button
       editor
     end
   end
@@ -56,7 +55,7 @@ class Components::Roles::RoleSetCard < Components::Base
   end
 
   def summary_row
-    summary(class: "flex cursor-pointer list-none items-center gap-2 px-4 py-3 pr-24") do
+    summary(class: "flex cursor-pointer list-none select-none items-center gap-2 px-4 py-3 [&::-webkit-details-marker]:hidden") do
       div(class: "min-w-0 flex-1") do
         div(class: "flex items-center gap-2") do
           span(class: "truncate text-sm font-semibold") { @name.presence || t(".unnamed") }
@@ -64,20 +63,19 @@ class Components::Roles::RoleSetCard < Components::Base
         end
         p(class: "mt-0.5 truncate text-xs text-text-muted") { subtitle }
       end
-      render Components::Icon.new("caret-down", class: "dropdown-chevron size-4 flex-none text-text-muted group-open:rotate-180")
+      delete_button
+      render Components::Icon.new("caret-down", class: "dropdown-chevron size-4 flex-none text-text-muted")
     end
   end
 
   def delete_button
-    div(class: "absolute right-3 top-2.5") do
-      button(
-        type: "button",
-        title: t(".delete"),
-        aria_label: t(".delete"),
-        data: {action: "role-sets#remove"},
-        class: "#{ICON_BUTTON} hover:bg-danger-soft hover:text-danger"
-      ) { render Components::Icon.new("trash", class: "size-4") }
-    end
+    button(
+      type: "button",
+      title: t(".delete"),
+      aria_label: t(".delete"),
+      data: {action: "role-sets#remove"},
+      class: "#{ICON_BUTTON} flex-none hover:bg-danger-soft hover:text-danger"
+    ) { render Components::Icon.new("trash", class: "size-4") }
   end
 
   def editor

--- a/app/components/roles/role_set_card.rb
+++ b/app/components/roles/role_set_card.rb
@@ -82,7 +82,7 @@ class Components::Roles::RoleSetCard < Components::Base
   end
 
   def editor
-    div(class: "dropdown-menu grid gap-5 border-t border-border-subtle p-5", data: {dropdown_target: "menu"}) do
+    div(class: "dropdown-menu flex flex-col gap-5 border-t border-border-subtle p-5", data: {dropdown_target: "menu"}) do
       top_fields
       channel_override_field
       roles_field

--- a/app/components/roles/role_set_card.rb
+++ b/app/components/roles/role_set_card.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+class Components::Roles::RoleSetCard < Components::Base
+  ICON_BUTTON = "flex size-8 flex-none items-center justify-center rounded-md text-text-muted transition-colors"
+
+  def initialize(
+    index:,
+    channels:,
+    role_options:,
+    channels_by_id:,
+    default_channel_id:,
+    any_unassignable:,
+    set_id: nil,
+    name: "",
+    selection_mode: "single",
+    channel_override: nil,
+    selected_role_ids: [],
+    open: false
+  )
+    @index = index
+    @channels = channels
+    @role_options = role_options
+    @channels_by_id = channels_by_id
+    @default_channel_id = default_channel_id
+    @any_unassignable = any_unassignable
+    @set_id = set_id
+    @name = name
+    @selection_mode = selection_mode
+    @channel_override = channel_override
+    @selected_role_ids = selected_role_ids
+    @open = open
+  end
+
+  def view_template
+    details(
+      open: @open,
+      data: {role_set: true},
+      class: "group relative overflow-hidden rounded-card border border-border-default bg-surface-card shadow-sm"
+    ) do
+      hidden_fields
+      summary_row
+      delete_button
+      editor
+    end
+  end
+
+  private
+
+  def field(name)
+    "roles[role_sets][#{@index}][#{name}]"
+  end
+
+  def hidden_fields
+    input(type: "hidden", name: field(:id), value: @set_id, data: {role_set_id: true})
+    input(type: "hidden", name: field(:_destroy), value: "0", data: {role_set_destroy: true})
+  end
+
+  def summary_row
+    summary(class: "flex cursor-pointer list-none items-center gap-2 px-4 py-3 pr-24") do
+      div(class: "min-w-0 flex-1") do
+        div(class: "flex items-center gap-2") do
+          span(class: "truncate text-sm font-semibold") { @name.presence || t(".unnamed") }
+          render Components::Badge.new(variant: :brand, shape: :pill) { t(".mode.#{@selection_mode}") }
+        end
+        p(class: "mt-0.5 truncate text-xs text-text-muted") { subtitle }
+      end
+      render Components::Icon.new("caret-down", class: "dropdown-chevron size-4 flex-none text-text-muted group-open:rotate-180")
+    end
+  end
+
+  def delete_button
+    div(class: "absolute right-3 top-2.5") do
+      button(
+        type: "button",
+        title: t(".delete"),
+        aria_label: t(".delete"),
+        data: {action: "role-sets#remove"},
+        class: "#{ICON_BUTTON} hover:bg-danger-soft hover:text-danger"
+      ) { render Components::Icon.new("trash", class: "size-4") }
+    end
+  end
+
+  def editor
+    div(class: "grid gap-5 border-t border-border-subtle p-5") do
+      top_fields
+      channel_override_field
+      roles_field
+    end
+  end
+
+  def top_fields
+    div(class: "grid gap-5 sm:grid-cols-2") do
+      div do
+        label(class: "mb-1.5 block text-sm font-semibold") { t(".name.label") }
+        input(
+          type: "text",
+          name: field(:name),
+          value: @name,
+          required: true,
+          data: {role_set_name: true},
+          class: "h-10 w-full rounded-control border-[1.5px] border-border-strong bg-surface-card px-3 text-sm " \
+            "focus:border-accent focus:outline-none focus:ring-3 focus:ring-[var(--focus-ring)]"
+        )
+      end
+      div do
+        label(class: "mb-1.5 block text-sm font-semibold") { t(".selection.label") }
+        render Components::SegmentedControl.new(
+          name: field(:selection_mode),
+          value: @selection_mode,
+          options: [
+            {value: "single", label: t(".mode.single")},
+            {value: "multi", label: t(".mode.multi")}
+          ]
+        )
+      end
+    end
+  end
+
+  def channel_override_field
+    div do
+      label(class: "mb-1.5 block text-sm font-semibold") do
+        plain t(".channel.label")
+        span(class: "font-normal text-text-muted") { " #{t(".channel.optional")}" }
+      end
+      render Components::TomSelect.new(
+        name: field(:channel_override),
+        options: @channels,
+        selected: @channel_override,
+        placeholder: t(".channel.placeholder", channel: default_channel_label),
+        include_blank: true,
+        prefix: "#"
+      )
+    end
+  end
+
+  def roles_field
+    div do
+      label(class: "mb-1.5 block text-sm font-semibold") { t(".roles.label") }
+      render Components::TomSelect.new(
+        name: "#{field(:role_ids)}[]",
+        options: @role_options,
+        selected: @selected_role_ids,
+        placeholder: t(".roles.placeholder"),
+        multiple: true,
+        color_dots: true
+      )
+      unassignable_callout
+    end
+  end
+
+  def unassignable_callout
+    return unless @any_unassignable
+
+    div(class: "mt-2.5") do
+      render Components::Callout.new(variant: :warning) { t(".roles.unassignable") }
+    end
+  end
+
+  def subtitle
+    count = t(".roles.count", count: @selected_role_ids.size)
+    label = channel_label
+    label ? "##{label} · #{count}" : count
+  end
+
+  def channel_label
+    @channels_by_id[(@channel_override || @default_channel_id).to_i]
+  end
+
+  def default_channel_label
+    name = @channels_by_id[@default_channel_id.to_i]
+    name ? "##{name}" : t(".channel.no_default")
+  end
+end

--- a/app/components/roles/role_set_card.rb
+++ b/app/components/roles/role_set_card.rb
@@ -34,7 +34,7 @@ class Components::Roles::RoleSetCard < Components::Base
   def view_template
     details(
       open: @open,
-      data: {role_set: true},
+      data: {role_set: true, controller: "dropdown", dropdown_dismiss_on_outside_value: "false"},
       class: "rounded-card border border-border-default bg-surface-card shadow-sm"
     ) do
       hidden_fields
@@ -55,7 +55,10 @@ class Components::Roles::RoleSetCard < Components::Base
   end
 
   def summary_row
-    summary(class: "flex cursor-pointer list-none select-none items-center gap-2 px-4 py-3 [&::-webkit-details-marker]:hidden") do
+    summary(
+      class: "flex cursor-pointer list-none select-none items-center gap-2 px-4 py-3 [&::-webkit-details-marker]:hidden",
+      data: {action: "click->dropdown#toggle"}
+    ) do
       div(class: "min-w-0 flex-1") do
         div(class: "flex items-center gap-2") do
           span(class: "truncate text-sm font-semibold") { @name.presence || t(".unnamed") }
@@ -79,7 +82,7 @@ class Components::Roles::RoleSetCard < Components::Base
   end
 
   def editor
-    div(class: "grid gap-5 border-t border-border-subtle p-5") do
+    div(class: "dropdown-menu grid gap-5 border-t border-border-subtle p-5", data: {dropdown_target: "menu"}) do
       top_fields
       channel_override_field
       roles_field

--- a/app/components/segmented_control.rb
+++ b/app/components/segmented_control.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class Components::SegmentedControl < Components::Base
+  ACTIVE = "border-accent bg-accent-soft text-accent-soft-fg font-semibold"
+  INACTIVE = "border-border-default text-text-secondary font-medium"
+  BASE = "flex-1 h-10 rounded-control border-[1.5px] text-sm transition-colors"
+
+  def initialize(name:, value:, options:)
+    @name = name
+    @value = value.to_s
+    @options = options
+  end
+
+  def view_template
+    div(
+      class: "flex gap-2",
+      data: {controller: "segmented", segmented_active_class: ACTIVE, segmented_inactive_class: INACTIVE}
+    ) do
+      input(type: "hidden", name: @name, value: @value, data: {segmented_target: "input"})
+      @options.each { |opt| option_button(opt) }
+    end
+  end
+
+  private
+
+  def option_button(opt)
+    active = opt[:value].to_s == @value
+    button(
+      type: "button",
+      aria_pressed: active.to_s,
+      data: {segmented_target: "option", value: opt[:value], action: "segmented#select"},
+      class: "#{BASE} #{active ? ACTIVE : INACTIVE}"
+    ) { opt[:label] }
+  end
+end

--- a/app/components/tom_select.rb
+++ b/app/components/tom_select.rb
@@ -35,7 +35,7 @@ class Components::TomSelect < Components::Base
     attrs = {value: opt.value}
     attrs[:selected] = true if selected?(opt)
     attrs[:disabled] = true if opt.disabled
-    attrs[:data] = {data: opt.adornment.to_json} if opt.adornment.any?
+    attrs[:data] = opt.adornment if opt.adornment.any?
     attrs
   end
 

--- a/app/components/tom_select.rb
+++ b/app/components/tom_select.rb
@@ -1,24 +1,36 @@
 # frozen_string_literal: true
 
 class Components::TomSelect < Components::Base
-  Option = Data.define(:value, :label, :disabled) do
-    def self.for(value:, label:, disabled: false)
-      new(value: value, label: label, disabled: disabled)
+  Option = Data.define(:value, :label, :disabled, :color, :reason) do
+    def self.for(value:, label:, disabled: false, color: nil, reason: nil)
+      new(value: value, label: label, disabled: disabled, color: color, reason: reason)
     end
   end
 
-  def initialize(name:, options:, selected: nil, placeholder: nil, include_blank: false, prefix: nil, dom_id: nil)
+  def initialize(
+    name:,
+    options:,
+    selected: nil,
+    placeholder: nil,
+    include_blank: false,
+    prefix: nil,
+    multiple: false,
+    color_dots: false,
+    dom_id: nil
+  )
     @name = name
     @options = options
     @selected = selected
     @placeholder = placeholder
     @include_blank = include_blank
     @prefix = prefix
+    @multiple = multiple
+    @color_dots = color_dots
     @dom_id = dom_id
   end
 
   def view_template
-    select(name: @name, id: @dom_id, autocomplete: "off", class: "w-full", data: data) do
+    select(name: @name, id: @dom_id, multiple: @multiple, autocomplete: "off", class: "w-full", data: data) do
       option(value: "") if @include_blank
       @options.each do |opt|
         option(**option_attrs(opt)) { opt.label }
@@ -32,13 +44,25 @@ class Components::TomSelect < Components::Base
     attrs = {controller: "tom-select"}
     attrs[:tom_select_placeholder_value] = @placeholder if @placeholder
     attrs[:tom_select_prefix_value] = @prefix if @prefix
+    attrs[:tom_select_color_dots_value] = true if @color_dots
     attrs
   end
 
   def option_attrs(opt)
     attrs = {value: opt.value}
-    attrs[:selected] = true if @selected.present? && opt.value.to_s == @selected.to_s
+    attrs[:selected] = true if selected?(opt)
     attrs[:disabled] = true if opt.disabled
+    attrs[:data] = {data: adornment(opt)} if @color_dots
     attrs
+  end
+
+  def adornment(opt)
+    {color: opt.color, reason: opt.reason}.compact.to_json
+  end
+
+  def selected?(opt)
+    return false if @selected.blank?
+
+    Array(@selected).map(&:to_s).include?(opt.value.to_s)
   end
 end

--- a/app/components/tom_select.rb
+++ b/app/components/tom_select.rb
@@ -5,32 +5,23 @@ class Components::TomSelect < Components::Base
     def self.for(value:, label:, disabled: false, color: nil, reason: nil)
       new(value: value, label: label, disabled: disabled, color: color, reason: reason)
     end
+
+    def adornment
+      {color: color, reason: reason}.compact
+    end
   end
 
-  def initialize(
-    name:,
-    options:,
-    selected: nil,
-    placeholder: nil,
-    include_blank: false,
-    prefix: nil,
-    multiple: false,
-    color_dots: false,
-    dom_id: nil
-  )
+  def initialize(name:, options:, selected: nil, multiple: false, include_blank: false, controller_data: {})
     @name = name
     @options = options
     @selected = selected
-    @placeholder = placeholder
-    @include_blank = include_blank
-    @prefix = prefix
     @multiple = multiple
-    @color_dots = color_dots
-    @dom_id = dom_id
+    @include_blank = include_blank
+    @controller_data = controller_data
   end
 
   def view_template
-    select(name: @name, id: @dom_id, multiple: @multiple, autocomplete: "off", class: "w-full", data: data) do
+    select(name: @name, multiple: @multiple, autocomplete: "off", class: "w-full", data: {controller: "tom-select", **@controller_data}) do
       option(value: "") if @include_blank
       @options.each do |opt|
         option(**option_attrs(opt)) { opt.label }
@@ -40,24 +31,12 @@ class Components::TomSelect < Components::Base
 
   private
 
-  def data
-    attrs = {controller: "tom-select"}
-    attrs[:tom_select_placeholder_value] = @placeholder if @placeholder
-    attrs[:tom_select_prefix_value] = @prefix if @prefix
-    attrs[:tom_select_color_dots_value] = true if @color_dots
-    attrs
-  end
-
   def option_attrs(opt)
     attrs = {value: opt.value}
     attrs[:selected] = true if selected?(opt)
     attrs[:disabled] = true if opt.disabled
-    attrs[:data] = {data: adornment(opt)} if @color_dots
+    attrs[:data] = {data: opt.adornment.to_json} if opt.adornment.any?
     attrs
-  end
-
-  def adornment(opt)
-    {color: opt.color, reason: opt.reason}.compact.to_json
   end
 
   def selected?(opt)

--- a/app/components/welcomes/config_form.rb
+++ b/app/components/welcomes/config_form.rb
@@ -39,13 +39,12 @@ class Components::Welcomes::ConfigForm < Components::Base
       if channels.empty?
         p(class: "text-sm text-text-secondary") { t(".channel.none") }
       else
-        render Components::TomSelect.new(
+        render Components::ChannelSelect.new(
           name: "welcomes[channel_id]",
           options: channels,
           selected: @settings.channel_id,
           placeholder: t(".channel.placeholder"),
-          include_blank: true,
-          prefix: "#"
+          include_blank: true
         )
       end
     end

--- a/app/components/welcomes/config_form.rb
+++ b/app/components/welcomes/config_form.rb
@@ -130,9 +130,7 @@ class Components::Welcomes::ConfigForm < Components::Base
   end
 
   def channels
-    @channels ||= @config.server_channels.text.map do |channel|
-      Components::TomSelect::Option.for(value: channel.discord_id, label: channel.name)
-    end
+    @channels ||= ChannelOptions.new(@config).options
   end
 
   def camel(name)

--- a/app/controllers/concerns/configures_plugin.rb
+++ b/app/controllers/concerns/configures_plugin.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module ConfiguresPlugin
+  extend ActiveSupport::Concern
+
+  private
+
+  def plugin_enabled?
+    @server_configuration.plugins.enabled.exists?(key: controller_name)
+  end
+
+  def flash_for(result)
+    return {notice: t("servers.#{controller_name}.saved")} if result.success?
+
+    {alert: result.errors.to_sentence}
+  end
+end

--- a/app/controllers/servers/logging_controller.rb
+++ b/app/controllers/servers/logging_controller.rb
@@ -2,6 +2,7 @@
 
 class Servers::LoggingController < ApplicationController
   include RequiresManageableServer
+  include ConfiguresPlugin
 
   def show
     render Views::Servers::Logging::Show.new(
@@ -31,10 +32,6 @@ class Servers::LoggingController < ApplicationController
 
   private
 
-  def plugin_enabled?
-    @server_configuration.plugins.enabled.exists?(key: :logging)
-  end
-
   def submitted_actions
     raw = logging_params[:actions] || {}
     LoggableEventCatalog.all.to_h { |definition| [definition.key, ActiveModel::Type::Boolean.new.cast(raw[definition.key])] }
@@ -42,11 +39,5 @@ class Servers::LoggingController < ApplicationController
 
   def logging_params
     params.require(:logging).permit(:channel_id, :enabled, actions: {})
-  end
-
-  def flash_for(result)
-    return {notice: t("servers.logging.saved")} if result.success?
-
-    {alert: result.errors.to_sentence}
   end
 end

--- a/app/controllers/servers/roles_controller.rb
+++ b/app/controllers/servers/roles_controller.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+class Servers::RolesController < ApplicationController
+  include RequiresManageableServer
+
+  def show
+    render Views::Servers::Roles::Show.new(
+      server_configuration: @server_configuration,
+      user: current_user,
+      enabled: plugin_enabled?
+    )
+  end
+
+  def update
+    result = Ops::Roles::Configure.call(
+      server_configuration: @server_configuration,
+      channel_id: roles_params[:channel_id],
+      enabled: roles_params[:enabled],
+      role_sets: submitted_sets
+    )
+    @enabled = result.value.enabled?
+    @success = result.success?
+    @toast =
+      if result.success?
+        {level: "notice", message: t("servers.roles.saved")}
+      else
+        {level: "alert", message: result.errors.to_sentence.presence || t("servers.roles.failed")}
+      end
+
+    respond_to do |format|
+      format.turbo_stream { render status: result.success? ? :ok : :unprocessable_content }
+      format.html { redirect_to server_roles_path(params[:server_id]), **flash_for(result) }
+    end
+  end
+
+  private
+
+  def plugin_enabled?
+    @server_configuration.plugins.enabled.exists?(key: :roles)
+  end
+
+  def submitted_sets
+    raw = roles_params[:role_sets]
+    list = raw.respond_to?(:values) ? raw.values : Array(raw)
+    list.map { |set| set.to_h.symbolize_keys }
+  end
+
+  def roles_params
+    params.require(:roles).permit(
+      :channel_id,
+      :enabled,
+      role_sets: [:id, :name, :selection_mode, :channel_override, :_destroy, {role_ids: []}]
+    )
+  end
+
+  def flash_for(result)
+    return {notice: t("servers.roles.saved")} if result.success?
+
+    {alert: result.errors.to_sentence}
+  end
+end

--- a/app/controllers/servers/roles_controller.rb
+++ b/app/controllers/servers/roles_controller.rb
@@ -18,7 +18,6 @@ class Servers::RolesController < ApplicationController
       enabled: roles_params[:enabled],
       role_sets: submitted_sets
     )
-    @enabled = result.value.enabled?
     @success = result.success?
     @toast =
       if result.success?

--- a/app/controllers/servers/roles_controller.rb
+++ b/app/controllers/servers/roles_controller.rb
@@ -2,6 +2,7 @@
 
 class Servers::RolesController < ApplicationController
   include RequiresManageableServer
+  include ConfiguresPlugin
 
   def show
     render Views::Servers::Roles::Show.new(
@@ -34,10 +35,6 @@ class Servers::RolesController < ApplicationController
 
   private
 
-  def plugin_enabled?
-    @server_configuration.plugins.enabled.exists?(key: :roles)
-  end
-
   def submitted_sets
     raw = roles_params[:role_sets]
     list = raw.respond_to?(:values) ? raw.values : Array(raw)
@@ -50,11 +47,5 @@ class Servers::RolesController < ApplicationController
       :enabled,
       role_sets: [:id, :name, :selection_mode, :channel_override, :_destroy, {role_ids: []}]
     )
-  end
-
-  def flash_for(result)
-    return {notice: t("servers.roles.saved")} if result.success?
-
-    {alert: result.errors.to_sentence}
   end
 end

--- a/app/controllers/servers/welcomes_controller.rb
+++ b/app/controllers/servers/welcomes_controller.rb
@@ -2,6 +2,7 @@
 
 class Servers::WelcomesController < ApplicationController
   include RequiresManageableServer
+  include ConfiguresPlugin
 
   def show
     render Views::Servers::Welcomes::Show.new(
@@ -32,17 +33,7 @@ class Servers::WelcomesController < ApplicationController
 
   private
 
-  def plugin_enabled?
-    @server_configuration.plugins.enabled.exists?(key: :welcomes)
-  end
-
   def welcomes_params
     params.expect(welcomes: [:channel_id, :join_message, :leave_message, :enabled])
-  end
-
-  def flash_for(result)
-    return {notice: t("servers.welcomes.saved")} if result.success?
-
-    {alert: result.errors.to_sentence}
   end
 end

--- a/app/javascript/controllers/enable_gate_controller.js
+++ b/app/javascript/controllers/enable_gate_controller.js
@@ -5,13 +5,6 @@ export default class extends Controller {
 
   connect() {
     this.update()
-    // reset fires before the control's value updates, so re-veil on the next frame
-    this.onReset = () => requestAnimationFrame(() => this.update())
-    this.element.addEventListener("reset", this.onReset)
-  }
-
-  disconnect() {
-    this.element.removeEventListener("reset", this.onReset)
   }
 
   update() {

--- a/app/javascript/controllers/role_sets_controller.js
+++ b/app/javascript/controllers/role_sets_controller.js
@@ -1,0 +1,30 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["list", "template"]
+
+  add() {
+    const uid = Date.now()
+    const html = this.templateTarget.innerHTML.replaceAll("NEW_RECORD", uid)
+    this.listTarget.insertAdjacentHTML("beforeend", html)
+    this.notifyDirty()
+    this.listTarget.lastElementChild?.querySelector("[data-role-set-name]")?.focus()
+  }
+
+  remove(event) {
+    const card = event.currentTarget.closest("[data-role-set]")
+    const id = card.querySelector("[data-role-set-id]")
+    if (id?.value) {
+      card.querySelector("[data-role-set-destroy]").value = "1"
+      card.querySelector("[data-role-set-name]")?.removeAttribute("required")
+      card.hidden = true
+    } else {
+      card.remove()
+    }
+    this.notifyDirty()
+  }
+
+  notifyDirty() {
+    this.element.dispatchEvent(new Event("input", { bubbles: true }))
+  }
+}

--- a/app/javascript/controllers/role_sets_controller.js
+++ b/app/javascript/controllers/role_sets_controller.js
@@ -7,11 +7,16 @@ export default class extends Controller {
     // <details> toggle events don't bubble, so capture them to keep the open-set current
     this.onToggle = () => this.persistOpen()
     this.element.addEventListener("toggle", this.onToggle, true)
+    // a default-open new set never fires toggle, so also snapshot right before a save
+    this.form = this.element.closest("form")
+    this.onSubmit = () => this.persistOpen()
+    this.form?.addEventListener("submit", this.onSubmit)
     this.restoreOpen()
   }
 
   disconnect() {
     this.element.removeEventListener("toggle", this.onToggle, true)
+    this.form?.removeEventListener("submit", this.onSubmit)
   }
 
   add() {
@@ -41,19 +46,20 @@ export default class extends Controller {
     this.element.dispatchEvent(new Event("input", {bubbles: true}))
   }
 
-  // Open/closed state is client-only, so it's lost when a save re-renders this
-  // list or a discard reloads the page. Persist the open sets (by id) so the
-  // same ones reopen. New unsaved sets have no id yet and collapse on save.
+  // Open/closed state is client-only, so it's lost when a save re-renders this list
+  // or a discard reloads the page. Persist the open sets and restore on connect.
+  // Existing sets key on their id; a brand-new set has none yet, so it keys on its
+  // name until the save assigns an id (two sets sharing a name could both reopen).
   restoreOpen() {
     const open = this.openSet()
     this.cards().forEach((card) => {
-      if (open.has(this.cardId(card))) card.open = true
+      if (this.cardKeys(card).some((key) => open.has(key))) card.open = true
     })
   }
 
   persistOpen() {
-    const ids = this.cards().filter((card) => card.open).map((card) => this.cardId(card)).filter(Boolean)
-    sessionStorage.setItem(this.storageKey, JSON.stringify(ids))
+    const keys = this.cards().filter((card) => card.open).map((card) => this.cardKeys(card)[0]).filter(Boolean)
+    sessionStorage.setItem(this.storageKey, JSON.stringify(keys))
   }
 
   openSet() {
@@ -68,8 +74,8 @@ export default class extends Controller {
     return Array.from(this.element.querySelectorAll("[data-role-set]"))
   }
 
-  cardId(card) {
-    return card.querySelector("[data-role-set-id]")?.value
+  cardKeys(card) {
+    return [card.querySelector("[data-role-set-id]")?.value, card.querySelector("[data-role-set-name]")?.value].filter(Boolean)
   }
 
   get storageKey() {

--- a/app/javascript/controllers/role_sets_controller.js
+++ b/app/javascript/controllers/role_sets_controller.js
@@ -20,8 +20,9 @@ export default class extends Controller {
   }
 
   add() {
-    const uid = Date.now()
-    const html = this.templateTarget.innerHTML.replaceAll("NEW_RECORD", uid)
+    // monotonic so two adds in the same millisecond can't share a field-name index
+    this.seq = this.seq === undefined ? Date.now() : this.seq + 1
+    const html = this.templateTarget.innerHTML.replaceAll("NEW_RECORD", this.seq)
     this.listTarget.insertAdjacentHTML("beforeend", html)
     this.notifyDirty()
     this.listTarget.lastElementChild?.querySelector("[data-role-set-name]")?.focus()

--- a/app/javascript/controllers/role_sets_controller.js
+++ b/app/javascript/controllers/role_sets_controller.js
@@ -12,6 +12,7 @@ export default class extends Controller {
   }
 
   remove(event) {
+    event.preventDefault() // the button lives inside <summary>; don't toggle the disclosure
     const card = event.currentTarget.closest("[data-role-set]")
     const id = card.querySelector("[data-role-set-id]")
     if (id?.value) {

--- a/app/javascript/controllers/role_sets_controller.js
+++ b/app/javascript/controllers/role_sets_controller.js
@@ -3,6 +3,17 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ["list", "template"]
 
+  connect() {
+    // <details> toggle events don't bubble, so capture them to keep the open-set current
+    this.onToggle = () => this.persistOpen()
+    this.element.addEventListener("toggle", this.onToggle, true)
+    this.restoreOpen()
+  }
+
+  disconnect() {
+    this.element.removeEventListener("toggle", this.onToggle, true)
+  }
+
   add() {
     const uid = Date.now()
     const html = this.templateTarget.innerHTML.replaceAll("NEW_RECORD", uid)
@@ -12,7 +23,8 @@ export default class extends Controller {
   }
 
   remove(event) {
-    event.preventDefault() // the button lives inside <summary>; don't toggle the disclosure
+    event.preventDefault()
+    event.stopPropagation() // the button lives inside <summary>; don't toggle the disclosure
     const card = event.currentTarget.closest("[data-role-set]")
     const id = card.querySelector("[data-role-set-id]")
     if (id?.value) {
@@ -26,6 +38,41 @@ export default class extends Controller {
   }
 
   notifyDirty() {
-    this.element.dispatchEvent(new Event("input", { bubbles: true }))
+    this.element.dispatchEvent(new Event("input", {bubbles: true}))
+  }
+
+  // Open/closed state is client-only, so it's lost when a save re-renders this
+  // list or a discard reloads the page. Persist the open sets (by id) so the
+  // same ones reopen. New unsaved sets have no id yet and collapse on save.
+  restoreOpen() {
+    const open = this.openSet()
+    this.cards().forEach((card) => {
+      if (open.has(this.cardId(card))) card.open = true
+    })
+  }
+
+  persistOpen() {
+    const ids = this.cards().filter((card) => card.open).map((card) => this.cardId(card)).filter(Boolean)
+    sessionStorage.setItem(this.storageKey, JSON.stringify(ids))
+  }
+
+  openSet() {
+    try {
+      return new Set(JSON.parse(sessionStorage.getItem(this.storageKey) || "[]"))
+    } catch {
+      return new Set()
+    }
+  }
+
+  cards() {
+    return Array.from(this.element.querySelectorAll("[data-role-set]"))
+  }
+
+  cardId(card) {
+    return card.querySelector("[data-role-set-id]")?.value
+  }
+
+  get storageKey() {
+    return `role-sets-open:${window.location.pathname}`
   }
 }

--- a/app/javascript/controllers/save_bar_controller.js
+++ b/app/javascript/controllers/save_bar_controller.js
@@ -9,6 +9,7 @@ export default class extends Controller {
     if (sessionStorage.getItem("save-bar-discarded")) {
       sessionStorage.removeItem("save-bar-discarded")
       this.showDiscardedToast()
+      this.restoreScroll()
     }
     this.blockVisit = (event) => {
       if (!this.dirty) return
@@ -47,7 +48,16 @@ export default class extends Controller {
     // reload from the server, not form.reset(): reset reverts to stale render-time defaults and can't undo card add/remove
     this.dirty = false
     sessionStorage.setItem("save-bar-discarded", "1")
+    sessionStorage.setItem("save-bar-scroll", String(window.scrollY))
     window.Turbo.visit(window.location.href, {action: "replace"})
+  }
+
+  restoreScroll() {
+    const y = sessionStorage.getItem("save-bar-scroll")
+    sessionStorage.removeItem("save-bar-scroll")
+    if (y === null) return
+    // after the reopened cards have laid out, so the offset still lands right
+    requestAnimationFrame(() => window.scrollTo(0, parseInt(y, 10)))
   }
 
   showDiscardedToast() {

--- a/app/javascript/controllers/save_bar_controller.js
+++ b/app/javascript/controllers/save_bar_controller.js
@@ -6,6 +6,10 @@ export default class extends Controller {
   connect() {
     this.baseline = this.snapshot()
     this.dirty = false
+    if (sessionStorage.getItem("save-bar-discarded")) {
+      sessionStorage.removeItem("save-bar-discarded")
+      this.showDiscardedToast()
+    }
     this.blockVisit = (event) => {
       if (!this.dirty) return
       event.preventDefault()
@@ -40,10 +44,10 @@ export default class extends Controller {
 
   discard(event) {
     event.preventDefault()
-    this.element.reset() // tom-select + enable-gate repaint on the reset event
-    this.baseline = this.snapshot()
-    this.setDirty(false)
-    this.showDiscardedToast()
+    // reload from the server, not form.reset(): reset reverts to stale render-time defaults and can't undo card add/remove
+    this.dirty = false
+    sessionStorage.setItem("save-bar-discarded", "1")
+    window.Turbo.visit(window.location.href, {action: "replace"})
   }
 
   showDiscardedToast() {

--- a/app/javascript/controllers/segmented_controller.js
+++ b/app/javascript/controllers/segmented_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["input", "option"]
+  static classes = ["active", "inactive"]
+
+  select(event) {
+    const value = event.currentTarget.dataset.value
+    this.inputTarget.value = value
+    this.optionTargets.forEach((option) => {
+      const active = option.dataset.value === value
+      option.setAttribute("aria-pressed", active)
+      option.classList.remove(...(active ? this.inactiveClasses : this.activeClasses))
+      option.classList.add(...(active ? this.activeClasses : this.inactiveClasses))
+    })
+    this.inputTarget.dispatchEvent(new Event("input", { bubbles: true }))
+  }
+}

--- a/app/javascript/controllers/tom_select_controller.js
+++ b/app/javascript/controllers/tom_select_controller.js
@@ -1,10 +1,8 @@
 import { Controller } from "@hotwired/stimulus"
 import TomSelect from "tom-select"
 
-const LOCK_SVG = `<svg viewBox="0 0 256 256" fill="currentColor" aria-hidden="true"><path d="M208 80h-32V56a48 48 0 0 0-96 0v24H48a16 16 0 0 0-16 16v112a16 16 0 0 0 16 16h160a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16ZM96 56a32 32 0 0 1 64 0v24H96Zm112 152H48V96h160z"/></svg>`
-
 export default class extends Controller {
-  static values = { placeholder: String, prefix: String, colorDots: Boolean }
+  static values = { placeholder: String, prefix: String, colorDots: Boolean, lockIcon: String }
 
   connect() {
     this.select = new TomSelect(this.element, {
@@ -39,7 +37,7 @@ export default class extends Controller {
   roleRenderers() {
     const row = (data, escape) => {
       const dot = data.color ? `<span class="ts-dot" style="background:${escape(data.color)}"></span>` : ""
-      const lock = data.reason ? `<span class="ts-lock" title="${escape(data.reason)}">${LOCK_SVG}</span>` : ""
+      const lock = data.reason ? `<span class="ts-lock" title="${escape(data.reason)}">${this.lockIconValue}</span>` : ""
       return `<div title="${data.reason ? escape(data.reason) : ""}">${dot}${escape(data.text)}${lock}</div>`
     }
     return { option: row, item: row }

--- a/app/javascript/controllers/tom_select_controller.js
+++ b/app/javascript/controllers/tom_select_controller.js
@@ -11,14 +11,9 @@ export default class extends Controller {
       placeholder: this.placeholderValue || undefined,
       allowEmptyOption: false,
       maxOptions: null,
-      dataAttr: "data-data",
       plugins: this.plugins(),
       render: this.renderers()
     })
-    // a form reset restores the <select> but not Tom Select's UI; re-sync once it settles
-    this.form = this.element.form
-    this.onReset = () => requestAnimationFrame(() => this.select?.sync())
-    this.form?.addEventListener("reset", this.onReset)
   }
 
   plugins() {
@@ -51,7 +46,6 @@ export default class extends Controller {
   }
 
   disconnect() {
-    this.form?.removeEventListener("reset", this.onReset)
     this.select?.destroy()
   }
 }

--- a/app/javascript/controllers/tom_select_controller.js
+++ b/app/javascript/controllers/tom_select_controller.js
@@ -1,8 +1,10 @@
 import { Controller } from "@hotwired/stimulus"
 import TomSelect from "tom-select"
 
+const LOCK_SVG = `<svg viewBox="0 0 256 256" fill="currentColor" aria-hidden="true"><path d="M208 80h-32V56a48 48 0 0 0-96 0v24H48a16 16 0 0 0-16 16v112a16 16 0 0 0 16 16h160a16 16 0 0 0 16-16V96a16 16 0 0 0-16-16ZM96 56a32 32 0 0 1 64 0v24H96Zm112 152H48V96h160z"/></svg>`
+
 export default class extends Controller {
-  static values = { placeholder: String, prefix: String }
+  static values = { placeholder: String, prefix: String, colorDots: Boolean }
 
   connect() {
     this.select = new TomSelect(this.element, {
@@ -10,12 +12,18 @@ export default class extends Controller {
       allowEmptyOption: false,
       maxOptions: null,
       plugins: ["dropdown_input"],
-      render: this.prefixValue ? this.prefixRenderers() : {}
+      render: this.renderers()
     })
     // a form reset restores the <select> but not Tom Select's UI; re-sync once it settles
     this.form = this.element.form
     this.onReset = () => requestAnimationFrame(() => this.select?.sync())
     this.form?.addEventListener("reset", this.onReset)
+  }
+
+  renderers() {
+    if (this.colorDotsValue) return this.roleRenderers()
+    if (this.prefixValue) return this.prefixRenderers()
+    return {}
   }
 
   prefixRenderers() {
@@ -24,6 +32,15 @@ export default class extends Controller {
       const label = escape(data.text)
       if (!data.value) return `<div>${label}</div>`
       return `<div><span class="ts-prefix">${escape(prefix)}</span>${label}</div>`
+    }
+    return { option: row, item: row }
+  }
+
+  roleRenderers() {
+    const row = (data, escape) => {
+      const dot = data.color ? `<span class="ts-dot" style="background:${escape(data.color)}"></span>` : ""
+      const lock = data.reason ? `<span class="ts-lock" title="${escape(data.reason)}">${LOCK_SVG}</span>` : ""
+      return `<div title="${data.reason ? escape(data.reason) : ""}">${dot}${escape(data.text)}${lock}</div>`
     }
     return { option: row, item: row }
   }

--- a/app/javascript/controllers/tom_select_controller.js
+++ b/app/javascript/controllers/tom_select_controller.js
@@ -11,13 +11,18 @@ export default class extends Controller {
       placeholder: this.placeholderValue || undefined,
       allowEmptyOption: false,
       maxOptions: null,
-      plugins: ["dropdown_input"],
+      dataAttr: "data-data",
+      plugins: this.plugins(),
       render: this.renderers()
     })
     // a form reset restores the <select> but not Tom Select's UI; re-sync once it settles
     this.form = this.element.form
     this.onReset = () => requestAnimationFrame(() => this.select?.sync())
     this.form?.addEventListener("reset", this.onReset)
+  }
+
+  plugins() {
+    return this.colorDotsValue ? ["dropdown_input", "remove_button"] : ["dropdown_input", "clear_button"]
   }
 
   renderers() {

--- a/app/operations/logging/configure.rb
+++ b/app/operations/logging/configure.rb
@@ -3,6 +3,8 @@
 module Ops
   module Logging
     class Configure < ApplicationOperation
+      include Ops::PluginConfiguration
+
       receives :server_configuration, :channel_id, :enabled_actions, :enabled
 
       def call
@@ -19,14 +21,8 @@ module Ops
 
       private
 
-      def staged_activation
-        activation = server_configuration.plugin_activations.find_or_initialize_by(plugin: Plugin.find_by!(key: :logging))
-        activation.enabled = enabled
-        activation
-      end
-
-      def messages(*records)
-        records.flat_map { |record| record.errors.full_messages }
+      def plugin_key
+        :logging
       end
     end
   end

--- a/app/operations/plugin_configuration.rb
+++ b/app/operations/plugin_configuration.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Ops
+  module PluginConfiguration
+    private
+
+    def staged_activation
+      activation = server_configuration.plugin_activations.find_or_initialize_by(plugin: Plugin.find_by!(key: plugin_key))
+      activation.enabled = enabled
+      activation
+    end
+
+    def plugin_key
+      raise AbstractMethodError, "#{self.class} must implement #plugin_key"
+    end
+
+    def messages(*records)
+      records.flat_map { |record| record.errors.full_messages }
+    end
+  end
+end

--- a/app/operations/roles/configure.rb
+++ b/app/operations/roles/configure.rb
@@ -3,6 +3,8 @@
 module Ops
   module Roles
     class Configure < ApplicationOperation
+      include Ops::PluginConfiguration
+
       receives :server_configuration, :channel_id, :enabled, :role_sets
 
       def call
@@ -68,18 +70,12 @@ module Ops
         server_configuration.role_setting.role_sets.maximum(:position) || -1
       end
 
-      def staged_activation
-        activation = server_configuration.plugin_activations.find_or_initialize_by(plugin: Plugin.find_by!(key: :roles))
-        activation.enabled = enabled
-        activation
+      def plugin_key
+        :roles
       end
 
       def truthy?(value)
         ActiveModel::Type::Boolean.new.cast(value)
-      end
-
-      def messages(*records)
-        records.flat_map { |record| record.errors.full_messages }
       end
     end
   end

--- a/app/operations/roles/configure.rb
+++ b/app/operations/roles/configure.rb
@@ -25,8 +25,10 @@ module Ops
       private
 
       def reconcile_sets(setting)
-        kept = role_sets.reject { |attrs| truthy?(attrs[:_destroy]) }.map do |attrs|
+        kept = role_sets.reject { |attrs| truthy?(attrs[:_destroy]) }.filter_map do |attrs|
           set = find_or_build_set(setting, attrs)
+          next unless set
+
           set.update!(name: attrs[:name], selection_mode: attrs[:selection_mode], channel_override: attrs[:channel_override].presence)
           reconcile_roles(set, assignable_ids(attrs))
           set.id
@@ -35,9 +37,9 @@ module Ops
       end
 
       def find_or_build_set(setting, attrs)
-        return setting.role_sets.find(attrs[:id]) if attrs[:id].present?
+        return setting.role_sets.find_by(id: attrs[:id]) if attrs[:id].present?
 
-        setting.role_sets.new(position: next_position(setting))
+        setting.role_sets.new(position: next_position)
       end
 
       def reconcile_roles(set, role_ids)
@@ -50,12 +52,20 @@ module Ops
       end
 
       def assignable_ids(attrs)
-        submitted = Array(attrs[:role_ids]).map(&:to_i)
-        submitted & server_configuration.server_roles.pluck(:discord_id)
+        Array(attrs[:role_ids]).map(&:to_i) & valid_role_ids
       end
 
-      def next_position(setting)
-        (setting.role_sets.maximum(:position) || -1) + 1
+      def valid_role_ids
+        @valid_role_ids ||= server_configuration.server_roles.pluck(:discord_id)
+      end
+
+      def next_position
+        @next_position = existing_max_position if @next_position.nil?
+        @next_position += 1
+      end
+
+      def existing_max_position
+        server_configuration.role_setting.role_sets.maximum(:position) || -1
       end
 
       def staged_activation

--- a/app/operations/roles/configure.rb
+++ b/app/operations/roles/configure.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Ops
+  module Roles
+    class Configure < ApplicationOperation
+      receives :server_configuration, :channel_id, :enabled, :role_sets
+
+      def call
+        setting = server_configuration.role_setting
+        setting.channel_id = channel_id.presence
+        activation = staged_activation
+
+        return failure(messages(setting, activation), value: activation) unless setting.valid? && activation.valid?
+
+        ActiveRecord::Base.transaction do
+          setting.save!
+          reconcile_sets(setting)
+          activation.save!
+        end
+        ok(activation)
+      rescue ActiveRecord::RecordInvalid => error
+        failure([error.record.errors.full_messages.to_sentence], value: activation)
+      end
+
+      private
+
+      def reconcile_sets(setting)
+        kept = role_sets.reject { |attrs| truthy?(attrs[:_destroy]) }.map do |attrs|
+          set = find_or_build_set(setting, attrs)
+          set.update!(name: attrs[:name], selection_mode: attrs[:selection_mode], channel_override: attrs[:channel_override].presence)
+          reconcile_roles(set, assignable_ids(attrs))
+          set.id
+        end
+        setting.role_sets.where.not(id: kept).destroy_all
+      end
+
+      def find_or_build_set(setting, attrs)
+        return setting.role_sets.find(attrs[:id]) if attrs[:id].present?
+
+        setting.role_sets.new(position: next_position(setting))
+      end
+
+      def reconcile_roles(set, role_ids)
+        existing = set.assignable_roles.index_by { |role| role.role_id }
+        role_ids.each_with_index do |role_id, index|
+          role = existing[role_id] || set.assignable_roles.new(role_id: role_id)
+          role.update!(position: index)
+        end
+        set.assignable_roles.where.not(role_id: role_ids).destroy_all
+      end
+
+      def assignable_ids(attrs)
+        submitted = Array(attrs[:role_ids]).map(&:to_i)
+        submitted & server_configuration.server_roles.pluck(:discord_id)
+      end
+
+      def next_position(setting)
+        (setting.role_sets.maximum(:position) || -1) + 1
+      end
+
+      def staged_activation
+        activation = server_configuration.plugin_activations.find_or_initialize_by(plugin: Plugin.find_by!(key: :roles))
+        activation.enabled = enabled
+        activation
+      end
+
+      def truthy?(value)
+        ActiveModel::Type::Boolean.new.cast(value)
+      end
+
+      def messages(*records)
+        records.flat_map { |record| record.errors.full_messages }
+      end
+    end
+  end
+end

--- a/app/operations/server_configuration/server_roles/sync.rb
+++ b/app/operations/server_configuration/server_roles/sync.rb
@@ -9,7 +9,7 @@ module Ops
         def call
           roles.each do |data|
             role = server_configuration.server_roles.find_or_initialize_by(discord_id: data[:discord_id])
-            role.update!(name: data[:name], position: data[:position], managed: data[:managed])
+            role.update!(name: data[:name], position: data[:position], managed: data[:managed], color: data[:color] || 0)
           end
           server_configuration.server_roles.where.not(discord_id: roles.map { |r| r[:discord_id] }).delete_all
           server_configuration.update!(bot_role_position: bot_role_position)

--- a/app/operations/welcomes/configure.rb
+++ b/app/operations/welcomes/configure.rb
@@ -3,6 +3,8 @@
 module Ops
   module Welcomes
     class Configure < ApplicationOperation
+      include Ops::PluginConfiguration
+
       receives :server_configuration, :channel_id, :join_message, :leave_message, :enabled
 
       def call
@@ -19,14 +21,8 @@ module Ops
 
       private
 
-      def staged_activation
-        activation = server_configuration.plugin_activations.find_or_initialize_by(plugin: Plugin.find_by!(key: :welcomes))
-        activation.enabled = enabled
-        activation
-      end
-
-      def messages(*records)
-        records.flat_map { |record| record.errors.full_messages }
+      def plugin_key
+        :welcomes
       end
     end
   end

--- a/app/presenters/assignable_role_options.rb
+++ b/app/presenters/assignable_role_options.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class AssignableRoleOptions
+  DEFAULT_COLOR = "#99aab5"
+
+  def initialize(server_configuration)
+    @config = server_configuration
+  end
+
+  def options
+    assignable_roles.map do |role|
+      Components::TomSelect::Option.for(
+        value: role.discord_id,
+        label: role.name,
+        color: color_hex(role.color),
+        disabled: reason_for(role).present?,
+        reason: reason_for(role)
+      )
+    end
+  end
+
+  def any_unassignable?
+    assignable_roles.any? { |role| reason_for(role).present? }
+  end
+
+  private
+
+  def assignable_roles
+    @assignable_roles ||= @config.server_roles
+      .where.not(discord_id: @config.discord_id)
+      .order(position: :desc)
+  end
+
+  def reason_for(role)
+    return I18n.t("assignable_roles.managed") if role.managed?
+    return I18n.t("assignable_roles.above_bot") if role.position.to_i >= bot_position
+
+    nil
+  end
+
+  def bot_position
+    @bot_position ||= @config.bot_role_position || 0
+  end
+
+  def color_hex(color)
+    return DEFAULT_COLOR if color.nil? || color.zero?
+
+    format("#%06x", color & 0xFFFFFF)
+  end
+end

--- a/app/presenters/assignable_role_options.rb
+++ b/app/presenters/assignable_role_options.rb
@@ -33,13 +33,13 @@ class AssignableRoleOptions
 
   def reason_for(role)
     return I18n.t("assignable_roles.managed") if role.managed?
-    return I18n.t("assignable_roles.above_bot") if role.position.to_i >= bot_position
+    return I18n.t("assignable_roles.above_bot") if bot_position && role.position.to_i >= bot_position
 
     nil
   end
 
   def bot_position
-    @bot_position ||= @config.bot_role_position || 0
+    @config.bot_role_position
   end
 
   def color_hex(color)

--- a/app/presenters/channel_options.rb
+++ b/app/presenters/channel_options.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class ChannelOptions
+  def initialize(server_configuration)
+    @config = server_configuration
+  end
+
+  def options
+    @config.server_channels.text.map do |channel|
+      Components::TomSelect::Option.for(value: channel.discord_id, label: channel.name)
+    end
+  end
+end

--- a/app/views/servers/roles/show.rb
+++ b/app/views/servers/roles/show.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class Views::Servers::Roles::Show < Views::Base
+  def initialize(server_configuration:, user:, enabled:)
+    @config = server_configuration
+    @user = user
+    @enabled = enabled
+  end
+
+  def view_template
+    render Components::AppShell.new(
+      user: @user,
+      sidebar: Components::PluginSidebar.new(server_configuration: @config, active_key: :roles)
+    ) do
+      render Components::ConfigPage.new(
+        icon: "users-three",
+        title: t(".title"),
+        description: t(".description"),
+        dashboard_path: server_path(@config.discord_id),
+        gate: {
+          url: server_roles_path(@config.discord_id),
+          field: "roles[enabled]",
+          enabled: @enabled,
+          message: t(".gate_message")
+        }
+      ) do
+        render Components::Roles::ConfigForm.new(server_configuration: @config)
+      end
+    end
+  end
+end

--- a/app/views/servers/roles/update.turbo_stream.erb
+++ b/app/views/servers/roles/update.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%= turbo_stream.replace "roles-config", html: render(Components::Roles::ConfigForm.new(server_configuration: @server_configuration)) if @success %>
+<%= turbo_stream.append "toasts", html: render(Components::Toast.new(**@toast)) %>

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -1,5 +1,8 @@
 ---
 en:
+  assignable_roles:
+    above_bot: Above shrkbot — it ranks below this role.
+    managed: Managed by Discord — bots can't assign integration roles.
   authentication:
     login_required: Please sign in to continue.
   components:
@@ -65,6 +68,39 @@ en:
     plugin_sidebar:
       dashboard: Dashboard
       plugins: Plugins
+    roles:
+      config_form:
+        channel:
+          help: Each role set posts here unless it has its own channel override.
+          label: Default channel for role menus
+          none: No channels have synced yet. shrkbot needs to be in the server first.
+          placeholder: Choose a channel
+        sets:
+          add: Add role set
+          label: Role sets
+      role_set_card:
+        channel:
+          label: Channel override
+          no_default: no default set
+          optional: "(optional)"
+          placeholder: Use plugin default (%{channel})
+        delete: Delete role set
+        mode:
+          multi: Multi
+          single: Single
+        name:
+          label: Set name
+        roles:
+          count:
+            one: "%{count} role"
+            other: "%{count} roles"
+          label: Assignable roles
+          placeholder: Choose roles members can pick
+          unassignable: Greyed-out roles can't be assigned. shrkbot can only assign
+            roles below its own highest role, and never Discord-managed ones.
+        selection:
+          label: Selection type
+        unnamed: Untitled role set
     save_bar:
       discard: Discard
       discarded: Changes discarded
@@ -102,6 +138,9 @@ en:
     not_found: That server isn't available to configure.
     plugin_disabled: "%{plugin} disabled."
     plugin_enabled: "%{plugin} enabled."
+    roles:
+      failed: Couldn't save the role settings.
+      saved: Role settings saved.
     unknown_plugin: That plugin doesn't exist.
     welcomes:
       saved: Welcomes settings saved.
@@ -145,6 +184,12 @@ en:
           description: Record moderation events to a channel of your choice.
           gate_message: Enable the plugin to choose a channel and pick events.
           title: Logging
+      roles:
+        show:
+          description: Let members give themselves roles from a menu you post in a
+            channel.
+          gate_message: Enable the plugin to configure role sets.
+          title: Roles
       show:
         breadcrumb_servers: Servers
         channels:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
     scope module: :servers do
       resource :welcomes, only: [:show, :update]
       resource :logging, only: [:show, :update], controller: "logging"
+      resource :roles, only: [:show, :update]
     end
   end
 

--- a/db/migrate/20260628220015_add_color_to_server_roles.rb
+++ b/db/migrate/20260628220015_add_color_to_server_roles.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddColorToServerRoles < ActiveRecord::Migration[8.1]
+  def change
+    add_column :server_roles, :color, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_22_120306) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_28_220015) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -42,7 +42,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_22_120306) do
     t.string "target_type", null: false
     t.datetime "updated_at", null: false
     t.index ["server_channel_id", "target_id"], name: "index_channel_overwrites_on_server_channel_id_and_target_id", unique: true
-    t.check_constraint "target_type::text = ANY (ARRAY['role'::character varying, 'member'::character varying]::text[])", name: "channel_overwrites_target_type_check"
+    t.check_constraint "target_type::text = ANY (ARRAY['role'::character varying::text, 'member'::character varying::text])", name: "channel_overwrites_target_type_check"
   end
 
   create_table "logging_settings", id: :string, default: -> { "('lgs_'::text || gen_random_uuid())" }, force: :cascade do |t|
@@ -96,7 +96,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_22_120306) do
     t.string "selection_mode", null: false
     t.datetime "updated_at", null: false
     t.index ["role_setting_id"], name: "index_role_sets_on_role_setting_id"
-    t.check_constraint "selection_mode::text = ANY (ARRAY['single'::character varying, 'multi'::character varying]::text[])", name: "role_sets_selection_mode_check"
+    t.check_constraint "selection_mode::text = ANY (ARRAY['single'::character varying::text, 'multi'::character varying::text])", name: "role_sets_selection_mode_check"
   end
 
   create_table "role_settings", id: :string, default: -> { "('rls_'::text || gen_random_uuid())" }, force: :cascade do |t|
@@ -128,6 +128,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_22_120306) do
   end
 
   create_table "server_roles", id: :string, default: -> { "('srl_'::text || gen_random_uuid())" }, force: :cascade do |t|
+    t.integer "color", default: 0, null: false
     t.datetime "created_at", null: false
     t.bigint "discord_id", null: false
     t.boolean "managed", default: false, null: false

--- a/spec/bot/guild_metadata_spec.rb
+++ b/spec/bot/guild_metadata_spec.rb
@@ -27,10 +27,10 @@ RSpec.describe GuildMetadata do
   describe ".roles" do
     subject(:roles) { described_class.roles(server) }
 
-    let(:server) { double("server", roles: [double("role", id: 222, name: "Admin", position: 3, managed?: false)]) }
+    let(:server) { double("server", roles: [double("role", id: 222, name: "Admin", position: 3, managed?: false, color: double(combined: 0x37a79e))]) }
 
-    it "maps each role to a plain hash with its position and managed flag" do
-      expect(roles).to eq([{discord_id: 222, name: "Admin", position: 3, managed: false}])
+    it "maps each role to a plain hash with its position, managed flag, and colour" do
+      expect(roles).to eq([{discord_id: 222, name: "Admin", position: 3, managed: false, color: 0x37a79e}])
     end
   end
 

--- a/spec/components/channel_select_spec.rb
+++ b/spec/components/channel_select_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::ChannelSelect do
+  subject(:html) do
+    described_class.new(
+      name: "welcomes[channel_id]",
+      options: [Components::TomSelect::Option.for(value: 111, label: "general")],
+      selected: 111,
+      placeholder: "Choose a channel",
+      include_blank: true
+    ).call
+  end
+
+  it "renders a single channel select with the # prefix adornment" do
+    expect(html).to include("<select")
+    expect(html).not_to include("multiple")
+    expect(html).to include('data-tom-select-prefix-value="#"')
+  end
+
+  it "passes the placeholder through to the controller" do
+    expect(html).to include('data-tom-select-placeholder-value="Choose a channel"')
+  end
+
+  it "keeps the prefix out of the option label" do
+    expect(html).to include(">general<")
+    expect(html).not_to include("# general")
+  end
+
+  it "renders a blank option when include_blank is set" do
+    expect(html).to include('value=""')
+  end
+end

--- a/spec/components/role_select_spec.rb
+++ b/spec/components/role_select_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::RoleSelect do
+  subject(:html) do
+    described_class.new(
+      name: "roles[role_sets][0][role_ids][]",
+      options: [
+        Components::TomSelect::Option.for(value: 10, label: "Member", color: "#37a79e"),
+        Components::TomSelect::Option.for(value: 11, label: "Admin", disabled: true, reason: "Above shrkbot.")
+      ],
+      selected: [10],
+      placeholder: "Choose roles"
+    ).call
+  end
+
+  it "renders a multi-select wired for colour dots" do
+    expect(html).to include("multiple")
+    expect(html).to include("data-tom-select-color-dots-value")
+  end
+
+  it "marks the already-assigned roles selected" do
+    expect(html).to include('value="10"').and include("selected")
+  end
+
+  it "carries each role's colour and disabled reason for the dropdown render" do
+    expect(html).to include("#37a79e")
+    expect(html).to include("Above shrkbot.")
+    expect(html).to include('value="11"').and include("disabled")
+  end
+end

--- a/spec/components/tom_select_spec.rb
+++ b/spec/components/tom_select_spec.rb
@@ -7,11 +7,10 @@ RSpec.describe Components::TomSelect do
     described_class.new(
       name: "welcomes[channel_id]",
       options: [
-        Components::TomSelect::Option.for(value: 111, label: "# general"),
-        Components::TomSelect::Option.for(value: 222, label: "# announcements", disabled: true)
+        Components::TomSelect::Option.for(value: 111, label: "general"),
+        Components::TomSelect::Option.for(value: 222, label: "announcements", disabled: true)
       ],
       selected: 111,
-      placeholder: "Choose a channel",
       include_blank: true
     ).call
   end
@@ -20,10 +19,9 @@ RSpec.describe Components::TomSelect do
     expect(html).to include("<select")
     expect(html).to include('name="welcomes[channel_id]"')
     expect(html).to include('data-controller="tom-select"')
-    expect(html).to include('data-tom-select-placeholder-value="Choose a channel"')
   end
 
-  it "renders a blank option for the placeholder" do
+  it "renders a blank option when include_blank is set" do
     expect(html).to include('value=""')
   end
 
@@ -35,33 +33,33 @@ RSpec.describe Components::TomSelect do
     expect(html).to include('value="222"').and include("disabled")
   end
 
-  context "with a prefix adornment (the channel picker's #)" do
-    subject(:prefixed) do
-      described_class.new(
-        name: "welcomes[channel_id]",
-        options: [Components::TomSelect::Option.for(value: 111, label: "general")],
-        prefix: "#"
-      ).call
-    end
-
-    it "passes the prefix to the controller and keeps it out of the option label" do
-      expect(prefixed).to include('data-tom-select-prefix-value="#"')
-      expect(prefixed).to include(">general<")
-      expect(prefixed).not_to include("# general")
-    end
+  it "merges caller-supplied controller data onto the select" do
+    html = described_class.new(name: "x", options: [], controller_data: {tom_select_prefix_value: "#"}).call
+    expect(html).to include('data-tom-select-prefix-value="#"')
   end
 
-  context "without a placeholder or blank option" do
-    subject(:plain) do
+  it "renders a multi-select when asked" do
+    html = described_class.new(name: "x", options: [], multiple: true).call
+    expect(html).to include("multiple")
+  end
+
+  context "with per-option adornment data" do
+    subject(:adorned) do
       described_class.new(
-        name: "x",
-        options: [Components::TomSelect::Option.for(value: 1, label: "one")]
+        name: "roles[]",
+        options: [
+          Components::TomSelect::Option.for(value: 1, label: "Admin", color: "#37a79e"),
+          Components::TomSelect::Option.for(value: 2, label: "Plain")
+        ]
       ).call
     end
 
-    it "omits the blank option and the placeholder data attribute" do
-      expect(plain).to include("<select")
-      expect(plain).not_to include("tom-select-placeholder-value")
+    it "emits a data-data blob for options that carry colour or a reason" do
+      expect(adorned).to include("#37a79e")
+    end
+
+    it "leaves plain options without a data-data blob" do
+      expect(adorned).to include(">Plain<")
     end
   end
 end

--- a/spec/components/tom_select_spec.rb
+++ b/spec/components/tom_select_spec.rb
@@ -54,12 +54,14 @@ RSpec.describe Components::TomSelect do
       ).call
     end
 
-    it "emits a data-data blob for options that carry colour or a reason" do
-      expect(adorned).to include("#37a79e")
+    it "emits data-* attributes Tom Select copies onto the option for colour or a reason" do
+      expect(adorned).to include('data-color="#37a79e"')
     end
 
-    it "leaves plain options without a data-data blob" do
-      expect(adorned).to include(">Plain<")
+    it "leaves plain options without adornment attributes" do
+      plain = described_class.new(name: "x", options: [Components::TomSelect::Option.for(value: 2, label: "Plain")]).call
+      expect(plain).to include(">Plain<")
+      expect(plain).not_to include("data-color")
     end
   end
 end

--- a/spec/operations/plugin_configuration_spec.rb
+++ b/spec/operations/plugin_configuration_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Ops::PluginConfiguration do
+  subject(:operation) do
+    Class.new(Ops::ApplicationOperation) do
+      include Ops::PluginConfiguration
+
+      def call
+        plugin_key
+      end
+    end
+  end
+
+  it "requires the including operation to define plugin_key" do
+    expect { operation.call }.to raise_error(AbstractMethodError)
+  end
+end

--- a/spec/operations/roles/configure_spec.rb
+++ b/spec/operations/roles/configure_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Ops::Roles::Configure do
+  subject(:result) do
+    described_class.call(
+      server_configuration: config,
+      channel_id: channel_id,
+      enabled: enabled,
+      role_sets: role_sets
+    )
+  end
+
+  let(:config) { create(:server_configuration) }
+  let!(:setting) { create(:role_setting, server_configuration: config, channel_id: nil) }
+  let!(:plugin) { create(:plugin, key: "roles", name: "Roles") }
+  let(:channel_id) { 555 }
+  let(:enabled) { "0" }
+  let(:role_sets) { [] }
+
+  before do
+    create(:server_role, server_configuration: config, discord_id: 10, position: 1)
+    create(:server_role, server_configuration: config, discord_id: 11, position: 2)
+  end
+
+  it "stores the default channel" do
+    result
+    expect(setting.reload.channel_id).to eq(555)
+  end
+
+  context "with a new role set" do
+    let(:role_sets) do
+      [{name: "Pings", selection_mode: "multi", channel_override: "", role_ids: ["10", "11"]}]
+    end
+
+    it "creates the set with its assignable roles" do
+      expect { result }.to change { setting.role_sets.count }.by(1)
+      set = setting.role_sets.last
+      expect(set).to have_attributes(name: "Pings", selection_mode: "multi", channel_override: nil)
+      expect(set.assignable_roles.map(&:role_id)).to contain_exactly(10, 11)
+    end
+
+    it "drops role ids that don't belong to the server" do
+      role_sets.first[:role_ids] = ["10", "999"]
+      result
+      expect(setting.role_sets.last.assignable_roles.map(&:role_id)).to contain_exactly(10)
+    end
+  end
+
+  context "with an existing set" do
+    let!(:existing) { create(:role_set, role_setting: setting, name: "Old", selection_mode: "single") }
+
+    before { create(:assignable_role, role_set: existing, role_id: 10) }
+
+    let(:role_sets) do
+      [{id: existing.id, name: "New", selection_mode: "multi", channel_override: "777", role_ids: ["11"]}]
+    end
+
+    it "updates the set and reconciles its roles" do
+      result
+      expect(existing.reload).to have_attributes(name: "New", selection_mode: "multi", channel_override: 777)
+      expect(existing.assignable_roles.map(&:role_id)).to contain_exactly(11)
+    end
+
+    it "deletes a set marked for destruction" do
+      role_sets.first[:_destroy] = "1"
+      expect { result }.to change { setting.role_sets.count }.by(-1)
+    end
+
+    it "deletes a set that is no longer submitted" do
+      expect { described_class.call(server_configuration: config, channel_id: channel_id, enabled: "0", role_sets: []) }
+        .to change { setting.role_sets.count }.by(-1)
+    end
+  end
+
+  context "with an invalid set" do
+    let(:role_sets) { [{name: "", selection_mode: "multi", role_ids: []}] }
+
+    it "fails and persists nothing" do
+      expect { result }.not_to change { setting.role_sets.count }
+      expect(result).to be_failure
+      expect(result.errors).to be_present
+    end
+  end
+
+  context "when enabling" do
+    let(:enabled) { "1" }
+
+    it "enables the plugin once a default channel is set" do
+      result
+      expect(config.plugins.enabled.exists?(key: :roles)).to be(true)
+    end
+
+    context "without a default channel" do
+      let(:channel_id) { "" }
+
+      it "fails and enables nothing" do
+        expect(result).to be_failure
+        expect(config.plugins.enabled.exists?(key: :roles)).to be(false)
+      end
+    end
+  end
+end

--- a/spec/operations/roles/configure_spec.rb
+++ b/spec/operations/roles/configure_spec.rb
@@ -46,6 +46,20 @@ RSpec.describe Ops::Roles::Configure do
       result
       expect(setting.role_sets.last.assignable_roles.map(&:role_id)).to contain_exactly(10)
     end
+
+    it "assigns increasing positions across several new sets in one save" do
+      described_class.call(
+        server_configuration: config,
+        channel_id: channel_id,
+        enabled: "0",
+        role_sets: [
+          {name: "First", selection_mode: "multi", role_ids: []},
+          {name: "Second", selection_mode: "single", role_ids: []}
+        ]
+      )
+      expect(setting.role_sets.order(:position).pluck(:name)).to eq(["First", "Second"])
+      expect(setting.role_sets.pluck(:position).uniq.size).to eq(2)
+    end
   end
 
   context "with an existing set" do
@@ -81,6 +95,22 @@ RSpec.describe Ops::Roles::Configure do
       expect { result }.not_to change { setting.role_sets.count }
       expect(result).to be_failure
       expect(result.errors).to be_present
+    end
+  end
+
+  context "with a stale or forged set id" do
+    let(:role_sets) { [{id: "rst_missing", name: "Ghost", selection_mode: "multi", role_ids: []}] }
+
+    it "skips it instead of raising RecordNotFound" do
+      expect { result }.not_to raise_error
+      expect(result).to be_success
+      expect(setting.role_sets).to be_empty
+    end
+
+    it "won't touch a set id that belongs to another server" do
+      other = create(:role_set, name: "Theirs")
+      described_class.call(server_configuration: config, channel_id: channel_id, enabled: "0", role_sets: [{id: other.id, name: "Hijacked", selection_mode: "multi", role_ids: []}])
+      expect(other.reload.name).to eq("Theirs")
     end
   end
 

--- a/spec/presenters/assignable_role_options_spec.rb
+++ b/spec/presenters/assignable_role_options_spec.rb
@@ -50,4 +50,15 @@ RSpec.describe AssignableRoleOptions do
   it "reports when any role is unassignable" do
     expect(described_class.new(config).any_unassignable?).to be(true)
   end
+
+  context "when the bot's role position hasn't synced yet" do
+    let(:config) { create(:server_configuration, discord_id: 900, bot_role_position: nil) }
+
+    it "greys managed roles but not by position" do
+      admin = options.find { |option| option.label == "Admin" }
+      booster = options.find { |option| option.label == "Booster" }
+      expect(admin.disabled).to be(false)
+      expect(booster.disabled).to be(true)
+    end
+  end
 end

--- a/spec/presenters/assignable_role_options_spec.rb
+++ b/spec/presenters/assignable_role_options_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssignableRoleOptions do
+  subject(:options) { described_class.new(config).options }
+
+  let(:config) { create(:server_configuration, discord_id: 900, bot_role_position: 5) }
+
+  before do
+    create(:server_role, server_configuration: config, discord_id: 900, name: "everyone", position: 0)
+    create(:server_role, server_configuration: config, discord_id: 10, name: "Member", position: 2, color: 0x37a79e)
+    create(:server_role, server_configuration: config, discord_id: 11, name: "Admin", position: 8)
+    create(:server_role, server_configuration: config, discord_id: 12, name: "Booster", position: 1, managed: true)
+  end
+
+  it "excludes the @everyone role whose id matches the guild" do
+    expect(options.map(&:label)).not_to include("everyone")
+  end
+
+  it "orders roles from highest to lowest" do
+    expect(options.map(&:label)).to eq(["Admin", "Member", "Booster"])
+  end
+
+  it "renders the stored colour as a hex string" do
+    member = options.find { |option| option.label == "Member" }
+    expect(member.color).to eq("#37a79e")
+  end
+
+  it "falls back to a neutral colour when the role has none" do
+    admin = options.find { |option| option.label == "Admin" }
+    expect(admin.color).to eq(described_class::DEFAULT_COLOR)
+  end
+
+  it "disables roles ranked at or above shrkbot with a reason" do
+    admin = options.find { |option| option.label == "Admin" }
+    expect(admin).to have_attributes(disabled: true, reason: I18n.t("assignable_roles.above_bot"))
+  end
+
+  it "disables Discord-managed roles with a reason" do
+    booster = options.find { |option| option.label == "Booster" }
+    expect(booster).to have_attributes(disabled: true, reason: I18n.t("assignable_roles.managed"))
+  end
+
+  it "leaves assignable roles enabled" do
+    member = options.find { |option| option.label == "Member" }
+    expect(member).to have_attributes(disabled: false, reason: nil)
+  end
+
+  it "reports when any role is unassignable" do
+    expect(described_class.new(config).any_unassignable?).to be(true)
+  end
+end

--- a/spec/requests/roles_config_spec.rb
+++ b/spec/requests/roles_config_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Roles config", type: :request do
 
     before do
       post "/auth/discord/callback"
-      create(:server_configuration, discord_id: guild.id)
+      create(:server_configuration, discord_id: guild.id, bot_role_position: 100)
       config.create_role_setting!
       create(:server_channel, server_configuration: config, name: "get-roles", discord_id: 111)
       create(:server_role, server_configuration: config, discord_id: 222, name: "Member", position: 1)
@@ -86,12 +86,12 @@ RSpec.describe "Roles config", type: :request do
         end
 
         it "warns about roles shrkbot can't assign" do
+          create(:server_role, server_configuration: config, name: "Integration", discord_id: 333, managed: true)
           get server_roles_path(guild.id)
           expect(response.body).to include("Greyed-out roles")
         end
 
         it "omits the warning when every role is assignable" do
-          config.update!(bot_role_position: 100)
           get server_roles_path(guild.id)
           expect(response.body).not_to include("Greyed-out roles")
         end

--- a/spec/requests/roles_config_spec.rb
+++ b/spec/requests/roles_config_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Roles config", type: :request do
+  let(:auth) do
+    OmniAuth::AuthHash.new(
+      provider: "discord",
+      uid: "12345",
+      info: {name: "shrk"},
+      credentials: {token: "discord-access-token"}
+    )
+  end
+
+  let(:guild) { Discord::Guild.new(id: 900_000_001, name: "Dev Refuge", owner: true, permissions: 0, icon: nil, member_count: 5) }
+  let(:config) { ServerConfiguration.find_by(discord_id: guild.id) }
+  let(:turbo) { {headers: {"Accept" => "text/vnd.turbo-stream.html"}} }
+
+  before do
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:discord] = auth
+    Rails.application.env_config["omniauth.auth"] = auth
+  end
+
+  after do
+    OmniAuth.config.test_mode = false
+    OmniAuth.config.mock_auth[:discord] = nil
+    Rails.application.env_config.delete("omniauth.auth")
+  end
+
+  context "when signed out" do
+    it "redirects to the sign-in page" do
+      get server_roles_path(900_000_001)
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  context "when signed in" do
+    let!(:roles) { create(:plugin, key: "roles", name: "Roles") }
+
+    before do
+      post "/auth/discord/callback"
+      create(:server_configuration, discord_id: guild.id)
+      config.create_role_setting!
+      create(:server_channel, server_configuration: config, name: "get-roles", discord_id: 111)
+      create(:server_role, server_configuration: config, discord_id: 222, name: "Member", position: 1)
+      allow(Discord::UserGuilds).to receive(:call).and_return([guild])
+    end
+
+    context "without proving the server is manageable this session" do
+      it "redirects to the picker" do
+        get server_roles_path(guild.id)
+        expect(response).to redirect_to(servers_path)
+      end
+    end
+
+    context "after loading the dashboard authorizes the server" do
+      before { get server_path(guild.id) }
+
+      describe "GET /servers/:server_id/roles" do
+        it "renders the config page in the app shell" do
+          get server_roles_path(guild.id)
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include("Roles")
+          expect(response.body).to include("Role sets")
+          expect(response.body).to include("Add role set")
+        end
+
+        it "marks roles active in the plugin sidebar" do
+          get server_roles_path(guild.id)
+          expect(response.body).to include("<aside").and include('aria-current="page"')
+          expect(response.body).to include(server_logging_path(guild.id))
+        end
+
+        it "renders existing role sets with their roles selected" do
+          set = create(:role_set, role_setting: config.role_setting, name: "Pings", selection_mode: "multi")
+          create(:assignable_role, role_set: set, role_id: 222)
+          get server_roles_path(guild.id)
+          expect(response.body).to include("Pings")
+        end
+
+        it "tells the user when no channels have synced" do
+          config.server_channels.destroy_all
+          get server_roles_path(guild.id)
+          expect(response.body).to include("No channels have synced")
+        end
+
+        it "warns about roles shrkbot can't assign" do
+          get server_roles_path(guild.id)
+          expect(response.body).to include("Greyed-out roles")
+        end
+
+        it "omits the warning when every role is assignable" do
+          config.update!(bot_role_position: 100)
+          get server_roles_path(guild.id)
+          expect(response.body).not_to include("Greyed-out roles")
+        end
+      end
+
+      describe "PATCH /servers/:server_id/roles" do
+        it "creates a role set and enables the plugin in one request" do
+          patch server_roles_path(guild.id),
+            params: {
+              roles: {
+                channel_id: 111,
+                enabled: "1",
+                role_sets: {"0" => {name: "Pings", selection_mode: "multi", role_ids: ["222"]}}
+              }
+            },
+            **turbo
+          expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+          expect(config.role_setting.reload.channel_id).to eq(111)
+          expect(config.role_setting.role_sets.last.assignable_roles.map(&:role_id)).to contain_exactly(222)
+          expect(config.plugins.enabled.exists?(key: :roles)).to be(true)
+          expect(response.body).to include("saved")
+        end
+
+        it "returns 422 without a body replace when enabling without a channel" do
+          patch server_roles_path(guild.id),
+            params: {roles: {channel_id: "", enabled: "1", role_sets: {}}},
+            **turbo
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(config.plugins.enabled.exists?(key: :roles)).to be(false)
+          expect(response.body).not_to include('id="roles-config"')
+        end
+
+        it "falls back to a redirect without Turbo" do
+          patch server_roles_path(guild.id),
+            params: {roles: {channel_id: 111, enabled: "0", role_sets: {}}}
+          expect(response).to redirect_to(server_roles_path(guild.id))
+        end
+
+        it "redirects with an alert when a non-Turbo save fails" do
+          patch server_roles_path(guild.id),
+            params: {roles: {channel_id: "", enabled: "1", role_sets: {}}}
+          expect(response).to redirect_to(server_roles_path(guild.id))
+          expect(flash[:alert]).to be_present
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Step 5 of the design-system redesign: the **Roles config page** (the big one). Mirrors the Welcomes/Logging config shape.

## What's here
- **Route + controller** (`Servers::RolesController#show/update`) + `Views::Servers::Roles::Show` + a body-only `Components::Roles::ConfigForm` (root `#roles-config`, the Turbo-replace target).
- Reuses the gated `ConfigPage` (header + enable toggle + `EnableGate` + save bar); Roles just supplies icon/title/gate + the body form.
- `:roles` added to `Components::PluginNav#plugin_config_path`, so the plugin sidebar **and** the dashboard "Configure" link pick it up automatically.
- **Default channel** select (Tom Select, `#` prefix).
- **Role-set list** → collapsible `Components::Roles::RoleSetCard`: name + multi/single badge + "#channel · N roles" summary, delete button, and an expanded editor with a set-name input, `Components::SegmentedControl` (single/multi), a channel-override select, and an assignable-role multi-select.
- **Role picker = new Tom Select capability:** per-role colour dots + disabled-with-reason (greys roles shrkbot can't assign — Discord-managed or ranked above the bot — with a lock + tooltip + a warning `Callout`). Built as a separate `color_dots` render path; does not overload `prefix:`.

## How saving works
The whole page is **one form committed by the save bar**. `Ops::Roles::Configure` reconciles the default channel, the staged enable, and the full role-set list (create/update/delete sets and their assignable roles) in **one transaction**. Add/remove of cards is client-side (`role_sets_controller.js`) until Save. On failure the controller returns **422** (save bar stays dirty) and shows an error toast **without** replacing the body, so in-progress edits aren't lost; on success it re-renders `#roles-config` so new sets get their IDs.

Role-set CRUD reused the existing `Ops::Roles::*` data model; the atomic web save needed the new `Configure` reconcile op on top.

## Role colour
`server_roles` gains a `color` column, captured on guild sync (`GuildMetadata` + `ServerRoles::Sync`). **Existing rows stay `color = 0` (neutral dot) until their next guild sync** — needs a live check that the bot populates it.

## Deliberately deferred (flagged, not done — to keep the PR proportionate)
- **Resync button.** The mockup shows a per-set resync (repost the Discord menu). That needs a web→bot seam that doesn't exist yet (`Ops::Roles::Messages::Repost` requires a live gateway `bot`; the jobs process isn't the gateway). Omitted rather than ship a dead button — candidate backend follow-up.
- **Server-side rejection of unassignable role IDs.** The op already drops IDs not belonging to the guild; it does *not* reject managed/above-bot IDs from a forged request (benign — the bot can't assign them anyway). Possible future hardening.
- The two backend follow-ups already in the plan (channel-picker Discord ordering; caching guild name/icon) are untouched.

## Gates
`rspec` (564 examples), `standardrb`, `active_record_doctor`, `undercover --compare origin/main`, `i18n-tasks missing` + `check-normalized` — all green locally.

## Needs your eyes (no browser in the sandbox)
- Segmented control (single/multi) active state, both themes.
- Role picker: colour dots + disabled-with-reason (lock + tooltip + callout).
- Collapsed vs expanded role-set cards; add/remove a card; save-bar dirty + 422-stays-dirty.
- Both light and dark themes.
