### PR TITLE
Adopt hash value omission everywhere

### DIFF
--- a/app/bot/announce_modal.rb
+++ b/app/bot/announce_modal.rb
@@ -7,7 +7,7 @@ class AnnounceModal < BaseEvent
     return reject unless owner?
 
     event.defer(ephemeral: true)
-    result = OwnerBroadcast.call(bots: BotRegistry.all, content: content)
+    result = OwnerBroadcast.call(bots: BotRegistry.all, content:)
     event.edit_response(
       content: "📣 Sent to #{result.sent}/#{result.owner_count} unique owner(s) across #{result.server_count} server(s)."
     )
@@ -20,7 +20,7 @@ class AnnounceModal < BaseEvent
   end
 
   def owner?
-    CommandPermissions.permitted?(event: event, required: [], owner_only: true)
+    CommandPermissions.permitted?(event:, required: [], owner_only: true)
   end
 
   def reject

--- a/app/bot/base_command.rb
+++ b/app/bot/base_command.rb
@@ -50,7 +50,7 @@ class BaseCommand
     def registration
       Registration.new(
         name: command_name,
-        description: description,
+        description:,
         permissions: requires_permissions,
         owner_only: owner_only?,
         context: register_in,
@@ -112,7 +112,7 @@ class BaseCommand
 
   def permitted?
     CommandPermissions.permitted?(
-      event: event,
+      event:,
       required: self.class.requires_permissions,
       owner_only: self.class.owner_only?
     )

--- a/app/bot/config_subscriber.rb
+++ b/app/bot/config_subscriber.rb
@@ -42,6 +42,6 @@ class ConfigSubscriber
     set = Roles::Set.find_by(id: set_id)
     return unless set
 
-    Ops::Roles::Messages::Repost.call(bot: bot, role_set: set)
+    Ops::Roles::Messages::Repost.call(bot:, role_set: set)
   end
 end

--- a/app/bot/discord/components.rb
+++ b/app/bot/discord/components.rb
@@ -10,7 +10,7 @@ module Discord
     module_function
 
     def container(blocks, accent_color: BotConfig::ACCENT_COLOR)
-      {components: [{type: CONTAINER, accent_color: accent_color, components: blocks}], flags: COMPONENTS_V2}
+      {components: [{type: CONTAINER, accent_color:, components: blocks}], flags: COMPONENTS_V2}
     end
 
     def text(body)

--- a/app/bot/guild_metadata.rb
+++ b/app/bot/guild_metadata.rb
@@ -11,7 +11,7 @@ module GuildMetadata
       roles: roles(server),
       bot_role_position: bot_role_position(server, bot)
     )
-    Ops::ServerConfiguration::Channels::Reconcile.call(server_configuration: config, bot: bot)
+    Ops::ServerConfiguration::Channels::Reconcile.call(server_configuration: config, bot:)
     ServerOnboarder.notify(bot, server, config)
     config
   end

--- a/app/bot/owner_broadcast.rb
+++ b/app/bot/owner_broadcast.rb
@@ -12,7 +12,7 @@ module OwnerBroadcast
     messenger = bots.first
     sent = owner_ids.count { |owner_id| deliver(messenger, owner_id, content) }
 
-    Result.new(owner_count: owner_ids.size, sent: sent, server_count: servers.size)
+    Result.new(owner_count: owner_ids.size, sent:, server_count: servers.size)
   end
 
   def deliver(bot, owner_id, content)

--- a/app/components/plugin_tile.rb
+++ b/app/components/plugin_tile.rb
@@ -15,7 +15,7 @@ class Components::PluginTile < Components::Base
 
   def view_template
     span(class: "chamfer-tile flex flex-none items-center justify-center #{box}") do
-      render Components::Icon.new(@icon, weight: weight, class: @size[:icon])
+      render Components::Icon.new(@icon, weight:, class: @size[:icon])
     end
   end
 

