### PR TITLE
Extract ChannelCard from the config forms

### DIFF
--- a/app/components/channel_card.rb
+++ b/app/components/channel_card.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class Components::ChannelCard < Components::Base
+  def initialize(name:, channels:, selected:, label:, help:, required: false, **attrs)
+    @name = name
+    @channels = channels
+    @selected = selected
+    @label = label
+    @help = help
+    @required = required
+    @attrs = attrs
+  end
+
+  def view_template(&block)
+    render Components::Card.new(**@attrs) do
+      label(class: "block text-sm font-semibold") do
+        plain @label
+        required_marker if @required
+      end
+      p(class: "mb-2 mt-0.5 text-sm text-text-secondary") { @help }
+      if @channels.empty?
+        p(class: "text-sm text-text-secondary") { t(".none") }
+      else
+        render Components::ChannelSelect.new(
+          name: @name,
+          options: @channels,
+          selected: @selected,
+          placeholder: t(".placeholder"),
+          include_blank: true
+        )
+      end
+      yield if block
+    end
+  end
+
+  private
+
+  def required_marker
+    span(class: "ml-1 text-xs font-semibold text-danger", title: t(".required")) { "*" }
+  end
+end

--- a/app/components/logging/config_form.rb
+++ b/app/components/logging/config_form.rb
@@ -24,31 +24,19 @@ class Components::Logging::ConfigForm < Components::Base
   end
 
   def channel_card
-    render Components::Card.new(
+    render Components::ChannelCard.new(
+      name: "logging[channel_id]",
+      channels:,
+      selected: @settings.channel_id,
+      label: t(".channel.label"),
+      help: t(".channel.help"),
+      required: true,
       data: {
         controller: "channel-warning",
         action: "change->channel-warning#update",
         channel_warning_visible_ids_value: visible_channel_ids.to_json
       }
-    ) do
-      label(class: "block text-sm font-semibold") do
-        plain t(".channel.label")
-        required_marker
-      end
-      p(class: "mb-2 mt-0.5 text-sm text-text-secondary") { t(".channel.help") }
-      if channels.empty?
-        p(class: "text-sm text-text-secondary") { t(".channel.none") }
-      else
-        render Components::ChannelSelect.new(
-          name: "logging[channel_id]",
-          options: channels,
-          selected: @settings.channel_id,
-          placeholder: t(".channel.placeholder"),
-          include_blank: true
-        )
-      end
-      visibility_warning
-    end
+    ) { visibility_warning }
   end
 
   def events_card
@@ -128,10 +116,6 @@ class Components::Logging::ConfigForm < Components::Base
     ) do
       plain t(".channel.visible_warning")
     end
-  end
-
-  def required_marker
-    span(class: "ml-1 text-xs font-semibold text-danger", title: t(".channel.required")) { "*" }
   end
 
   def visible_channel?

--- a/app/components/roles/config_form.rb
+++ b/app/components/roles/config_form.rb
@@ -16,21 +16,13 @@ class Components::Roles::ConfigForm < Components::Base
   private
 
   def default_channel_card
-    render Components::Card.new do
-      label(class: "block text-sm font-semibold") { t(".channel.label") }
-      p(class: "mb-2 mt-0.5 text-sm text-text-secondary") { t(".channel.help") }
-      if channels.empty?
-        p(class: "text-sm text-text-secondary") { t(".channel.none") }
-      else
-        render Components::ChannelSelect.new(
-          name: "roles[channel_id]",
-          options: channels,
-          selected: @setting.channel_id,
-          placeholder: t(".channel.placeholder"),
-          include_blank: true
-        )
-      end
-    end
+    render Components::ChannelCard.new(
+      name: "roles[channel_id]",
+      channels:,
+      selected: @setting.channel_id,
+      label: t(".channel.label"),
+      help: t(".channel.help")
+    )
   end
 
   def role_sets_section

--- a/app/components/welcomes/config_form.rb
+++ b/app/components/welcomes/config_form.rb
@@ -30,24 +30,14 @@ class Components::Welcomes::ConfigForm < Components::Base
   end
 
   def channel_card
