### PR TITLE
Cache guild display metadata on ServerConfiguration

### DIFF
--- a/app/bot/discord/cdn_url.rb
+++ b/app/bot/discord/cdn_url.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Discord
+  module CdnUrl
+    module_function
+
+    def guild_icon(guild_id, icon_hash)
+      "https://cdn.discordapp.com/icons/#{guild_id}/#{icon_hash}.png?size=64" if icon_hash
+    end
+  end
+end

--- a/app/bot/discord/guild.rb
+++ b/app/bot/discord/guild.rb
@@ -25,7 +25,7 @@ module Discord
     end
 
     def icon_url
-      "https://cdn.discordapp.com/icons/#{id}/#{icon}.png?size=64" if icon
+      CdnUrl.guild_icon(id, icon)
     end
   end
 end

--- a/app/bot/guild_metadata.rb
+++ b/app/bot/guild_metadata.rb
@@ -5,6 +5,12 @@ module GuildMetadata
 
   def sync(server, bot)
     config = Ops::ServerConfiguration::Ensure.call(discord_id: server.id).value
+    Ops::ServerConfiguration::Metadata::Sync.call(
+      server_configuration: config,
+      name: server.name,
+      icon_hash: server.icon_id,
+      member_count: server.member_count
+    )
     Ops::ServerConfiguration::ServerChannels::Sync.call(server_configuration: config, channels: channels(server))
     Ops::ServerConfiguration::ServerRoles::Sync.call(
       server_configuration: config,

--- a/app/components/config_page.rb
+++ b/app/components/config_page.rb
@@ -3,7 +3,7 @@
 class Components::ConfigPage < Components::Base
   include Phlex::Rails::Helpers::FormWith
 
-  def initialize(icon:, title:, description:, dashboard_path:, url:, gate: nil, badge: nil)
+  def initialize(icon:, title:, description:, dashboard_path:, url:, gate: nil, badge: nil, dashboard_label: nil)
     @icon = icon
     @title = title
     @description = description
@@ -11,6 +11,7 @@ class Components::ConfigPage < Components::Base
     @url = url
     @gate = gate
     @badge = badge
+    @dashboard_label = dashboard_label
   end
 
   def view_template(&block)
@@ -18,7 +19,7 @@ class Components::ConfigPage < Components::Base
       render Components::Breadcrumb.new(
         [
           {label: t(".servers"), href: servers_path},
-          {label: t(".dashboard"), href: @dashboard_path},
+          {label: @dashboard_label || t(".dashboard"), href: @dashboard_path},
           {label: @title}
         ]
       )

--- a/app/components/config_page.rb
+++ b/app/components/config_page.rb
@@ -3,15 +3,14 @@
 class Components::ConfigPage < Components::Base
   include Phlex::Rails::Helpers::FormWith
 
-  def initialize(icon:, title:, description:, dashboard_path:, url:, gate: nil, badge: nil, dashboard_label: nil)
+  def initialize(icon:, title:, description:, server_configuration:, url:, gate: nil, badge: nil)
     @icon = icon
     @title = title
     @description = description
-    @dashboard_path = dashboard_path
+    @server_configuration = server_configuration
     @url = url
     @gate = gate
     @badge = badge
-    @dashboard_label = dashboard_label
   end
 
   def view_template(&block)
@@ -19,7 +18,7 @@ class Components::ConfigPage < Components::Base
       render Components::Breadcrumb.new(
         [
           {label: t(".servers"), href: servers_path},
-          {label: @dashboard_label || t(".dashboard"), href: @dashboard_path},
+          {label: @server_configuration.name || t(".dashboard"), href: server_path(@server_configuration.discord_id)},
           {label: @title}
         ]
       )

--- a/app/components/plugin_shell.rb
+++ b/app/components/plugin_shell.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class Components::PluginShell < Components::Base
+  def initialize(user:, server_configuration:, active_key:)
+    @user = user
+    @server_configuration = server_configuration
+    @active_key = active_key
+  end
+
+  def view_template(&block)
+    render Components::AppShell.new(
+      user: @user,
+      sidebar: Components::PluginSidebar.new(server_configuration: @server_configuration, active_key: @active_key)
+    ), &block
+  end
+end

--- a/app/components/plugin_sidebar.rb
+++ b/app/components/plugin_sidebar.rb
@@ -33,7 +33,7 @@ class Components::PluginSidebar < Components::Base
       class: "group flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors hover:bg-surface-card"
     ) do
       render Components::Icon.new("arrow-left", class: "size-4 flex-none text-text-muted")
