### PR TITLE
Fix roles page crash on guilds with categorised channels

### DIFF
--- a/app/components/roles/config_form.rb
+++ b/app/components/roles/config_form.rb
@@ -75,12 +75,16 @@ class Components::Roles::ConfigForm < Components::Base
     end
   end
 
+  def channel_options
+    @channel_options ||= ChannelOptions.new(@config)
+  end
+
   def channels
-    @channels ||= ChannelOptions.new(@config).options
+    @channels ||= channel_options.options
   end
 
   def channels_by_id
-    @channels_by_id ||= channels.to_h { |option| [option.value.to_i, option.label] }
+    @channels_by_id ||= channel_options.labels_by_id
   end
 
   def assignable_options

--- a/app/presenters/channel_options.rb
+++ b/app/presenters/channel_options.rb
@@ -11,6 +11,10 @@ class ChannelOptions
     end
   end
 
+  def labels_by_id
+    channels.to_h { |channel| [channel.discord_id, channel.name] }
+  end
+
   private
 
   def grouped(category, group)
@@ -27,7 +31,7 @@ class ChannelOptions
   end
 
   def channels
-    @config.server_channels.text.in_discord_order
+    @channels ||= @config.server_channels.text.in_discord_order
   end
 
   def categories

--- a/spec/components/roles/config_form_spec.rb
+++ b/spec/components/roles/config_form_spec.rb
@@ -19,4 +19,15 @@ RSpec.describe Components::Roles::ConfigForm do
   it "shows the none-message when no channels have synced" do
     expect(html).to include("No channels have synced yet")
   end
+
+  context "when a guild has a category with child text channels" do
+    before do
+      create(:server_channel, server_configuration: config, name: "General", channel_type: 4, discord_id: 900, position: 0)
+      create(:server_channel, server_configuration: config, name: "chat", channel_type: 0, discord_id: 901, position: 0, parent_id: 900)
+    end
+
+    it "renders without raising NoMethodError" do
+      expect { html }.not_to raise_error
+    end
+  end
 end

--- a/spec/presenters/channel_options_spec.rb
+++ b/spec/presenters/channel_options_spec.rb
@@ -30,4 +30,21 @@ RSpec.describe ChannelOptions do
 
     expect(labels).not_to include("info")
   end
+
+  describe "#labels_by_id" do
+    subject(:labels_by_id) { described_class.new(server).labels_by_id }
+
+    it "maps discord_id to name for uncategorised text channels" do
+      expect(labels_by_id[1]).to eq("welcome")
+    end
+
+    it "maps discord_id to name for text channels inside a category" do
+      expect(labels_by_id[11]).to eq("rules")
+      expect(labels_by_id[12]).to eq("faq")
+    end
+
+    it "excludes the category channel itself" do
+      expect(labels_by_id).not_to have_key(10)
+    end
+  end
 end


### PR DESCRIPTION
Latent regression from #79, surfaced by the live check: `ChannelOptions#options` returns `TomSelect::Group` wrappers whenever a guild has categorised text channels, but `Components::Roles::ConfigForm#channels_by_id` still assumed flat options and called `.value` on the group — `NoMethodError` on opening the Roles config page for any guild with a category.

Fix: the presenter now exposes `ChannelOptions#labels_by_id` built straight from the channel scope (`discord_id → name`, text channels only), and the form delegates to it, so the id→name lookup no longer depends on the option structure. One `ChannelOptions` instance is reused and its scope memoized.

Welcomes/Logging are unaffected — they only feed the options into a select, and `TomSelect` itself renders groups correctly. This was the sole flat-assumption consumer.

Specs: `#labels_by_id` unit coverage (uncategorised, categorised, category row excluded) + a regression spec at the crash site (category + child channel renders; verified failing with `NoMethodError` before the fix). rspec 639 green, standardrb / active_record_doctor / undercover clean.

Note: #81 needs this to be live-testable (its Resync button lives on this page) — the fix branch is merged into `feature/role-menu-posting-seam` as well; #81's diff shrinks back to its own commit once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)