### PR TITLE
Split fat role-config constructors and harden assignable-role writes

### DIFF
--- a/app/components/app_shell.rb
+++ b/app/components/app_shell.rb
@@ -3,6 +3,7 @@
 class Components::AppShell < Components::Base
   include Phlex::Rails::Helpers::ImageTag
   include Phlex::Rails::Helpers::ButtonTo
+  include Components::Initials
 
   def initialize(user:, current_server: nil, servers: [], plugin_counts: {}, sidebar: nil)
     @user = user
@@ -147,9 +148,5 @@ class Components::AppShell < Components::Base
     else
       span(class: "flex size-8 items-center justify-center rounded-full bg-accent-soft text-xs font-bold text-accent-soft-fg") { initials(@user.display_name) }
     end
-  end
-
-  def initials(name)
-    name.split.filter_map { |word| word[0] }.first(2).join.upcase
   end
 end

--- a/app/components/initials.rb
+++ b/app/components/initials.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Components
+  module Initials
+    private
+
+    def initials(name)
+      name.split.filter_map { |word| word[0] }.first(2).join.upcase
+    end
+  end
+end

--- a/app/components/roles/config_form.rb
+++ b/app/components/roles/config_form.rb
@@ -37,29 +37,35 @@ class Components::Roles::ConfigForm < Components::Base
   end
 
   def card_for(set, index)