-      span(class: "truncate text-sm font-medium text-text-secondary group-hover:text-text-primary") { t(".dashboard") }
+      span(class: "truncate text-sm font-medium text-text-secondary group-hover:text-text-primary") { @config.name || t(".dashboard") }
     end
   end
 

--- a/app/controllers/concerns/requires_manageable_server.rb
+++ b/app/controllers/concerns/requires_manageable_server.rb
@@ -3,6 +3,8 @@
 module RequiresManageableServer
   extend ActiveSupport::Concern
 
+  include SetsManageableServers
+
   included do
     before_action :require_manageable_server
   end
@@ -17,6 +19,6 @@ module RequiresManageableServer
   end
 
   def manageable_server?(discord_id)
-    Array(session[SetsManageableServers::SESSION_KEY]).include?(discord_id.to_i)
+    manageable_server_ids.include?(discord_id.to_i)
   end
 end

--- a/app/controllers/concerns/sets_manageable_servers.rb
+++ b/app/controllers/concerns/sets_manageable_servers.rb
@@ -10,4 +10,8 @@ module SetsManageableServers
   def remember_manageable_servers(discord_ids)
     session[SESSION_KEY] = discord_ids
   end
+
+  def manageable_server_ids
+    Array(session[SESSION_KEY])
+  end
 end

--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -18,7 +18,7 @@ class ServersController < ApplicationController
     render Views::Servers::Index.new(
       present:,
       absent:,
-      plugin_counts: enabled_plugin_counts(configured),
+      plugin_counts: PluginActivation.enabled_counts_for(configured),
       user: current_user
     )
   end
@@ -45,7 +45,7 @@ class ServersController < ApplicationController
     configured = configured_ids(manageable)
     remember_manageable_servers(configured)
     @configured_guilds = manageable.select { |guild| configured.include?(guild.id) }
-    @plugin_counts = enabled_plugin_counts(configured)
+    @plugin_counts = PluginActivation.enabled_counts_for(configured)
   rescue Discord::UserGuilds::Unauthorized
     raise
   rescue Discord::UserGuilds::Error
@@ -53,13 +53,16 @@ class ServersController < ApplicationController
   end
 
   def load_dashboard_from_cache
-    configs = ServerConfiguration.where(discord_id: manageable_server_ids).where.not(name: nil)
-    @server_configuration = configs.find { |config| config.discord_id == params[:id].to_i }
-    return false unless @server_configuration
+    dashboard = CachedDashboard.for(
+      discord_id: params[:id].to_i,
+      manageable_ids: manageable_server_ids
+    )
+    return false unless dashboard
 
-    @guild = CachedGuild.from(@server_configuration)
-    @configured_guilds = configs.sort_by { |config| -config.member_count.to_i }.map { |config| CachedGuild.from(config) }
-    @plugin_counts = enabled_plugin_counts(configs.map(&:discord_id))
+    @server_configuration = dashboard.server_configuration
+    @guild = dashboard.guild
+    @configured_guilds = dashboard.configured_guilds
+    @plugin_counts = dashboard.plugin_counts
     true
   end
 
@@ -71,14 +74,6 @@ class ServersController < ApplicationController
 
   def configured_ids(guilds)
     ServerConfiguration.where(discord_id: guilds.map(&:id)).pluck(:discord_id)
-  end
-
-  def enabled_plugin_counts(discord_ids)
-    PluginActivation
-      .joins(:server_configuration)
-      .where(server_configurations: {discord_id: discord_ids}, enabled: true)
-      .group("server_configurations.discord_id")
-      .count
   end
 
   def reauthenticate

--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -46,6 +46,21 @@ class ServersController < ApplicationController
     remember_manageable_servers(configured)
     @configured_guilds = manageable.select { |guild| configured.include?(guild.id) }
     @plugin_counts = enabled_plugin_counts(configured)
