### PR TITLE
Order the channel picker like Discord's channel list

### DIFF
--- a/.active_record_doctor.rb
+++ b/.active_record_doctor.rb
@@ -31,6 +31,7 @@ ActiveRecordDoctor.configure do
       "welcome_settings.channel_id",
       "assignable_roles.role_id",
       "server_channels.discord_id",
+      "server_channels.parent_id",
       "server_roles.discord_id",
       "channel_overwrites.target_id"
     ]

--- a/app/assets/tailwind/tom-select.css
+++ b/app/assets/tailwind/tom-select.css
@@ -76,6 +76,16 @@
 .ts-dropdown .option[data-selectable].disabled,
 .ts-dropdown .option.disabled { color: var(--text-muted); cursor: not-allowed; opacity: 0.7; }
 .ts-dropdown .no-results { padding: 0.5rem 0.75rem; color: var(--text-muted); }
+.ts-dropdown .optgroup-header {
+  padding: 0.5rem 0.75rem 0.25rem;
+  border: none;
+  background: var(--surface-card);
+  color: var(--text-muted);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
 .ts-dot {
   width: 0.625rem;
   height: 0.625rem;

--- a/app/bot/guild_metadata.rb
+++ b/app/bot/guild_metadata.rb
@@ -18,7 +18,14 @@ module GuildMetadata
 
   def channels(server)
     server.channels.map do |channel|
-      {discord_id: channel.id, name: channel.name, channel_type: channel.type, overwrites: overwrites(channel)}
+      {
+        discord_id: channel.id,
+        name: channel.name,
+        channel_type: channel.type,
+        position: channel.position,
+        parent_id: channel.parent_id,
+        overwrites: overwrites(channel)
+      }
     end
   end
 

--- a/app/components/tom_select.rb
+++ b/app/components/tom_select.rb
@@ -11,6 +11,12 @@ class Components::TomSelect < Components::Base
     end
   end
 
+  Group = Data.define(:label, :options) do
+    def self.for(label:, options:)
+      new(label:, options:)
+    end
+  end
+
   def initialize(name:, options:, selected: nil, multiple: false, include_blank: false, controller_data: {})
     @name = name
     @options = options
@@ -23,13 +29,26 @@ class Components::TomSelect < Components::Base
   def view_template
     select(name: @name, multiple: @multiple, autocomplete: "off", class: "w-full", data: {controller: "tom-select", **@controller_data}) do
       option(value: "") if @include_blank
-      @options.each do |opt|
-        option(**option_attrs(opt)) { opt.label }
+      @options.each do |entry|
+        render_entry(entry)
       end
     end
   end
 
   private
+
+  def render_entry(entry)
+    case entry
+    when Group
+      optgroup(label: entry.label) do
+        entry.options.each do |opt|
+          option(**option_attrs(opt)) { opt.label }
+        end
+      end
+    else
+      option(**option_attrs(entry)) { entry.label }
+    end
+  end
 
   def option_attrs(opt)
     attrs = {value: opt.value}

--- a/app/models/server_channel.rb
+++ b/app/models/server_channel.rb
@@ -13,6 +13,16 @@ class ServerChannel < ApplicationRecord
   TEXT_TYPES = [0, 5].freeze
 
   scope :text, -> { where(channel_type: TEXT_TYPES).order(:name) }
+  scope :in_discord_order, -> {
+    joins(<<~SQL)
+      LEFT JOIN server_channels categories
+        ON categories.server_configuration_id = server_channels.server_configuration_id
+        AND categories.discord_id = server_channels.parent_id
+    SQL
+      .reorder(Arel.sql(
+        "categories.position NULLS FIRST, categories.name, server_channels.position, server_channels.name"
+      ))
+  }
 
   def everyone_visible?
     overwrite = channel_overwrites.find_by(target_id: server_configuration.discord_id)

--- a/app/models/server_channel.rb
+++ b/app/models/server_channel.rb
@@ -12,6 +12,8 @@ class ServerChannel < ApplicationRecord
 
   TEXT_TYPES = [0, 5].freeze
 
+  CATEGORY_TYPE = 4
+
   scope :text, -> { where(channel_type: TEXT_TYPES).order(:name) }
   scope :in_discord_order, -> {
     joins(<<~SQL)

--- a/app/operations/server_configuration/server_channels/sync.rb
+++ b/app/operations/server_configuration/server_channels/sync.rb
@@ -16,7 +16,12 @@ module Ops
 
         def sync_channel(data)
           channel = server_configuration.server_channels.find_or_initialize_by(discord_id: data[:discord_id])
-          channel.update!(name: data[:name], channel_type: data[:channel_type])
+          channel.update!(
+            name: data[:name],
+            channel_type: data[:channel_type],
+            position: data[:position],
+            parent_id: data[:parent_id]
+          )
           sync_overwrites(channel, data[:overwrites])
         end
 

--- a/app/presenters/channel_options.rb
+++ b/app/presenters/channel_options.rb
@@ -6,7 +6,7 @@ class ChannelOptions
   end
 
   def options
-    @config.server_channels.text.map do |channel|
+    @config.server_channels.text.in_discord_order.map do |channel|
       Components::TomSelect::Option.for(value: channel.discord_id, label: channel.name)
     end
   end

--- a/app/presenters/channel_options.rb
+++ b/app/presenters/channel_options.rb
@@ -6,8 +6,31 @@ class ChannelOptions
   end
 
   def options
-    @config.server_channels.text.in_discord_order.map do |channel|
-      Components::TomSelect::Option.for(value: channel.discord_id, label: channel.name)
+    channels.group_by(&:parent_id).flat_map do |parent_id, group|
+      grouped(categories[parent_id], group)
     end
+  end
+
+  private
+
+  def grouped(category, group)
+    return group.map { |channel| option_for(channel) } unless category
+
+    Components::TomSelect::Group.for(
+      label: category.name,
+      options: group.map { |channel| option_for(channel) }
+    )
+  end
+
+  def option_for(channel)
+    Components::TomSelect::Option.for(value: channel.discord_id, label: channel.name)
+  end
+
+  def channels
+    @config.server_channels.text.in_discord_order
+  end
+
+  def categories
+    @categories ||= @config.server_channels.where(channel_type: ServerChannel::CATEGORY_TYPE).index_by(&:discord_id)
   end
 end

--- a/db/migrate/20260703225437_add_discord_ordering_to_server_channels.rb
+++ b/db/migrate/20260703225437_add_discord_ordering_to_server_channels.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddDiscordOrderingToServerChannels < ActiveRecord::Migration[8.1]
+  def change
+    add_column :server_channels, :position, :integer
+    add_column :server_channels, :parent_id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_28_220015) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_03_225437) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -112,6 +112,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_28_220015) do
     t.datetime "created_at", null: false
     t.bigint "discord_id", null: false
     t.string "name", null: false