--- a/app/components/roles/config_form.rb
+++ b/app/components/roles/config_form.rb
@@ -46,7 +46,7 @@ class Components::Roles::ConfigForm < Components::Base
 
   def card_for(set, index)
     card(
-      index: index,
+      index:,
       set_id: set.id,
       name: set.name,
       selection_mode: set.selection_mode,
@@ -61,9 +61,9 @@ class Components::Roles::ConfigForm < Components::Base
 
   def card(**attrs)
     Components::Roles::RoleSetCard.new(
-      channels: channels,
-      role_options: role_options,
-      channels_by_id: channels_by_id,
+      channels:,
+      role_options:,
+      channels_by_id:,
       default_channel_id: @setting.channel_id,
       any_unassignable: assignable_options.any_unassignable?,
       **attrs

--- a/app/components/tom_select.rb
+++ b/app/components/tom_select.rb
@@ -3,11 +3,11 @@
 class Components::TomSelect < Components::Base
   Option = Data.define(:value, :label, :disabled, :color, :reason) do
     def self.for(value:, label:, disabled: false, color: nil, reason: nil)
-      new(value: value, label: label, disabled: disabled, color: color, reason: reason)
+      new(value:, label:, disabled:, color:, reason:)
     end
 
     def adornment
-      {color: color, reason: reason}.compact
+      {color:, reason:}.compact
     end
   end
 

--- a/app/operations/application_operation.rb
+++ b/app/operations/application_operation.rb
@@ -25,7 +25,7 @@ module Ops
         end
 
         names.each do |name|
-          receive_declarations[name] = {required: !optional && !has_default, has_default: has_default, default: default}
+          receive_declarations[name] = {required: !optional && !has_default, has_default:, default:}
           attr_reader(name)
         end
       end

--- a/app/operations/logging/configure.rb
+++ b/app/operations/logging/configure.rb
@@ -9,7 +9,7 @@ module Ops
 
       def call
         settings = server_configuration.logging_setting
-        settings.assign_attributes(channel_id: channel_id, enabled_actions: enabled_actions)
+        settings.assign_attributes(channel_id:, enabled_actions:)
         activation = staged_activation
 
         return failure(messages(settings, activation), value: activation) unless settings.valid? && activation.valid?

--- a/app/operations/logging/settings/update.rb
+++ b/app/operations/logging/settings/update.rb
@@ -10,7 +10,7 @@ module Ops
           return failure("A channel is required.") if channel_id.blank?
 
           setting = server_configuration.logging_setting
-          setting.update!(channel_id: channel_id)
+          setting.update!(channel_id:)
           ok(setting, warnings: visibility_warnings)
         end
 

--- a/app/operations/reminders/create.rb
+++ b/app/operations/reminders/create.rb
@@ -14,12 +14,12 @@ module Ops
 
         remind_at = Time.current + span
         reminder = ::Reminders::Reminder.create!(
-          user_id: user_id,
-          channel_id: channel_id,
-          server_id: server_id,
+          user_id:,
+          channel_id:,
+          server_id:,
           message: ::Reminders::Sanitizer.call(message),
-          remind_at: remind_at,
-          deliver_via_dm: deliver_via_dm
+          remind_at:,
+          deliver_via_dm:
         )
         ::Reminders::DeliverJob.set(wait_until: remind_at).perform_later(reminder.id)
         ok(reminder)

--- a/app/operations/roles/assignable_roles/add.rb
+++ b/app/operations/roles/assignable_roles/add.rb
@@ -10,9 +10,9 @@ module Ops
 
         def call
           role = role_set.assignable_roles.create!(
-            role_id: role_id,
-            description: description,
-            emoji: emoji,
+            role_id:,
+            description:,
+            emoji:,
             position: next_position
           )
           ok(role)

--- a/app/operations/roles/configure.rb
+++ b/app/operations/roles/configure.rb
@@ -47,7 +47,7 @@ module Ops
       def reconcile_roles(set, role_ids)
         existing = set.assignable_roles.index_by { |role| role.role_id }
         role_ids.each_with_index do |role_id, index|
-          role = existing[role_id] || set.assignable_roles.new(role_id: role_id)
+          role = existing[role_id] || set.assignable_roles.new(role_id:)
           role.update!(position: index)
         end
         set.assignable_roles.where.not(role_id: role_ids).destroy_all

--- a/app/operations/roles/sets/create.rb
+++ b/app/operations/roles/sets/create.rb
@@ -10,9 +10,9 @@ module Ops
         def call
           setting = server_configuration.role_setting
           set = setting.role_sets.create!(
-            name: name,
-            selection_mode: selection_mode,
-            channel_override: channel_override,
+            name:,
+            selection_mode:,
+            channel_override:,
             position: next_position(setting)
           )
           ok(set)

--- a/app/operations/roles/sets/update.rb
+++ b/app/operations/roles/sets/update.rb
@@ -7,7 +7,7 @@ module Ops
         receives :role_set, :name, :selection_mode, :channel_override
 
         def call
-          role_set.update!(name: name, selection_mode: selection_mode, channel_override: channel_override)
+          role_set.update!(name:, selection_mode:, channel_override:)
           ok(role_set)
         end
       end

--- a/app/operations/roles/settings/update.rb
+++ b/app/operations/roles/settings/update.rb
@@ -8,7 +8,7 @@ module Ops
 
         def call
           setting = server_configuration.role_setting
-          setting.update!(channel_id: channel_id)
+          setting.update!(channel_id:)
           ok(setting)
         end
       end

--- a/app/operations/server_configuration/channels/disable_plugins.rb
+++ b/app/operations/server_configuration/channels/disable_plugins.rb
@@ -23,14 +23,14 @@ module Ops
           plugin = Plugin.find_by(key: definition.key)
           transaction do
             setting.update!(channel_id: nil)
-            Plugins::Toggle.call(server_configuration: server_configuration, plugin:, enabled: false)
+            Plugins::Toggle.call(server_configuration:, plugin:, enabled: false)
           end
           plugin
         end
 
         def notify_owner(plugin)
           OwnerNotifier.notify(
-            bot: bot,
+            bot:,
             message: "⚠️ **#{plugin.name}** was disabled because its configured channel was deleted. Reconfigure it to turn it back on."
           )
         end

--- a/app/operations/server_configuration/channels/reconcile.rb
+++ b/app/operations/server_configuration/channels/reconcile.rb
@@ -12,7 +12,7 @@ module Ops
           existing = server_configuration.server_channels.pluck(:discord_id)
           stale = stale_channel_ids(existing)
           stale.each do |channel_id|
-            DisablePlugins.call(server_configuration: server_configuration, channel_id:, bot: bot)
+            DisablePlugins.call(server_configuration:, channel_id:, bot:)
           end
           ok(stale)
         end

--- a/app/operations/server_configuration/ensure.rb
+++ b/app/operations/server_configuration/ensure.rb
@@ -9,14 +9,14 @@ module Ops
 
       def call
         config = transaction do
-          sc = ::ServerConfiguration.find_or_create_by!(discord_id: discord_id)
+          sc = ::ServerConfiguration.find_or_create_by!(discord_id:)
           ensure_activations(sc)
           ensure_settings(sc)
           sc
         end
         ok(config)
       rescue ActiveRecord::RecordNotUnique
-        ok(::ServerConfiguration.find_by!(discord_id: discord_id))
+        ok(::ServerConfiguration.find_by!(discord_id:))
       end
 
       private

--- a/app/operations/server_configuration/plugins/toggle.rb
+++ b/app/operations/server_configuration/plugins/toggle.rb
@@ -7,7 +7,7 @@ module Ops
         receives :server_configuration, :plugin, :enabled
 
         def call
-          activation = PluginActivation.find_or_initialize_by(server_configuration: server_configuration, plugin: plugin)
+          activation = PluginActivation.find_or_initialize_by(server_configuration:, plugin:)
           activation.enabled = enabled
           if activation.enabled? && !prerequisites_met?
             return failure("#{plugin.name} can't be enabled until its required settings are configured.")

--- a/app/operations/server_configuration/server_roles/sync.rb
+++ b/app/operations/server_configuration/server_roles/sync.rb
@@ -12,7 +12,7 @@ module Ops
             role.update!(name: data[:name], position: data[:position], managed: data[:managed], color: data[:color] || 0)
           end
           server_configuration.server_roles.where.not(discord_id: roles.map { |r| r[:discord_id] }).delete_all
-          server_configuration.update!(bot_role_position: bot_role_position)
+          server_configuration.update!(bot_role_position:)
           ok(server_configuration.server_roles.reload)
         end
       end

--- a/app/operations/welcomes/configure.rb
+++ b/app/operations/welcomes/configure.rb
@@ -9,7 +9,7 @@ module Ops
 
       def call
         settings = server_configuration.welcome_settings
-        settings.assign_attributes(channel_id: channel_id, join_message: join_message, leave_message: leave_message)
+        settings.assign_attributes(channel_id:, join_message:, leave_message:)
         activation = staged_activation
 
         return failure(messages(settings, activation), value: activation) unless settings.valid? && activation.valid?

--- a/app/operations/welcomes/settings/update.rb
+++ b/app/operations/welcomes/settings/update.rb
@@ -8,7 +8,7 @@ module Ops
 
         def call
           setting = server_configuration.welcome_settings
-          setting.update!(channel_id: channel_id, join_message: join_message, leave_message: leave_message)
+          setting.update!(channel_id:, join_message:, leave_message:)
           ok(setting)
         end
       end

--- a/app/plugins/reminders/commands/unremind.rb
+++ b/app/plugins/reminders/commands/unremind.rb
@@ -13,7 +13,7 @@ module Reminders
       reminder = Reminders::Reminder.find_by(id: event.options["reminder"], user_id: event.user.id)
       return event.respond(content: "⚠️ That reminder doesn't exist.", ephemeral: true) unless reminder
 
-      Ops::Reminders::Delete.call(reminder: reminder)
+      Ops::Reminders::Delete.call(reminder:)
       event.respond(content: "🗑️ Reminder cancelled.", ephemeral: true)
     end
 
@@ -21,7 +21,7 @@ module Reminders
       choices = Reminders::Reminder.for_user(event.user.id).limit(25).map do |reminder|
         {name: choice_label(reminder), value: reminder.id}
       end
-      event.respond(choices: choices)
+      event.respond(choices:)
     end
 
     private

--- a/app/plugins/roles/custom_id.rb
+++ b/app/plugins/roles/custom_id.rb
@@ -20,7 +20,7 @@ module Roles
 
     def parse(custom_id)
       _prefix, action, set_id, role_id = custom_id.split(":")
-      {action: action&.to_sym, set_id: set_id, role_id: role_id&.to_i}
+      {action: action&.to_sym, set_id:, role_id: role_id&.to_i}
     end
   end
 end

--- a/app/plugins/roles/message.rb
+++ b/app/plugins/roles/message.rb
@@ -46,7 +46,7 @@ module Roles
     end
 
     def action_row(components)
-      {type: ACTION_ROW, components: components}
+      {type: ACTION_ROW, components:}
     end
 
     def single_content(set)
@@ -83,7 +83,7 @@ module Roles
         custom_id: CustomId.select(set),
         min_values: 0,
         max_values: options.size,
-        options: options
+        options:
       }
     end
 

--- a/spec/bot/command_permissions_spec.rb
+++ b/spec/bot/command_permissions_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe CommandPermissions do
   def event_for(user_id:, member: :unset)
     user = double("user", id: user_id)
     if member == :unset
-      double("event", user: user) # DM-style: no member
+      double("event", user:) # DM-style: no member
     else
-      double("event", user: user, member: member)
+      double("event", user:, member:)
     end
   end
 

--- a/spec/bot/commands/info_spec.rb
+++ b/spec/bot/commands/info_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Commands::Info do
   subject(:execute) { described_class.new(event).execute }
 
   let(:profile) { double("profile", username: "shrkbot") }
-  let(:event) { double("event", bot: double("bot", profile: profile), respond: nil) }
+  let(:event) { double("event", bot: double("bot", profile:), respond: nil) }
 
   def texts(args)
     args[:components].first[:components].filter_map { |block| block[:content] }

--- a/spec/bot/config_subscriber_spec.rb
+++ b/spec/bot/config_subscriber_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe ConfigSubscriber do
       let(:payload) { JSON.generate(type: "roles_repost", set_id: set.id) }
 
       it "runs the repost operation for that set with the bot" do
-        expect(Ops::Roles::Messages::Repost).to receive(:call).with(bot: bot, role_set: set)
+        expect(Ops::Roles::Messages::Repost).to receive(:call).with(bot:, role_set: set)
 
         subscriber.handle(payload)
       end

--- a/spec/bot/discord/user_guilds_spec.rb
+++ b/spec/bot/discord/user_guilds_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Discord::UserGuilds do
   subject(:fetch) { described_class.call("access-token") }
 
   let(:http) { instance_double(Net::HTTP) }
-  let(:response) { instance_double(Net::HTTPResponse, code: code, body: body) }
+  let(:response) { instance_double(Net::HTTPResponse, code:, body:) }
   let(:code) { "200" }
   let(:body) { [{"id" => "42", "name" => "Dev Refuge", "owner" => true, "permissions" => "8", "icon" => nil, "approximate_member_count" => 2481}].to_json }
 

--- a/spec/bot/event_registrar_spec.rb
+++ b/spec/bot/event_registrar_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe EventRegistrar do
       end
 
       def button(attributes = {}, &block)
-        @handlers[:button] = {attributes: attributes, block: block}
+        @handlers[:button] = {attributes:, block:}
       end
     end.new
   end

--- a/spec/bot/owner_broadcast_spec.rb
+++ b/spec/bot/owner_broadcast_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe OwnerBroadcast do
   describe ".call" do
-    subject(:result) { described_class.call(bots: bots, content: "hello owners") }
+    subject(:result) { described_class.call(bots:, content: "hello owners") }
 
     let(:bots) { [shard_one, shard_two] }
     let(:shard_one) { double("shard_one", servers: {1 => server(10), 2 => server(20)}) }

--- a/spec/bot/server_onboarder_spec.rb
+++ b/spec/bot/server_onboarder_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ServerOnboarder do
   let(:owner) { double("owner", id: 999) }
   let(:server) { double("server", id: 77, owner:) }
   let(:pm_channel) { double("pm_channel", send_message: nil) }
-  let(:bot) { double("bot", pm_channel: pm_channel) }
+  let(:bot) { double("bot", pm_channel:) }
 
   context "when the server has not been onboarded" do
     it "DMs the guild owner the welcome message" do

--- a/spec/components/toasts_spec.rb
+++ b/spec/components/toasts_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Components::Toasts do
-  subject(:html) { described_class.new(flash: flash).call }
+  subject(:html) { described_class.new(flash:).call }
 
   context "with a notice" do
     let(:flash) { {"notice" => "Signed in as shrk."} }

--- a/spec/operations/logging/configure_spec.rb
+++ b/spec/operations/logging/configure_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe Ops::Logging::Configure do
   subject(:result) do
     described_class.call(
       server_configuration: config,
-      channel_id: channel_id,
-      enabled_actions: enabled_actions,
-      enabled: enabled
+      channel_id:,
+      enabled_actions:,
+      enabled:
     )
   end
 
@@ -25,7 +25,7 @@ RSpec.describe Ops::Logging::Configure do
       expect(config.logging_setting.reload.channel_id).to eq(200)
       expect(config.logging_setting.action_enabled?("roles.role_gained")).to be(true)
       expect(config.logging_setting.action_enabled?("roles.role_lost")).to be(false)
-      expect(config.plugin_activations.find_by(plugin: plugin).enabled).to be(true)
+      expect(config.plugin_activations.find_by(plugin:).enabled).to be(true)
     end
   end
 
@@ -46,7 +46,7 @@ RSpec.describe Ops::Logging::Configure do
     it "stores the toggles and leaves the plugin disabled" do
       expect(result).to be_success
       expect(config.logging_setting.reload.action_enabled?("roles.role_gained")).to be(true)
-      expect(config.plugin_activations.find_by(plugin: plugin)&.enabled).to be_falsey
+      expect(config.plugin_activations.find_by(plugin:)&.enabled).to be_falsey
     end
   end
 end

--- a/spec/operations/roles/configure_spec.rb
+++ b/spec/operations/roles/configure_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe Ops::Roles::Configure do
   subject(:result) do
     described_class.call(
       server_configuration: config,
-      channel_id: channel_id,
-      enabled: enabled,
-      role_sets: role_sets
+      channel_id:,
+      enabled:,
+      role_sets:
     )
   end
 
@@ -50,7 +50,7 @@ RSpec.describe Ops::Roles::Configure do
     it "assigns increasing positions across several new sets in one save" do
       described_class.call(
         server_configuration: config,
-        channel_id: channel_id,
+        channel_id:,
         enabled: "0",
         role_sets: [
           {name: "First", selection_mode: "multi", role_ids: []},
@@ -83,7 +83,7 @@ RSpec.describe Ops::Roles::Configure do
     end
 
     it "deletes a set that is no longer submitted" do
-      expect { described_class.call(server_configuration: config, channel_id: channel_id, enabled: "0", role_sets: []) }
+      expect { described_class.call(server_configuration: config, channel_id:, enabled: "0", role_sets: []) }
         .to change { setting.role_sets.count }.by(-1)
     end
   end
@@ -109,7 +109,7 @@ RSpec.describe Ops::Roles::Configure do
 
     it "won't touch a set id that belongs to another server" do
       other = create(:role_set, name: "Theirs")
-      described_class.call(server_configuration: config, channel_id: channel_id, enabled: "0", role_sets: [{id: other.id, name: "Hijacked", selection_mode: "multi", role_ids: []}])
+      described_class.call(server_configuration: config, channel_id:, enabled: "0", role_sets: [{id: other.id, name: "Hijacked", selection_mode: "multi", role_ids: []}])
       expect(other.reload.name).to eq("Theirs")
     end
   end

--- a/spec/operations/roles/messages/repost_spec.rb
+++ b/spec/operations/roles/messages/repost_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Ops::Roles::Messages::Repost do
-  subject(:result) { described_class.call(bot: bot, role_set: set) }
+  subject(:result) { described_class.call(bot:, role_set: set) }
 
   let(:bot) { double("bot") }
   let(:channel) { double("channel") }

--- a/spec/operations/welcomes/configure_spec.rb
+++ b/spec/operations/welcomes/configure_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe Ops::Welcomes::Configure do
   subject(:result) do
     described_class.call(
       server_configuration: config,
-      channel_id: channel_id,
+      channel_id:,
       join_message: "hi {user}",
       leave_message: "bye",
-      enabled: enabled
+      enabled:
     )
   end
 
@@ -24,7 +24,7 @@ RSpec.describe Ops::Welcomes::Configure do
       expect(result).to be_success
       expect(config.welcome_settings.reload.channel_id).to eq(111)
       expect(config.welcome_settings.join_message).to eq("hi {user}")
-      expect(config.plugin_activations.find_by(plugin: plugin).enabled).to be(true)
+      expect(config.plugin_activations.find_by(plugin:).enabled).to be(true)
     end
   end
 
@@ -46,7 +46,7 @@ RSpec.describe Ops::Welcomes::Configure do
     it "saves the messages and leaves the plugin disabled" do
       expect(result).to be_success
       expect(config.welcome_settings.reload.join_message).to eq("hi {user}")
-      expect(config.plugin_activations.find_by(plugin: plugin)&.enabled).to be_falsey
+      expect(config.plugin_activations.find_by(plugin:)&.enabled).to be_falsey
     end
   end
 end

--- a/spec/plugins/roles/events/pick_spec.rb
+++ b/spec/plugins/roles/events/pick_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Roles::Pick do
 
   let(:user) { double("user", id: 42) }
   let(:member) { double("member", roles: [], modify_roles: nil, mention: "<@42>") }
-  let(:server) { double("server", member: member) }
+  let(:server) { double("server", member:) }
   let(:bot) { double("bot") }
   let(:event) do
     double("event", custom_id: Roles::CustomId.pick(set, blue), server:, user:, respond: nil, bot:)

--- a/spec/plugins/roles/events/select_spec.rb
+++ b/spec/plugins/roles/events/select_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Roles::Select do
 
   let(:user) { double("user", id: 42) }
   let(:member) { double("member", roles: [], modify_roles: nil, mention: "<@42>") }
-  let(:server) { double("server", member: member) }
+  let(:server) { double("server", member:) }
   let(:bot) { double("bot") }
   let(:event) do
     double("event", custom_id: Roles::CustomId.select(set), server:, user:, values: ["100"], update_message: nil, bot:)

--- a/spec/plugins/roles/message_spec.rb
+++ b/spec/plugins/roles/message_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Roles::Message do
   let(:setting) { create(:role_setting, server_configuration: server_config) }
 
   def sync_role(discord_id, name)
-    create(:server_role, server_configuration: server_config, discord_id: discord_id, name: name)
+    create(:server_role, server_configuration: server_config, discord_id:, name:)
   end
 
   def container_blocks(rendered)


### PR DESCRIPTION
Mechanical sweep of the 93 pre-existing `key: key` kwarg/hash pairs across 43 files, autocorrected with rubocop `Style/HashSyntax` (`EnforcedShorthandSyntax: always`). No behavior change — pure syntax.

standardrb intentionally takes no style config, so it can't enforce this; if you want CI teeth, a thin `rubocop --only Style/HashSyntax` step with that one setting would do it. Flagged in the session, not added here.

Gates green locally: rspec (580), standardrb, active_record_doctor, undercover.

Note: will conflict trivially with the ChannelCard refactor PR (both touch the config forms) — merge this one first, the other rebases mechanically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)