+  rescue Discord::UserGuilds::Unauthorized
+    raise
+  rescue Discord::UserGuilds::Error
+    raise unless load_dashboard_from_cache
+  end
+
+  def load_dashboard_from_cache
+    configs = ServerConfiguration.where(discord_id: manageable_server_ids).where.not(name: nil)
+    @server_configuration = configs.find { |config| config.discord_id == params[:id].to_i }
+    return false unless @server_configuration
+
+    @guild = CachedGuild.from(@server_configuration)
+    @configured_guilds = configs.sort_by { |config| -config.member_count.to_i }.map { |config| CachedGuild.from(config) }
+    @plugin_counts = enabled_plugin_counts(configs.map(&:discord_id))
+    true
   end
 
   def manageable_guilds

--- a/app/models/plugin_activation.rb
+++ b/app/models/plugin_activation.rb
@@ -7,6 +7,13 @@ class PluginActivation < ApplicationRecord
   validates :plugin_id, uniqueness: {scope: :server_configuration_id}
   validate :enabling_requires_prerequisites
 
+  def self.enabled_counts_for(discord_ids)
+    joins(:server_configuration)
+      .where(server_configurations: {discord_id: discord_ids}, enabled: true)
+      .group("server_configurations.discord_id")
+      .count
+  end
+
   private
 
   def enabling_requires_prerequisites

--- a/app/models/server_configuration.rb
+++ b/app/models/server_configuration.rb
@@ -12,4 +12,8 @@ class ServerConfiguration < ApplicationRecord
   has_many :server_roles, dependent: :delete_all
 
   validates :discord_id, presence: true, uniqueness: true
+
+  def icon_url
+    Discord::CdnUrl.guild_icon(discord_id, icon_hash)
+  end
 end

--- a/app/operations/server_configuration/metadata/sync.rb
+++ b/app/operations/server_configuration/metadata/sync.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Ops
+  module ServerConfiguration
+    module Metadata
+      class Sync < ApplicationOperation
+        receives :server_configuration, :name, :icon_hash, :member_count
+
+        def call
+          server_configuration.update!(name:, icon_hash:, member_count:)
+          ok(server_configuration)
+        end
+      end
+    end
+  end
+end

--- a/app/presenters/cached_dashboard.rb
+++ b/app/presenters/cached_dashboard.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class CachedDashboard
+  def self.for(discord_id:, manageable_ids:)
+    configs = ServerConfiguration.where(discord_id: manageable_ids).where.not(name: nil)
+    config = configs.find { |candidate| candidate.discord_id == discord_id }
+    new(config, configs) if config
+  end
+
+  attr_reader :server_configuration
+
+  def initialize(server_configuration, configs)
+    @server_configuration = server_configuration
+    @configs = configs
+  end
+
+  def guild
+    configured_guilds.find { |guild| guild.id == server_configuration.discord_id }
+  end
+
+  def configured_guilds
+    @configured_guilds ||= @configs.sort_by { |config| -config.member_count.to_i }.map { |config| CachedGuild.from(config) }
+  end
+
+  def plugin_counts
+    PluginActivation.enabled_counts_for(@configs.map(&:discord_id))
+  end
+end

--- a/app/presenters/cached_guild.rb
+++ b/app/presenters/cached_guild.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+CachedGuild = Data.define(:id, :name, :icon_url, :member_count) do
+  def self.from(server_configuration)
+    new(
+      id: server_configuration.discord_id,
+      name: server_configuration.name,
+      icon_url: server_configuration.icon_url,
+      member_count: server_configuration.member_count
+    )
+  end
+end

--- a/app/views/servers/logging/show.rb
+++ b/app/views/servers/logging/show.rb
@@ -8,16 +8,12 @@ class Views::Servers::Logging::Show < Views::Base
   end
 
   def view_template