+    t.bigint "parent_id"
+    t.integer "position"
     t.string "server_configuration_id", null: false
     t.datetime "updated_at", null: false
     t.index ["server_configuration_id", "discord_id"], name: "idx_on_server_configuration_id_discord_id_610352a54e", unique: true

--- a/spec/bot/guild_metadata_spec.rb
+++ b/spec/bot/guild_metadata_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe GuildMetadata do
       double("overwrite", id: 555, type: :role, allow: double(bits: 1024), deny: double(bits: 2048))
     end
     let(:channel) do
-      double("channel", id: 111, name: "general", type: 0,
+      double("channel", id: 111, name: "general", type: 0, position: 3, parent_id: 999,
         permission_overwrites: {555 => overwrite})
     end
     let(:server) { double("server", channels: [channel]) }
 
-    it "maps each channel to a plain hash" do
+    it "maps each channel to a plain hash with its position and category" do
       expect(channels).to eq([
-        {discord_id: 111, name: "general", channel_type: 0, overwrites: [
+        {discord_id: 111, name: "general", channel_type: 0, position: 3, parent_id: 999, overwrites: [
           {target_id: 555, target_type: "role", allow: 1024, deny: 2048}
         ]}
       ])

--- a/spec/components/tom_select_spec.rb
+++ b/spec/components/tom_select_spec.rb
@@ -43,6 +43,34 @@ RSpec.describe Components::TomSelect do
     expect(html).to include("multiple")
   end
 
+  context "with grouped options" do
+    subject(:grouped) do
+      described_class.new(
+        name: "roles[channel_id]",
+        options: [
+          Components::TomSelect::Option.for(value: 1, label: "welcome"),
+          Components::TomSelect::Group.for(
+            label: "Info",
+            options: [Components::TomSelect::Option.for(value: 2, label: "rules")]
+          )
+        ],
+        selected: 2
+      ).call
+    end
+
+    it "wraps a group's options in an optgroup with its label" do
+      expect(grouped).to match(%r{<optgroup label="Info"><option [^>]*value="2"[^>]*>rules</option></optgroup>})
+    end
+
+    it "renders ungrouped options outside any optgroup" do
+      expect(grouped).to match(%r{<option value="1">welcome</option><optgroup})
+    end
+
+    it "still marks selection inside a group" do
+      expect(grouped).to match(/value="2" selected/)
+    end
+  end
+
   context "with per-option adornment data" do
     subject(:adorned) do
       described_class.new(

--- a/spec/models/server_channel_spec.rb
+++ b/spec/models/server_channel_spec.rb
@@ -45,6 +45,45 @@ RSpec.describe ServerChannel do
     end
   end
 
+  describe ".in_discord_order" do
+    subject(:names) { server.server_channels.text.in_discord_order.pluck(:name) }
+
+    let(:server) { create(:server_configuration) }
+
+    before do
+      create(:server_channel, server_configuration: server, name: "info", channel_type: 4, discord_id: 10, position: 1)
+      create(:server_channel, server_configuration: server, name: "chat", channel_type: 4, discord_id: 20, position: 0)
+      create(:server_channel, server_configuration: server, name: "rules", channel_type: 0, discord_id: 11, position: 0, parent_id: 10)
+      create(:server_channel, server_configuration: server, name: "general", channel_type: 0, discord_id: 21, position: 1, parent_id: 20)
+      create(:server_channel, server_configuration: server, name: "memes", channel_type: 0, discord_id: 22, position: 0, parent_id: 20)
+      create(:server_channel, server_configuration: server, name: "welcome", channel_type: 0, discord_id: 1, position: 0)
+    end
+
+    it "lists uncategorised channels first, then each category's children by position" do
+      expect(names).to eq(%w[welcome memes general rules])
+    end
+
+    context "when positions within a group collide" do
+      before do
+        create(:server_channel, server_configuration: server, name: "announcements", channel_type: 5, discord_id: 2, position: 0)
+      end
+
+      it "breaks the tie by name" do
+        expect(names).to eq(%w[announcements welcome memes general rules])
+      end
+    end
+
+    context "with rows from before ordering was synced" do
+      before do
+        server.server_channels.update_all(position: nil, parent_id: nil)
+      end
+
+      it "falls back to alphabetical order" do
+        expect(names).to eq(%w[general memes rules welcome])
+      end
+    end
+  end
+
   describe "#everyone_visible?" do
     subject(:visible) { channel.everyone_visible? }
 

--- a/spec/operations/server_configuration/server_channels/sync_spec.rb
+++ b/spec/operations/server_configuration/server_channels/sync_spec.rb
@@ -10,13 +10,19 @@ RSpec.describe Ops::ServerConfiguration::ServerChannels::Sync do
   describe "upserting channels" do
     let(:channels) do
       [
-        {discord_id: 111, name: "general", channel_type: 0, overwrites: []},
-        {discord_id: 222, name: "Voice", channel_type: 2, overwrites: []}
+        {discord_id: 111, name: "general", channel_type: 0, position: 2, parent_id: 999, overwrites: []},
+        {discord_id: 222, name: "Voice", channel_type: 2, position: 0, parent_id: nil, overwrites: []}
       ]
     end
 
     it "creates a row per incoming channel" do
       expect { result }.to change { server.server_channels.count }.from(0).to(2)
+    end
+
+    it "stores each channel's position and category" do
+      result
+
+      expect(server.server_channels.find_by(discord_id: 111)).to have_attributes(position: 2, parent_id: 999)
     end
 
     context "when a channel was renamed since the last sync" do

--- a/spec/presenters/channel_options_spec.rb
+++ b/spec/presenters/channel_options_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ChannelOptions do
+  subject(:options) { described_class.new(server).options }
+
+  let(:server) { create(:server_configuration) }
+
+  before do
+    create(:server_channel, server_configuration: server, name: "info", channel_type: 4, discord_id: 10, position: 0)
+    create(:server_channel, server_configuration: server, name: "rules", channel_type: 0, discord_id: 11, position: 0, parent_id: 10)
+    create(:server_channel, server_configuration: server, name: "faq", channel_type: 0, discord_id: 12, position: 1, parent_id: 10)
+    create(:server_channel, server_configuration: server, name: "welcome", channel_type: 0, discord_id: 1, position: 0)
+  end
+
+  it "lists uncategorised channels as bare options before any group" do
+    expect(options.first).to have_attributes(value: 1, label: "welcome")
+  end
+
+  it "wraps categorised channels in a group named after their category, in position order" do
+    group = options.last
+
+    expect(group.label).to eq("info")
+    expect(group.options.map(&:label)).to eq(%w[rules faq])
+  end
+
+  it "does not offer the category itself as a pickable option" do
+    labels = options.flat_map { |entry| entry.is_a?(Components::TomSelect::Group) ? entry.options : entry }.map(&:label)
+
+    expect(labels).not_to include("info")
+  end
+end


### PR DESCRIPTION
## What

The channel `TomSelect` listed text channels alphabetically. This makes the picker mirror Discord's sidebar instead:

- Migration adds `position` (int) + `parent_id` (bigint, the category's snowflake) to `server_channels`; both captured in `GuildMetadata.channels` + `Ops::ServerConfiguration::ServerChannels::Sync`.
- New `ServerChannel.in_discord_order` scope: uncategorised channels first, then each category's children (categories by their position), each group ordered by position with name as tie-break. Implemented as a self-join on the synced category rows (type 4), so it's one query.
- `ChannelOptions` (all config-page channel pickers) now uses it.
- **Category names render as section headers**: `ChannelOptions` groups categorised channels into `TomSelect::Group`s, rendered as native `optgroup`s — Tom Select shows these as styled headers (uppercase, muted) in the dropdown. Uncategorised channels stay bare at the top; category rows themselves are never pickable.

`parent_id` joins the doctor's snowflake ignore-list — it references Discord's channel id, not our PK, and is never used as a lookup key.

## Live check needed

Existing rows keep `NULL` position/parent and stay alphabetical until the next guild sync — needs a live check that the bot populates the new columns on re-sync (no Discord access in the sandbox). Also eyeball the optgroup header styling in both themes.

## Gates

rspec (604, green) · standardrb · active_record_doctor · undercover vs origin/main — all green locally.