-    render Components::Card.new do
-      label(class: "block text-sm font-semibold") do
-        plain t(".channel.label")
-        required_marker
-      end
-      p(class: "mb-2 mt-0.5 text-sm text-text-secondary") { t(".channel.help") }
-      if channels.empty?
-        p(class: "text-sm text-text-secondary") { t(".channel.none") }
-      else
-        render Components::ChannelSelect.new(
-          name: "welcomes[channel_id]",
-          options: channels,
-          selected: @settings.channel_id,
-          placeholder: t(".channel.placeholder"),
-          include_blank: true
-        )
-      end
-    end
+    render Components::ChannelCard.new(
+      name: "welcomes[channel_id]",
+      channels:,
+      selected: @settings.channel_id,
+      label: t(".channel.label"),
+      help: t(".channel.help"),
+      required: true
+    )
   end
 
   def message_cards
@@ -116,10 +106,6 @@ class Components::Welcomes::ConfigForm < Components::Base
 
   def preview_body_data(kind)
     {welcome_preview_target: "#{kind}Output", empty_hint: t(".preview.empty")}
-  end
-
-  def required_marker
-    span(class: "ml-1 text-xs font-semibold text-danger", title: t(".channel.required")) { "*" }
   end
 
   def preview_channel

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -13,6 +13,10 @@ en:
         one: "%{count} plugin on"
         other: "%{count} plugins on"
       toggle_theme: Toggle dark mode
+    channel_card:
+      none: No channels have synced yet. shrkbot needs to be in the server first.
+      placeholder: Choose a channel
+      required: This setting is required to enable the plugin.
     config_page:
       dashboard: Dashboard
       disabled: Disabled
@@ -25,9 +29,6 @@ en:
         channel:
           help: Where moderation events are recorded.
           label: Channel
-          none: No channels have synced yet. shrkbot needs to be in the server first.
-          placeholder: Choose a channel
-          required: This setting is required to enable the plugin.
           visible_warning: Everyone can see this channel, so the moderation log would
             be public.
         events:
@@ -82,8 +83,6 @@ en:
         channel:
           help: Each role set posts here unless it has its own channel override.
           label: Default channel for role menus
-          none: No channels have synced yet. shrkbot needs to be in the server first.
-          placeholder: Choose a channel
         sets:
           add: Add role set
           label: Role sets
@@ -120,9 +119,6 @@ en:
         channel:
           help: Where join and leave messages are posted.
           label: Channel
-          none: No channels have synced yet. shrkbot needs to be in the server first.
-          placeholder: Choose a channel
-          required: This setting is required to enable the plugin.
         join_message:
           help: Sent when a member joins. Leave empty to send nothing.
           info: is a Discord mention in join messages.

--- a/spec/components/channel_card_spec.rb
+++ b/spec/components/channel_card_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::ChannelCard do
+  subject(:html) do
+    described_class.new(
+      name: "welcomes[channel_id]",
+      channels:,
+      selected:,
+      label: "Channel",
+      help: "Pick a channel."
+    ).render_in(view_context)
+  end
+
+  let(:view_context) { ApplicationController.new.view_context }
+  let(:channels) { [Components::TomSelect::Option.for(value: 111, label: "general")] }
+  let(:selected) { nil }
+
+  it "renders the label and help text" do
+    expect(html).to include("Channel").and include("Pick a channel.")
+  end
+
+  it "renders the channel select when channels are present" do
+    expect(html).to include("<select")
+  end
+
+  it "does not render a required marker by default" do
+    expect(html).not_to include("text-danger")
+  end
+
+  context "when required: true" do
+    subject(:html) do
+      described_class.new(
+        name: "welcomes[channel_id]",
+        channels:,
+        selected:,
+        label: "Channel",
+        help: "Pick a channel.",
+        required: true
+      ).render_in(view_context)
+    end
+
+    it "renders the required marker" do
+      expect(html).to include("text-danger").and include("*")
+    end
+  end
+
+  context "when channels are empty" do
+    let(:channels) { [] }
+
+    it "renders the none message instead of a select" do
+      expect(html).to include("No channels have synced yet")
+      expect(html).not_to include("<select")
+    end
+  end
+
+  context "with a block" do
+    subject(:html) do
+      described_class.new(
+        name: "welcomes[channel_id]",
+        channels:,
+        selected:,
+        label: "Channel",
+        help: "Pick a channel."
+      ).render_in(view_context) { "trailing content" }
+    end
+
+    it "renders the block inside the card" do
+      expect(html).to include("trailing content")
+    end
+  end
+
+  context "with extra attrs" do
+    subject(:html) do
+      described_class.new(
+        name: "welcomes[channel_id]",
+        channels:,
+        selected:,
+        label: "Channel",
+        help: "Pick a channel.",
+        data: {controller: "my-controller"}
+      ).render_in(view_context)
+    end
+
+    it "forwards extra attrs to the card element" do
+      expect(html).to include('data-controller="my-controller"')
+    end
+  end
+end