-    card(
-      index:,
-      set_id: set.id,
-      name: set.name,
-      selection_mode: set.selection_mode,
-      channel_override: set.channel_override,
-      selected_role_ids: set.assignable_roles.map(&:role_id),
-      repost_path: repost_path_for(set)
+    Components::Roles::RoleSetCard.new(
+      data: Components::Roles::RoleSetCardData.new(
+        index:,
+        set_id: set.id,
+        name: set.name,
+        selection_mode: set.selection_mode,
+        channel_override: set.channel_override,
+        selected_role_ids: set.assignable_roles.map(&:role_id),
+        open: false,
+        repost_path: repost_path_for(set)
+      ),
+      context: card_context
     )
   end
 
   def new_card
-    card(index: "NEW_RECORD", open: true)
+    Components::Roles::RoleSetCard.new(
+      data: Components::Roles::RoleSetCardData.empty,
+      context: card_context
+    )
   end
 
-  def card(**attrs)
-    Components::Roles::RoleSetCard.new(
+  def card_context
+    @card_context ||= Components::Roles::RoleFormContext.new(
       channels:,
       role_options:,
       channels_by_id:,
       default_channel_id: @setting.channel_id,
-      any_unassignable: assignable_options.any_unassignable?,
-      **attrs
+      any_unassignable: assignable_options.any_unassignable?
     )
   end
 

--- a/app/components/roles/role_form_context.rb
+++ b/app/components/roles/role_form_context.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Components
+  module Roles
+    RoleFormContext = Data.define(
+      :channels,
+      :role_options,
+      :channels_by_id,
+      :default_channel_id,
+      :any_unassignable
+    )
+  end
+end

--- a/app/components/roles/role_set_card.rb
+++ b/app/components/roles/role_set_card.rb
@@ -3,39 +3,14 @@
 class Components::Roles::RoleSetCard < Components::Base
   ICON_BUTTON = "flex size-8 flex-none items-center justify-center rounded-md text-text-muted transition-colors"
 
-  def initialize(
-    index:,
-    channels:,
-    role_options:,
-    channels_by_id:,
-    default_channel_id:,
-    any_unassignable:,
-    set_id: nil,
-    name: "",
-    selection_mode: "single",
-    channel_override: nil,
-    selected_role_ids: [],
-    open: false,
-    repost_path: nil
-  )
-    @index = index
-    @channels = channels
-    @role_options = role_options
-    @channels_by_id = channels_by_id
-    @default_channel_id = default_channel_id
-    @any_unassignable = any_unassignable
-    @set_id = set_id
-    @name = name
-    @selection_mode = selection_mode
-    @channel_override = channel_override
-    @selected_role_ids = selected_role_ids
-    @open = open
-    @repost_path = repost_path
+  def initialize(data:, context:)
+    @data = data
+    @context = context
   end
 
   def view_template
     details(
-      open: @open,
+      open: @data.open,
       data: {role_set: true, controller: "dropdown", dropdown_dismiss_on_outside_value: "false"},
       class: "rounded-card border border-border-default bg-surface-card shadow-sm"
     ) do
@@ -48,11 +23,11 @@ class Components::Roles::RoleSetCard < Components::Base
   private
 
   def field(name)
-    "roles[role_sets][#{@index}][#{name}]"
+    "roles[role_sets][#{@data.index}][#{name}]"
   end
 
   def hidden_fields
-    input(type: "hidden", name: field(:id), value: @set_id, data: {role_set_id: true})
+    input(type: "hidden", name: field(:id), value: @data.set_id, data: {role_set_id: true})
     input(type: "hidden", name: field(:_destroy), value: "0", data: {role_set_destroy: true})
   end
 
@@ -63,8 +38,8 @@ class Components::Roles::RoleSetCard < Components::Base
     ) do
       div(class: "min-w-0 flex-1") do
         div(class: "flex items-center gap-2") do
-          span(class: "truncate text-sm font-semibold") { @name.presence || t(".unnamed") }
-          render Components::Badge.new(variant: :brand, shape: :pill) { t(".mode.#{@selection_mode}") }
+          span(class: "truncate text-sm font-semibold") { @data.name.presence || t(".unnamed") }
+          render Components::Badge.new(variant: :brand, shape: :pill) { t(".mode.#{@data.selection_mode}") }
         end
         p(class: "mt-0.5 truncate text-xs text-text-muted") { subtitle }
       end
@@ -86,7 +61,7 @@ class Components::Roles::RoleSetCard < Components::Base
   end
 
   def repost_button
-    return if @repost_path.nil?
+    return if @data.repost_path.nil?
 
     render Components::Tooltip.new(text: t(".resync")) do
       button(
@@ -94,7 +69,7 @@ class Components::Roles::RoleSetCard < Components::Base
         aria_label: t(".resync"),
         data: {
           action: "role-sets#repost",
-          repost_url: @repost_path
+          repost_url: @data.repost_path
         },
         class: "#{ICON_BUTTON} hover:bg-accent-soft hover:text-accent-soft-fg"
       ) { render Components::Icon.new("arrows-clockwise", class: "size-4") }
@@ -116,7 +91,7 @@ class Components::Roles::RoleSetCard < Components::Base
         input(
           type: "text",
           name: field(:name),
-          value: @name,
+          value: @data.name,
           required: true,
           data: {role_set_name: true},
           class: "h-10 w-full rounded-control border-[1.5px] border-border-strong bg-surface-card px-3 text-sm " \
@@ -127,7 +102,7 @@ class Components::Roles::RoleSetCard < Components::Base
         label(class: "mb-1.5 block text-sm font-semibold") { t(".selection.label") }
         render Components::SegmentedControl.new(
           name: field(:selection_mode),
-          value: @selection_mode,
+          value: @data.selection_mode,
           options: [
             {value: "single", label: t(".mode.single")},
             {value: "multi", label: t(".mode.multi")}
@@ -145,8 +120,8 @@ class Components::Roles::RoleSetCard < Components::Base
       end
       render Components::ChannelSelect.new(
         name: field(:channel_override),
-        options: @channels,
-        selected: @channel_override,
+        options: @context.channels,
+        selected: @data.channel_override,
         placeholder: t(".channel.placeholder", channel: default_channel_label),
         include_blank: true
       )
@@ -158,8 +133,8 @@ class Components::Roles::RoleSetCard < Components::Base
       label(class: "mb-1.5 block text-sm font-semibold") { t(".roles.label") }
       render Components::RoleSelect.new(
         name: "#{field(:role_ids)}[]",
-        options: @role_options,
-        selected: @selected_role_ids,
+        options: @context.role_options,
+        selected: @data.selected_role_ids,
         placeholder: t(".roles.placeholder")
       )
       unassignable_callout
@@ -167,7 +142,7 @@ class Components::Roles::RoleSetCard < Components::Base
   end
 
   def unassignable_callout
-    return unless @any_unassignable
+    return unless @context.any_unassignable
 
     div(class: "mt-2.5") do
       render Components::Callout.new(variant: :warning) { t(".roles.unassignable") }
@@ -175,17 +150,17 @@ class Components::Roles::RoleSetCard < Components::Base
   end
 
   def subtitle
-    count = t(".roles.count", count: @selected_role_ids.size)
+    count = t(".roles.count", count: @data.selected_role_ids.size)
     label = channel_label
     label ? "##{label} · #{count}" : count
   end
 
   def channel_label
-    @channels_by_id[(@channel_override || @default_channel_id).to_i]
+    @context.channels_by_id[(@data.channel_override || @context.default_channel_id).to_i]
   end
 
   def default_channel_label
-    name = @channels_by_id[@default_channel_id.to_i]
+    name = @context.channels_by_id[@context.default_channel_id.to_i]
     name ? "##{name}" : t(".channel.no_default")
   end
 end

--- a/app/components/roles/role_set_card_data.rb
+++ b/app/components/roles/role_set_card_data.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Components
+  module Roles
+    RoleSetCardData = Data.define(
+      :index,
+      :set_id,
+      :name,
+      :selection_mode,
+      :channel_override,
+      :selected_role_ids,
+      :open,
+      :repost_path
+    ) do
+      def self.empty
+        new(
+          index: "NEW_RECORD",
+          set_id: nil,
+          name: "",
+          selection_mode: "single",
+          channel_override: nil,
+          selected_role_ids: [],
+          open: true,
+          repost_path: nil
+        )
+      end
+    end
+  end
+end

--- a/app/operations/roles/configure.rb
+++ b/app/operations/roles/configure.rb
@@ -81,7 +81,7 @@ module Ops
       end
 
       def valid_role_ids
-        @valid_role_ids ||= server_configuration.server_roles.pluck(:discord_id)
+        @valid_role_ids ||= ::Roles::AssignableServerRoles.new(server_configuration).assignable_ids
       end
 
       def next_position

--- a/app/plugins/roles/assignable_server_roles.rb
+++ b/app/plugins/roles/assignable_server_roles.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Roles
+  class AssignableServerRoles
+    def initialize(server_configuration)
+      @config = server_configuration
+    end
+
+    def candidates
+      @candidates ||= @config.server_roles
+        .where.not(discord_id: @config.discord_id)
+        .order(position: :desc)
+    end
+
+    def reason_for(role)
+      return :managed if role.managed?
+      return :above_bot if bot_position && role.position.to_i >= bot_position
+
+      nil
+    end
+
+    def any_unassignable?
+      candidates.any? { |role| reason_for(role) }
+    end
+
+    def assignable_ids
+      candidates.reject { |role| reason_for(role) }.map(&:discord_id)
+    end
+
+    private
+
+    def bot_position
+      @config.bot_role_position
+    end
+  end
+end

--- a/app/presenters/assignable_role_options.rb
+++ b/app/presenters/assignable_role_options.rb
@@ -3,43 +3,37 @@
 class AssignableRoleOptions
   DEFAULT_COLOR = "#99aab5"
 
+  REASON_KEYS = {
+    managed: "assignable_roles.managed",
+    above_bot: "assignable_roles.above_bot"
+  }.freeze
+
   def initialize(server_configuration)
-    @config = server_configuration
+    @roles = Roles::AssignableServerRoles.new(server_configuration)
   end
 
   def options
-    assignable_roles.map do |role|
+    @roles.candidates.map do |role|
+      reason = reason_text(role)
       Components::TomSelect::Option.for(
         value: role.discord_id,
         label: role.name,
         color: color_hex(role.color),
-        disabled: reason_for(role).present?,
-        reason: reason_for(role)
+        disabled: reason.present?,
+        reason:
       )
     end
   end
 
   def any_unassignable?
-    assignable_roles.any? { |role| reason_for(role).present? }
+    @roles.any_unassignable?
   end
 
   private
 
-  def assignable_roles
-    @assignable_roles ||= @config.server_roles
-      .where.not(discord_id: @config.discord_id)
-      .order(position: :desc)
-  end
-
-  def reason_for(role)
-    return I18n.t("assignable_roles.managed") if role.managed?
-    return I18n.t("assignable_roles.above_bot") if bot_position && role.position.to_i >= bot_position
-
-    nil
-  end
-
-  def bot_position
-    @config.bot_role_position
+  def reason_text(role)
+    key = REASON_KEYS[@roles.reason_for(role)]
+    key && I18n.t(key)
   end
 
   def color_hex(color)

--- a/app/views/servers/index.rb
+++ b/app/views/servers/index.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Views::Servers::Index < Views::Base
+  include Components::Initials
+
   def initialize(present:, absent:, user:, plugin_counts: {}, error: false)
     @present = present
     @absent = absent
@@ -111,10 +113,6 @@ class Views::Servers::Index < Views::Base
 
   def error_banner
     div(class: "mb-6 rounded-md border border-warning/30 bg-warning-soft px-4 py-3 text-sm text-warning") { t(".error") }
-  end
-
-  def initials(name)
-    name.split.filter_map { |word| word[0] }.first(2).join.upcase
   end
 
   def generic_invite_url

--- a/app/views/servers/show.rb
+++ b/app/views/servers/show.rb
@@ -2,6 +2,7 @@
 
 class Views::Servers::Show < Views::Base
   include Phlex::Rails::Helpers::ImageTag
+  include Components::Initials
 
   def initialize(guild:, server_configuration:, plugins:, user:, servers: [], plugin_counts: {})
     @guild = guild
@@ -66,9 +67,5 @@ class Views::Servers::Show < Views::Base
         render Components::PluginRow.new(server_id: @guild.id, key: row.key, enabled: row.enabled, configured: row.configured, locked: row.locked)
       end
     end
-  end
-
-  def initials(name)
-    name.split.filter_map { |word| word[0] }.first(2).join.upcase
   end
 end

--- a/spec/components/initials_spec.rb
+++ b/spec/components/initials_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::Initials do
+  let(:host) do
+    Class.new do
+      include Components::Initials
+
+      public :initials
+    end.new
+  end
+
+  it "returns first two initials for a multi-word name" do
+    expect(host.initials("Foo Bar Baz")).to eq("FB")
+  end
+
+  it "returns single initial for a one-word name" do
+    expect(host.initials("single")).to eq("S")
+  end
+
+  it "caps at two characters even with four words" do
+    expect(host.initials("a b c d")).to eq("AB")
+  end
+end

--- a/spec/components/roles/role_set_card_spec.rb
+++ b/spec/components/roles/role_set_card_spec.rb
@@ -5,19 +5,31 @@ require "rails_helper"
 RSpec.describe Components::Roles::RoleSetCard do
   let(:view_context) { ApplicationController.new.view_context }
 
-  let(:base_attrs) do
-    {
-      index: 0,
+  let(:context) do
+    Components::Roles::RoleFormContext.new(
       channels: [],
       role_options: [],
       channels_by_id: {},
       default_channel_id: nil,
       any_unassignable: false
-    }
+    )
   end
 
   context "when repost_path is given" do
-    subject(:html) { described_class.new(**base_attrs, repost_path: "/servers/123/role_sets/456/repost").render_in(view_context) }
+    let(:card_data) do
+      Components::Roles::RoleSetCardData.new(
+        index: 0,
+        set_id: nil,
+        name: "",
+        selection_mode: "single",
+        channel_override: nil,
+        selected_role_ids: [],
+        open: false,
+        repost_path: "/servers/123/role_sets/456/repost"
+      )
+    end
+
+    subject(:html) { described_class.new(data: card_data, context:).render_in(view_context) }
 
     it "renders a button with data-action role-sets#repost" do
       expect(html).to include('data-action="role-sets#repost"')
@@ -41,7 +53,9 @@ RSpec.describe Components::Roles::RoleSetCard do
   end
 
   context "when repost_path is nil (default)" do
-    subject(:html) { described_class.new(**base_attrs).render_in(view_context) }
+    let(:card_data) { Components::Roles::RoleSetCardData.empty }
+
+    subject(:html) { described_class.new(data: card_data, context:).render_in(view_context) }
 
     it "omits the repost button" do
       expect(html).not_to include('data-action="role-sets#repost"')

--- a/spec/operations/roles/configure_spec.rb
+++ b/spec/operations/roles/configure_spec.rb
@@ -330,4 +330,33 @@ RSpec.describe Ops::Roles::Configure do
       end
     end
   end
+
+  context "when a managed role is posted in role_ids" do
+    before do
+      create(:server_role, server_configuration: config, discord_id: 12, position: 3, managed: true)
+    end
+
+    let(:role_sets) do
+      [{name: "Pings", selection_mode: "multi", channel_override: "", role_ids: ["10", "12"]}]
+    end
+
+    it "rejects the managed role and keeps only the assignable one" do
+      result
+      expect(setting.role_sets.last.assignable_roles.map(&:role_id)).to contain_exactly(10)
+    end
+  end
+
+  context "when an above-bot role is posted in role_ids" do
+    let(:config) { create(:server_configuration, bot_role_position: 2) }
+    let!(:setting) { create(:role_setting, server_configuration: config, channel_id: nil) }
+
+    let(:role_sets) do
+      [{name: "Pings", selection_mode: "multi", channel_override: "", role_ids: ["10", "11"]}]
+    end
+
+    it "rejects the above-bot role and keeps only the assignable one" do
+      result
+      expect(setting.role_sets.last.assignable_roles.map(&:role_id)).to contain_exactly(10)
+    end
+  end
 end

--- a/spec/plugins/roles/assignable_server_roles_spec.rb
+++ b/spec/plugins/roles/assignable_server_roles_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Roles::AssignableServerRoles do
+  let(:config) { create(:server_configuration, discord_id: 900, bot_role_position: 5) }
+
+  before do
+    create(:server_role, server_configuration: config, discord_id: 900, name: "everyone", position: 0)
+    create(:server_role, server_configuration: config, discord_id: 10, name: "Member", position: 2)
+    create(:server_role, server_configuration: config, discord_id: 11, name: "Admin", position: 8)
+    create(:server_role, server_configuration: config, discord_id: 12, name: "Booster", position: 1, managed: true)
+  end
+
+  subject(:query) { described_class.new(config) }
+
+  describe "#candidates" do
+    it "excludes the @everyone role whose discord_id matches the guild" do
+      expect(query.candidates.map(&:name)).not_to include("everyone")
+    end
+
+    it "orders candidates highest position first" do
+      expect(query.candidates.map(&:name)).to eq(["Admin", "Member", "Booster"])
+    end
+  end
+
+  describe "#reason_for" do
+    let(:managed_role) { config.server_roles.find_by(discord_id: 12) }
+    let(:above_bot_role) { config.server_roles.find_by(discord_id: 11) }
+    let(:plain_role) { config.server_roles.find_by(discord_id: 10) }
+
+    it "returns :managed for a Discord-managed role" do
+      expect(query.reason_for(managed_role)).to eq(:managed)
+    end
+
+    it "returns :above_bot for a role at or above bot_role_position" do
+      expect(query.reason_for(above_bot_role)).to eq(:above_bot)
+    end
+
+    it "returns nil for a plain assignable role" do
+      expect(query.reason_for(plain_role)).to be_nil
+    end
+  end
+
+  describe "#assignable_ids" do
+    it "returns only discord_ids of assignable roles" do
+      expect(query.assignable_ids).to contain_exactly(10)
+    end
+  end
+
+  describe "#any_unassignable?" do
+    it "returns true when managed or above-bot candidates exist" do
+      expect(query.any_unassignable?).to be(true)
+    end
+
+    context "when no managed or above-bot candidates exist" do
+      let(:clean_config) { create(:server_configuration, discord_id: 800, bot_role_position: nil) }
+
+      before do
+        create(:server_role, server_configuration: clean_config, discord_id: 800, name: "everyone", position: 0)
+        create(:server_role, server_configuration: clean_config, discord_id: 20, name: "Member", position: 2)
+      end
+
+      subject(:clean_query) { described_class.new(clean_config) }
+
+      it "returns false" do
+        expect(clean_query.any_unassignable?).to be(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Three small SRP/cleanup items from the review backlog (`review-plans.md` §I1, §I5, plus the deferred forged-role-id hardening from the roles-config PR). One coherent, low-risk chunk.

## RoleSetCard constructor split (§I5)
`Components::Roles::RoleSetCard` took **13 keyword params**. Extracted two `Data.define` value objects:
- `Components::Roles::RoleSetCardData` — the 8 per-card fields (`index`, `set_id`, `name`, `selection_mode`, `channel_override`, `selected_role_ids`, `open`, `repost_path`) + an `.empty` factory for the "new set" template card.
- `Components::Roles::RoleFormContext` — the 5 fields shared across every card on a form (`channels`, `role_options`, `channels_by_id`, `default_channel_id`, `any_unassignable`), built once in `ConfigForm`.

Constructor is now `initialize(data:, context:)`.

## Assignable-role hardening + query extraction
The "which roles may a member self-assign" logic (exclude `@everyone`, Discord-managed roles, and roles ranked at/above the bot) lived only in the picker presenter. Extracted it into `Roles::AssignableServerRoles` (rule of two), now backing **both** `AssignableRoleOptions` (display) and `Ops::Roles::Configure` (write).

`Ops::Roles::Configure#valid_role_ids` previously accepted any role the server knew about, so a forged form submission could assign a managed or above-bot role that the UI had disabled. It now filters to the assignable set — the same classification at the display and write boundaries.

## initials dedup (§I1)
Three identical private `initials(name)` helpers (`AppShell`, `Views::Servers::Show`, `Views::Servers::Index`) collapsed into a `Components::Initials` mixin.

## Tests / gates
- New specs: `initials_spec`, `assignable_server_roles_spec` (incl. managed / above-bot / `@everyone` classification). Added forged-id rejection contexts to `configure_spec`.
- `rspec` 727/0, `standardrb`, `active_record_doctor`, `undercover --compare origin/main` all green. No new locale keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)