-    render Components::AppShell.new(
-      user: @user,
-      sidebar: Components::PluginSidebar.new(server_configuration: @config, active_key: :logging)
-    ) do
+    render Components::PluginShell.new(user: @user, server_configuration: @config, active_key: :logging) do
       render Components::ConfigPage.new(
         icon: "scroll",
         title: t(".title"),
         description: t(".description"),
-        dashboard_path: server_path(@config.discord_id),
-        dashboard_label: @config.name,
+        server_configuration: @config,
         url: server_logging_path(@config.discord_id),
         gate: {
           field: "logging[enabled]",

--- a/app/views/servers/logging/show.rb
+++ b/app/views/servers/logging/show.rb
@@ -17,6 +17,7 @@ class Views::Servers::Logging::Show < Views::Base
         title: t(".title"),
         description: t(".description"),
         dashboard_path: server_path(@config.discord_id),
+        dashboard_label: @config.name,
         url: server_logging_path(@config.discord_id),
         gate: {
           field: "logging[enabled]",

--- a/app/views/servers/reminders/show.rb
+++ b/app/views/servers/reminders/show.rb
@@ -16,6 +16,7 @@ class Views::Servers::Reminders::Show < Views::Base
         title: t(".title"),
         description: t(".description"),
         dashboard_path: server_path(@config.discord_id),
+        dashboard_label: @config.name,
         url: server_reminders_path(@config.discord_id),
         badge: t(".badge")
       ) do

--- a/app/views/servers/reminders/show.rb
+++ b/app/views/servers/reminders/show.rb
@@ -7,16 +7,12 @@ class Views::Servers::Reminders::Show < Views::Base
   end
 
   def view_template
-    render Components::AppShell.new(
-      user: @user,
-      sidebar: Components::PluginSidebar.new(server_configuration: @config, active_key: :reminders)
-    ) do
+    render Components::PluginShell.new(user: @user, server_configuration: @config, active_key: :reminders) do
       render Components::ConfigPage.new(
         icon: "bell-ringing",
         title: t(".title"),
         description: t(".description"),
-        dashboard_path: server_path(@config.discord_id),
-        dashboard_label: @config.name,
+        server_configuration: @config,
         url: server_reminders_path(@config.discord_id),
         badge: t(".badge")
       ) do

--- a/app/views/servers/roles/show.rb
+++ b/app/views/servers/roles/show.rb
@@ -8,16 +8,12 @@ class Views::Servers::Roles::Show < Views::Base
   end
 
   def view_template
-    render Components::AppShell.new(
-      user: @user,
-      sidebar: Components::PluginSidebar.new(server_configuration: @config, active_key: :roles)
-    ) do
+    render Components::PluginShell.new(user: @user, server_configuration: @config, active_key: :roles) do
       render Components::ConfigPage.new(
         icon: "users-three",
         title: t(".title"),
         description: t(".description"),
-        dashboard_path: server_path(@config.discord_id),
-        dashboard_label: @config.name,
+        server_configuration: @config,
         url: server_roles_path(@config.discord_id),
         gate: {
           field: "roles[enabled]",

--- a/app/views/servers/roles/show.rb
+++ b/app/views/servers/roles/show.rb
@@ -17,6 +17,7 @@ class Views::Servers::Roles::Show < Views::Base
         title: t(".title"),
         description: t(".description"),
         dashboard_path: server_path(@config.discord_id),
+        dashboard_label: @config.name,
         url: server_roles_path(@config.discord_id),
         gate: {
           field: "roles[enabled]",

--- a/app/views/servers/welcomes/show.rb
+++ b/app/views/servers/welcomes/show.rb
@@ -8,16 +8,12 @@ class Views::Servers::Welcomes::Show < Views::Base
   end
 
   def view_template
-    render Components::AppShell.new(
-      user: @user,
-      sidebar: Components::PluginSidebar.new(server_configuration: @config, active_key: :welcomes)
-    ) do
+    render Components::PluginShell.new(user: @user, server_configuration: @config, active_key: :welcomes) do
       render Components::ConfigPage.new(
         icon: "hand-waving",
         title: t(".title"),
         description: t(".description"),
-        dashboard_path: server_path(@config.discord_id),
-        dashboard_label: @config.name,
+        server_configuration: @config,
         url: server_welcomes_path(@config.discord_id),
         gate: {
           field: "welcomes[enabled]",

--- a/app/views/servers/welcomes/show.rb
+++ b/app/views/servers/welcomes/show.rb
@@ -17,6 +17,7 @@ class Views::Servers::Welcomes::Show < Views::Base
         title: t(".title"),
         description: t(".description"),
         dashboard_path: server_path(@config.discord_id),
+        dashboard_label: @config.name,
         url: server_welcomes_path(@config.discord_id),
         gate: {
           field: "welcomes[enabled]",

--- a/db/migrate/20260703232733_add_cached_guild_metadata_to_server_configurations.rb
+++ b/db/migrate/20260703232733_add_cached_guild_metadata_to_server_configurations.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddCachedGuildMetadataToServerConfigurations < ActiveRecord::Migration[8.1]
+  def change
+    add_column :server_configurations, :name, :string
+    add_column :server_configurations, :icon_hash, :string
+    add_column :server_configurations, :member_count, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_03_225437) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_03_232733) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -124,6 +124,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_03_225437) do
     t.datetime "created_at", null: false
     t.bigint "discord_id", null: false
     t.boolean "force_dm_reminders", default: false, null: false
+    t.string "icon_hash"
+    t.integer "member_count"
+    t.string "name"
     t.datetime "onboarded_at"
     t.datetime "updated_at", null: false
     t.index ["discord_id"], name: "index_server_configurations_on_discord_id", unique: true

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -222,7 +222,10 @@ upsert + prune of stale rows.
 
 `GuildMetadata.sync` ensures the config, then syncs channels and roles, then
 reconciles deleted channels — in one method, because the `server_create` handler
-order isn't fixed and the populate ops always need a config to attach to.
+order isn't fixed and the populate ops always need a config to attach to. It also
+caches guild display metadata (name, icon hash, member count) on `server_configurations`
+via `Ops::ServerConfiguration::Metadata::Sync`, so the web UI can render server identity
+without a live Discord API call when the API is temporarily unreachable.
 
 `ServerChannel#everyone_visible?` is the @everyone-visibility heuristic behind the
 logging-channel warning. The @everyone role's id equals the guild id. It checks the

--- a/spec/bot/guild_metadata_spec.rb
+++ b/spec/bot/guild_metadata_spec.rb
@@ -62,13 +62,14 @@ RSpec.describe GuildMetadata do
   describe ".sync" do
     subject(:sync) { described_class.sync(server, bot) }
 
-    let(:server) { double("server", id: 77, channels: [], roles: []) }
+    let(:server) { double("server", id: 77, channels: [], roles: [], name: "Dev Refuge", icon_id: "icyhash", member_count: 2481) }
     let(:bot) { double("bot") }
     let(:config) { instance_double(ServerConfiguration) }
 
     before do
       allow(Ops::ServerConfiguration::Ensure).to receive(:call)
         .with(discord_id: 77).and_return(double(value: config))
+      allow(Ops::ServerConfiguration::Metadata::Sync).to receive(:call)
       allow(described_class).to receive(:bot_role_position).with(server, bot).and_return(7)
       allow(ServerOnboarder).to receive(:notify)
     end
@@ -77,6 +78,19 @@ RSpec.describe GuildMetadata do
       expect(Ops::ServerConfiguration::ServerChannels::Sync).to receive(:call).with(server_configuration: config, channels: [])
       expect(Ops::ServerConfiguration::ServerRoles::Sync).to receive(:call).with(server_configuration: config, roles: [], bot_role_position: 7)
       expect(Ops::ServerConfiguration::Channels::Reconcile).to receive(:call).with(server_configuration: config, bot:)
+      sync
+    end
+
+    it "syncs the server's display metadata" do
+      allow(Ops::ServerConfiguration::ServerChannels::Sync).to receive(:call)
+      allow(Ops::ServerConfiguration::ServerRoles::Sync).to receive(:call)
+      allow(Ops::ServerConfiguration::Channels::Reconcile).to receive(:call)
+      expect(Ops::ServerConfiguration::Metadata::Sync).to receive(:call).with(
+        server_configuration: config,
+        name: "Dev Refuge",
+        icon_hash: "icyhash",
+        member_count: 2481
+      )
       sync
     end
 

--- a/spec/components/config_page_spec.rb
+++ b/spec/components/config_page_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::ConfigPage do
+  include_context "component view context"
+
+  subject(:html) do
+    described_class.new(
+      icon: "bell",
+      title: "Reminders",
+      description: "Manage reminders.",
+      dashboard_path: "/servers/1",
+      url: "/servers/1/reminders",
+      dashboard_label:
+    ).render_in(view_context) { "" }
+  end
+
+  context "when dashboard_label is provided" do
+    let(:dashboard_label) { "Dev Refuge" }
+
+    it "shows the given label in the breadcrumb" do
+      expect(html).to include("Dev Refuge")
+    end
+  end
+
+  context "when dashboard_label is nil" do
+    let(:dashboard_label) { nil }
+
+    it "falls back to the generic dashboard label" do
+      expect(html).to include("Dashboard")
+    end
+  end
+end

--- a/spec/components/plugin_shell_spec.rb
+++ b/spec/components/plugin_shell_spec.rb
@@ -2,33 +2,36 @@
 
 require "rails_helper"
 
-RSpec.describe Components::ConfigPage do
+RSpec.describe Components::PluginShell do
   include_context "component view context"
 
   subject(:html) do
     described_class.new(
-      icon: "bell",
-      title: "Reminders",
-      description: "Manage reminders.",
+      user:,
       server_configuration: config,
-      url: "/servers/900000001/reminders"
-    ).render_in(view_context) { "" }
+      active_key: :logging
+    ).render_in(view_context) { "block content" }
   end
 
+  let(:user) { create(:user) }
   let(:config) { create(:server_configuration, discord_id: 900_000_001, name:) }
 
   context "when the server configuration has a name" do
     let(:name) { "Dev Refuge" }
 
-    it "shows the server name in the breadcrumb" do
+    it "renders the sidebar with the server name" do
       expect(html).to include("Dev Refuge")
+    end
+
+    it "yields the block content" do
+      expect(html).to include("block content")
     end
   end
 
   context "when the server configuration has no name" do
     let(:name) { nil }
 
-    it "falls back to the generic dashboard label" do
+    it "renders the sidebar with the fallback dashboard label" do
       expect(html).to include("Dashboard")
     end
   end

--- a/spec/components/plugin_sidebar_spec.rb
+++ b/spec/components/plugin_sidebar_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::PluginSidebar do
+  include_context "component view context"
+
+  subject(:html) do
+    described_class.new(server_configuration: config, active_key: :logging).render_in(view_context)
+  end
+
+  let(:config) { create(:server_configuration, discord_id: 900_000_001, name:) }
+
+  context "when the server configuration has a name" do
+    let(:name) { "Dev Refuge" }
+
+    it "shows the server name in the back-link" do
+      expect(html).to include("Dev Refuge")
+    end
+  end
+
+  context "when the server configuration has no name" do
+    let(:name) { nil }
+
+    it "falls back to the generic dashboard label" do
+      expect(html).to include("Dashboard")
+    end
+  end
+end

--- a/spec/models/plugin_activation_spec.rb
+++ b/spec/models/plugin_activation_spec.rb
@@ -29,4 +29,34 @@ RSpec.describe PluginActivation do
 
     it { is_expected.to be_valid }
   end
+
+  describe ".enabled_counts_for" do
+    subject(:counts) { described_class.enabled_counts_for([server_a.discord_id, server_b.discord_id]) }
+
+    let(:server_a) { create(:server_configuration) }
+    let(:server_b) { create(:server_configuration) }
+    let(:plugin_a) { create(:plugin) }
+    let(:plugin_b) { create(:plugin) }
+
+    before do
+      create(:plugin_activation, server_configuration: server_a, plugin: plugin_a, enabled: true)
+      create(:plugin_activation, server_configuration: server_a, plugin: plugin_b, enabled: false)
+      create(:plugin_activation, server_configuration: server_b, plugin: plugin_a, enabled: true)
+      create(:plugin_activation, server_configuration: server_b, plugin: plugin_b, enabled: true)
+    end
+
+    it "counts only enabled activations" do
+      expect(counts[server_a.discord_id]).to eq(1)
+    end
+
+    it "groups counts by discord_id" do
+      expect(counts[server_b.discord_id]).to eq(2)
+    end
+
+    it "omits servers with no enabled activations" do
+      empty_server = create(:server_configuration)
+      result = described_class.enabled_counts_for([empty_server.discord_id])
+      expect(result).not_to have_key(empty_server.discord_id)
+    end
+  end
 end

--- a/spec/models/server_configuration_spec.rb
+++ b/spec/models/server_configuration_spec.rb
@@ -45,4 +45,24 @@ RSpec.describe ServerConfiguration do
       expect(activation).not_to be_valid
     end
   end
+
+  describe "#icon_url" do
+    subject(:icon_url) { server.icon_url }
+
+    let(:server) { create(:server_configuration, discord_id: 900_000_001, icon_hash:) }
+
+    context "when icon_hash is present" do
+      let(:icon_hash) { "abc123" }
+
+      it "builds the Discord CDN URL" do
+        expect(icon_url).to eq("https://cdn.discordapp.com/icons/900000001/abc123.png?size=64")
+      end
+    end
+
+    context "when icon_hash is nil" do
+      let(:icon_hash) { nil }
+
+      it { is_expected.to be_nil }
+    end
+  end
 end

--- a/spec/operations/server_configuration/metadata/sync_spec.rb
+++ b/spec/operations/server_configuration/metadata/sync_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Ops::ServerConfiguration::Metadata::Sync do
+  subject(:result) do
+    described_class.call(
+      server_configuration: server,
+      name: "Dev Refuge",
+      icon_hash: "abc123",
+      member_count: 42
+    )
+  end
+
+  let(:server) { create(:server_configuration) }
+
+  it "returns a successful result" do
+    expect(result).to be_success
+  end
+
+  it "returns the updated server configuration" do
+    expect(result.value).to eq(server)
+  end
+
+  it "writes the name to the record" do
+    result
+    expect(server.reload.name).to eq("Dev Refuge")
+  end
+
+  it "writes the icon_hash to the record" do
+    result
+    expect(server.reload.icon_hash).to eq("abc123")
+  end
+
+  it "writes the member_count to the record" do
+    result
+    expect(server.reload.member_count).to eq(42)
+  end
+
+  context "when icon_hash is nil" do
+    subject(:result) do
+      described_class.call(
+        server_configuration: server,
+        name: "Dev Refuge",
+        icon_hash: nil,
+        member_count: 42
+      )
+    end
+
+    it "returns a successful result" do
+      expect(result).to be_success
+    end
+
+    it "stores nil for icon_hash" do
+      result
+      expect(server.reload.icon_hash).to be_nil
+    end
+  end
+end

--- a/spec/presenters/cached_dashboard_spec.rb
+++ b/spec/presenters/cached_dashboard_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CachedDashboard do
+  let(:discord_id) { 900_000_001 }
+  let(:other_id) { 900_000_002 }
+  let!(:config) { create(:server_configuration, discord_id:, name: "Dev Refuge", member_count: 50) }
+  let!(:other_config) { create(:server_configuration, discord_id: other_id, name: "Other Server", member_count: 100) }
+
+  describe ".for" do
+    subject(:dashboard) do
+      described_class.for(
+        discord_id:,
+        manageable_ids: [discord_id, other_id]
+      )
+    end
+
+    it "returns a dashboard for the given discord_id" do
+      expect(dashboard).to be_a(described_class)
+    end
+
+    it "sets server_configuration to the matching config" do
+      expect(dashboard.server_configuration).to eq(config)
+    end
+
+    context "when the target id is not in manageable_ids" do
+      subject(:dashboard) do
+        described_class.for(
+          discord_id: 999_999_999,
+          manageable_ids: [discord_id, other_id]
+        )
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when the matching config has a nil name" do
+      before { config.update!(name: nil) }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe "#guild" do
+    subject(:guild) do
+      described_class.for(
+        discord_id:,
+        manageable_ids: [discord_id, other_id]
+      ).guild
+    end
+
+    it "returns a CachedGuild for the target server" do
+      expect(guild).to be_a(CachedGuild)
+      expect(guild.id).to eq(discord_id)
+    end
+  end
+
+  describe "#configured_guilds" do
+    subject(:guilds) do
+      described_class.for(
+        discord_id:,
+        manageable_ids: [discord_id, other_id]
+      ).configured_guilds
+    end
+
+    it "returns CachedGuild instances for each manageable config" do
+      expect(guilds).to all(be_a(CachedGuild))
+    end
+
+    it "orders guilds by member_count descending" do
+      expect(guilds.map(&:id)).to eq([other_id, discord_id])
+    end
+  end
+
+  describe "#plugin_counts" do
+    subject(:counts) do
+      described_class.for(
+        discord_id:,
+        manageable_ids: [discord_id, other_id]
+      ).plugin_counts
+    end
+
+    let(:plugin) { create(:plugin) }
+
+    before do
+      create(:plugin_activation, server_configuration: config, plugin:, enabled: true)
+    end
+
+    it "delegates to PluginActivation.enabled_counts_for with config discord_ids" do
+      expect(counts).to eq({discord_id => 1})
+    end
+  end
+end

--- a/spec/requests/server_dashboard_spec.rb
+++ b/spec/requests/server_dashboard_spec.rb
@@ -119,12 +119,44 @@ RSpec.describe "Server dashboard", type: :request do
       end
 
       context "when Discord cannot be reached" do
-        before { allow(Discord::UserGuilds).to receive(:call).and_raise(Discord::UserGuilds::Error) }
+        before do
+          get server_path(guild.id)
+          allow(Discord::UserGuilds).to receive(:call).and_raise(Discord::UserGuilds::Error)
+        end
 
-        it "renders the error state without raising" do
+        context "when cached metadata is present" do
+          before { config.update!(name: "Dev Refuge", icon_hash: "icyhash", member_count: 2481) }
+
+          it "serves a 200 from the cache" do
+            get_dashboard
+            expect(response).to have_http_status(:ok)
+          end
+
+          it "renders the server name from the cache" do
+            get_dashboard
+            expect(response.body).to include("Dev Refuge")
+          end
+        end
+
+        context "when no cached metadata is available" do
+          it "renders the error state" do
+            get_dashboard
+            expect(response).to have_http_status(:ok)
+            expect(response.body).to include("reach Discord")
+          end
+        end
+      end
+
+      context "when the Discord token has expired and Discord is also unreachable" do
+        before do
+          get server_path(guild.id)
+          allow(Discord::UserGuilds).to receive(:call).and_raise(Discord::UserGuilds::Unauthorized)
+          config.update!(name: "Dev Refuge", icon_hash: "icyhash", member_count: 2481)
+        end
+
+        it "still kicks off re-authentication without falling back to cache" do
           get_dashboard
-          expect(response).to have_http_status(:ok)
-          expect(response.body).to include("reach Discord")
+          expect(response.body).to include("Signing you back in")
         end
       end
     end

--- a/spec/support/component_view_context.rb
+++ b/spec/support/component_view_context.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.shared_context "component view context" do
+  let(:view_context) do
+    controller = ApplicationController.new
+    controller.request = ActionDispatch::TestRequest.create({"HTTP_HOST" => "localhost"})
+    controller.view_context
+  end
+end


### PR DESCRIPTION
## Why

Two long-standing papercuts from the redesign follow-up list:

1. `servers#show` fetched the user's guilds from Discord live on every load — an intermittent API failure rendered the "couldn't reach Discord" error page for the whole dashboard (first reported during #72).
2. Config controllers only load `ServerConfiguration`, so the plugin sidebar back-link and the breadcrumb both showed a generic "Dashboard" instead of the server.

## What

- New columns `name`, `icon_hash`, `member_count` on `server_configurations`, written during guild sync (`GuildMetadata.sync` → new `Ops::ServerConfiguration::Metadata::Sync`). Existing rows backfill on their next sync (`server_create` / `ready`).
- Dashboard fallback: on `Discord::UserGuilds::Error` the dashboard renders from the cache via the new `CachedDashboard` presenter (`CachedGuild` per server), scoped to the session's authorized server ids (same trust the config pages already place in that session key). `Unauthorized` still triggers re-authentication; servers never synced since this migration behave exactly as before (error page).
- Sidebar back-link and config breadcrumb show the cached server name, falling back to "Dashboard" when unset.
- `Discord::CdnUrl.guild_icon` extracted — now shared by `Discord::Guild#icon_url` and the new `ServerConfiguration#icon_url`.

## Needs a live check

The bot must populate the new columns on a real guild sync — `server.icon_id` / `server.member_count` are verified against the vendored discordrb source, but no Discord network here.

## Refactors from the review pass (second commit)

- `CachedDashboard` presenter owns the cache-path read-side assembly instead of the controller.
- `PluginActivation.enabled_counts_for` — the enabled-plugin-count query moved out of the controller (was about to hit its third copy).
- `Components::PluginShell` — the four config views repeated the AppShell+PluginSidebar nesting verbatim; extracted. `ConfigPage` now takes `server_configuration:` instead of `dashboard_path:`+`dashboard_label:` and derives both (constructor 8 → 7 params).

## Boyscouting

- `SetsManageableServers#manageable_server_ids` reader extracted; `RequiresManageableServer#manageable_server?` now uses it instead of reading the raw session key.
- Shared `"component view context"` spec context extracted (was about to be duplicated across component specs needing route helpers).

Flagged for future PRs (not done here, would bloat): dedupe the `initials` helper (show view + app shell), move the `reauthenticate`/`render_error` rescue handlers to a concern once a second controller needs them, extract the live dashboard path into a full query object, split ConfigPage's header params into a value object.

## Gates

`rspec` (635 examples, 0 failures), `standardrb`, `active_record_doctor`, `undercover --compare origin/main`, `i18n-tasks missing` + `check-normalized` — all green.