--- a/spec/components/logging/config_form_spec.rb
+++ b/spec/components/logging/config_form_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::Logging::ConfigForm do
+  subject(:html) do
+    described_class.new(server_configuration: config).render_in(view_context)
+  end
+
+  let(:view_context) { ApplicationController.new.view_context }
+  let(:config) { create(:server_configuration) }
+
+  before { create(:logging_setting, server_configuration: config) }
+
+  it "renders the channel card with the required marker" do
+    expect(html).to include("This setting is required to enable the plugin")
+  end
+
+  it "shows the none-message when no channels have synced" do
+    expect(html).to include("No channels have synced yet")
+  end
+
+  it "wires the channel-warning Stimulus controller on the card" do
+    expect(html).to include('data-controller="channel-warning"')
+  end
+end

--- a/spec/components/roles/config_form_spec.rb
+++ b/spec/components/roles/config_form_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::Roles::ConfigForm do
+  subject(:html) do
+    described_class.new(server_configuration: config).render_in(view_context)
+  end
+
+  let(:view_context) { ApplicationController.new.view_context }
+  let(:config) { create(:server_configuration) }
+
+  before { create(:role_setting, server_configuration: config) }
+
+  it "renders the default channel card without a required marker" do
+    expect(html).not_to include("This setting is required to enable the plugin")
+  end
+
+  it "shows the none-message when no channels have synced" do
+    expect(html).to include("No channels have synced yet")
+  end
+end

--- a/spec/components/welcomes/config_form_spec.rb
+++ b/spec/components/welcomes/config_form_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::Welcomes::ConfigForm do
+  subject(:html) do
+    described_class.new(server_configuration: config).render_in(view_context)
+  end
+
+  let(:view_context) { ApplicationController.new.view_context }
+  let(:config) { create(:server_configuration) }
+
+  before { config.create_welcome_settings! }
+
+  it "renders the channel card with the required marker" do
+    expect(html).to include("This setting is required to enable the plugin")
+  end
+
+  it "shows the none-message when no channels have synced" do
+    expect(html).to include("No channels have synced yet")
+  end
+end


### PR DESCRIPTION
## Summary

- Three plugin config forms (welcomes, logging, roles) each contained the same channel-picker card: a label row with an optional required marker, a help paragraph, and a `ChannelSelect` or none-message. The only differences were the field name, selected value, and whether `required: true` was set. Logging also forwarded Stimulus attrs and rendered a trailing visibility warning.
- Extracts all three into a single `Components::ChannelCard` component that takes `name:`, `channels:`, `selected:`, `label:`, `help:`, and an optional `required:` flag. Extra keyword args (e.g. Stimulus `data:`) are forwarded to the underlying `Components::Card`. A block, if given, is rendered as trailing card content — that's how logging's visibility warning slots in.
- The three duplicated i18n strings (`none`, `placeholder`, `required`) are moved from the `logging.config_form.channel`, `roles.config_form.channel`, and `welcomes.config_form.channel` scopes into a new shared `components.channel_card` scope. Per-form `label` and `help` strings stay where they are.
- Seven examples in `spec/components/channel_card_spec.rb` cover the component directly. Thin config form specs are added for all three forms to satisfy the undercover changed-line coverage gate (the existing request-level tests for these forms are blocked in this sandbox by a missing Tailwind asset, a pre-existing infra issue).

**Note:** This PR will conflict trivially with PR #76 (hash-value omission sweep), which touches the same three config form files. The conflict will be mechanical — hash-omission lines vs. the new `ChannelCard.new(...)` call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)