### PR TITLE
Extract dashboard query object and split ConfigPage constructor

### DIFF
--- a/app/bot/bot_config.rb
+++ b/app/bot/bot_config.rb
@@ -28,4 +28,8 @@ module BotConfig
   def shard_count
     [ENV.fetch("SHARD_COUNT", "1").to_i, 1].max
   end
+
+  def client_id
+    ENV["CLIENT_ID"]
+  end
 end

--- a/app/components/config_page.rb
+++ b/app/components/config_page.rb
@@ -3,14 +3,11 @@
 class Components::ConfigPage < Components::Base
   include Phlex::Rails::Helpers::FormWith
 
-  def initialize(icon:, title:, description:, server_configuration:, url:, gate: nil, badge: nil)
-    @icon = icon
-    @title = title
-    @description = description
+  def initialize(header:, server_configuration:, url:, gate: nil)
+    @header = header
     @server_configuration = server_configuration
     @url = url
     @gate = gate
-    @badge = badge
   end
 
   def view_template(&block)
@@ -19,7 +16,7 @@ class Components::ConfigPage < Components::Base
         [
           {label: t(".servers"), href: servers_path},
           {label: @server_configuration.name || t(".dashboard"), href: server_path(@server_configuration.discord_id)},
-          {label: @title}
+          {label: @header.title}
         ]
       )
       form_with(
@@ -48,21 +45,21 @@ class Components::ConfigPage < Components::Base
 
     render Components::EnableGate.new(
       enabled: @gate[:enabled],
-      title: t(".disabled_title", plugin: @title),
+      title: t(".disabled_title", plugin: @header.title),
       message: @gate[:message],
-      enable_label: t(".enable", plugin: @title)
+      enable_label: t(".enable", plugin: @header.title)
     ) { yield }
   end
 
   def header
     div(class: "mb-6 flex items-start gap-4") do
-      render Components::PluginTile.new(icon: @icon, size: :lg)
+      render Components::PluginTile.new(icon: @header.icon, size: :lg)
       div(class: "flex-1") do
         div(class: "flex flex-wrap items-center gap-3") do
-          h1(class: "font-display text-2xl font-bold tracking-tight") { @title }
-          render Components::Badge.new(variant: :copper) { @badge } if @badge
+          h1(class: "font-display text-2xl font-bold tracking-tight") { @header.title }
+          render Components::Badge.new(variant: :copper) { @header.badge } if @header.badge
         end
-        p(class: "mt-1 text-sm text-text-secondary") { @description }
+        p(class: "mt-1 text-sm text-text-secondary") { @header.description }
       end
       enable_control if gated?
     end
@@ -77,7 +74,7 @@ class Components::ConfigPage < Components::Base
       render Components::Toggle.new(
         name: @gate[:field],
         checked: @gate[:enabled],
-        label: t(".enable", plugin: @title),
+        label: t(".enable", plugin: @header.title),
         data: {enable_gate_target: "toggle", action: "change->enable-gate#update"}
       )
     end

--- a/app/components/config_page_header.rb
+++ b/app/components/config_page_header.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Components
+  ConfigPageHeader = Data.define(:icon, :title, :description, :badge) do
+    def initialize(icon:, title:, description:, badge: nil)
+      super
+    end
+  end
+end

--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -9,9 +9,9 @@ class ServersController < ApplicationController
   rescue_from Discord::UserGuilds::Unauthorized, with: :reauthenticate
 
   def index
-    manageable = manageable_guilds
+    manageable = ManageableGuilds.for(session[:discord_token])
     session.delete(:reauth_attempted)
-    configured = configured_ids(manageable)
+    configured = ServerConfiguration.configured_ids_among(manageable.map(&:id))
     remember_manageable_servers(configured)
     present, absent = manageable.partition { |guild| configured.include?(guild.id) }
 
@@ -37,43 +37,18 @@ class ServersController < ApplicationController
   private
 
   def load_dashboard
-    manageable = manageable_guilds
-    @guild = manageable.find { |guild| guild.id == params[:id].to_i }
-    @server_configuration = ServerConfiguration.find_by(discord_id: params[:id]) if @guild
-    return redirect_to(servers_path, alert: t("servers.not_found")) unless @guild && @server_configuration
-
-    configured = configured_ids(manageable)
-    remember_manageable_servers(configured)
-    @configured_guilds = manageable.select { |guild| configured.include?(guild.id) }
-    @plugin_counts = PluginActivation.enabled_counts_for(configured)
-  rescue Discord::UserGuilds::Unauthorized
-    raise
-  rescue Discord::UserGuilds::Error
-    raise unless load_dashboard_from_cache
-  end
-
-  def load_dashboard_from_cache
-    dashboard = CachedDashboard.for(
-      discord_id: params[:id].to_i,
-      manageable_ids: manageable_server_ids
+    result = ServerDashboard.resolve(
+      discord_token: session[:discord_token],
+      target_id: params[:id].to_i,
+      cached_ids: manageable_server_ids
     )
-    return false unless dashboard
+    return redirect_to(servers_path, alert: t("servers.not_found")) unless result
 
-    @server_configuration = dashboard.server_configuration
-    @guild = dashboard.guild
-    @configured_guilds = dashboard.configured_guilds
-    @plugin_counts = dashboard.plugin_counts
-    true
-  end
-
-  def manageable_guilds
-    Discord::UserGuilds.call(session[:discord_token])
-      .select(&:manageable?)
-      .sort_by { |guild| -guild.member_count.to_i }
-  end
-
-  def configured_ids(guilds)
-    ServerConfiguration.where(discord_id: guilds.map(&:id)).pluck(:discord_id)
+    remember_manageable_servers(result.configured_ids)
+    @guild = result.guild
+    @server_configuration = result.server_configuration
+    @configured_guilds = result.configured_guilds
+    @plugin_counts = result.plugin_counts
   end
 
   def reauthenticate

--- a/app/models/server_configuration.rb
+++ b/app/models/server_configuration.rb
@@ -13,6 +13,10 @@ class ServerConfiguration < ApplicationRecord
 
   validates :discord_id, presence: true, uniqueness: true
 
+  def self.configured_ids_among(discord_ids)
+    where(discord_id: discord_ids).pluck(:discord_id)
+  end
+
   def icon_url
     Discord::CdnUrl.guild_icon(discord_id, icon_hash)
   end

--- a/app/presenters/manageable_guilds.rb
+++ b/app/presenters/manageable_guilds.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ManageableGuilds
+  def self.for(discord_token)
+    Discord::UserGuilds.call(discord_token)
+      .select(&:manageable?)
+      .sort_by { |guild| -guild.member_count.to_i }
+  end
+end

--- a/app/presenters/server_dashboard.rb
+++ b/app/presenters/server_dashboard.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class ServerDashboard
+  Result = Data.define(:guild, :server_configuration, :configured_guilds, :plugin_counts, :configured_ids)
+
+  def self.resolve(discord_token:, target_id:, cached_ids:)
+    new(discord_token:, target_id:, cached_ids:).resolve
+  end
+
+  def initialize(discord_token:, target_id:, cached_ids:)
+    @discord_token = discord_token
+    @target_id = target_id
+    @cached_ids = cached_ids
+  end
+
+  def resolve
+    live
+  rescue Discord::UserGuilds::Unauthorized
+    raise
+  rescue Discord::UserGuilds::Error
+    cached || raise
+  end
+
+  private
+
+  def live
+    manageable = ManageableGuilds.for(@discord_token)
+    guild = manageable.find { |candidate| candidate.id == @target_id }
+    config = ServerConfiguration.find_by(discord_id: @target_id) if guild
+    return unless guild && config
+
+    ids = ServerConfiguration.configured_ids_among(manageable.map(&:id))
+    Result.new(
+      guild:,
+      server_configuration: config,
+      configured_guilds: manageable.select { |candidate| ids.include?(candidate.id) },
+      plugin_counts: PluginActivation.enabled_counts_for(ids),
+      configured_ids: ids
+    )
+  end
+
+  def cached
+    dashboard = CachedDashboard.for(discord_id: @target_id, manageable_ids: @cached_ids)
+    return unless dashboard
+
+    Result.new(
+      guild: dashboard.guild,
+      server_configuration: dashboard.server_configuration,
+      configured_guilds: dashboard.configured_guilds,
+      plugin_counts: dashboard.plugin_counts,
+      configured_ids: @cached_ids
+    )
+  end
+end

--- a/app/views/servers/index.rb
+++ b/app/views/servers/index.rb
@@ -116,7 +116,7 @@ class Views::Servers::Index < Views::Base
   end
 
   def generic_invite_url
-    "https://discord.com/oauth2/authorize?client_id=#{ENV["CLIENT_ID"]}&scope=bot+applications.commands"
+    "https://discord.com/oauth2/authorize?client_id=#{BotConfig.client_id}&scope=bot+applications.commands"
   end
 
   def invite_url(guild)

--- a/app/views/servers/logging/show.rb
+++ b/app/views/servers/logging/show.rb
@@ -10,9 +10,11 @@ class Views::Servers::Logging::Show < Views::Base
   def view_template
     render Components::PluginShell.new(user: @user, server_configuration: @config, active_key: :logging) do
       render Components::ConfigPage.new(
-        icon: "scroll",
-        title: t(".title"),
-        description: t(".description"),
+        header: Components::ConfigPageHeader.new(
+          icon: "scroll",
+          title: t(".title"),
+          description: t(".description")
+        ),
         server_configuration: @config,
         url: server_logging_path(@config.discord_id),
         gate: {

--- a/app/views/servers/reminders/show.rb
+++ b/app/views/servers/reminders/show.rb
@@ -9,12 +9,14 @@ class Views::Servers::Reminders::Show < Views::Base
   def view_template
     render Components::PluginShell.new(user: @user, server_configuration: @config, active_key: :reminders) do
       render Components::ConfigPage.new(
-        icon: "bell-ringing",
-        title: t(".title"),
-        description: t(".description"),
+        header: Components::ConfigPageHeader.new(
+          icon: "bell-ringing",
+          title: t(".title"),
+          description: t(".description"),
+          badge: t(".badge")
+        ),
         server_configuration: @config,
-        url: server_reminders_path(@config.discord_id),
-        badge: t(".badge")
+        url: server_reminders_path(@config.discord_id)
       ) do
         render Components::Reminders::ConfigForm.new(server_configuration: @config)
       end

--- a/app/views/servers/roles/show.rb
+++ b/app/views/servers/roles/show.rb
@@ -10,9 +10,11 @@ class Views::Servers::Roles::Show < Views::Base
   def view_template
     render Components::PluginShell.new(user: @user, server_configuration: @config, active_key: :roles) do
       render Components::ConfigPage.new(
-        icon: "users-three",
-        title: t(".title"),
-        description: t(".description"),
+        header: Components::ConfigPageHeader.new(
+          icon: "users-three",
+          title: t(".title"),
+          description: t(".description")
+        ),
         server_configuration: @config,
         url: server_roles_path(@config.discord_id),
         gate: {

--- a/app/views/servers/welcomes/show.rb
+++ b/app/views/servers/welcomes/show.rb
@@ -10,9 +10,11 @@ class Views::Servers::Welcomes::Show < Views::Base
   def view_template
     render Components::PluginShell.new(user: @user, server_configuration: @config, active_key: :welcomes) do
       render Components::ConfigPage.new(
-        icon: "hand-waving",
-        title: t(".title"),
-        description: t(".description"),
+        header: Components::ConfigPageHeader.new(
+          icon: "hand-waving",
+          title: t(".title"),
+          description: t(".description")
+        ),
         server_configuration: @config,
         url: server_welcomes_path(@config.discord_id),
         gate: {

--- a/spec/components/config_page_spec.rb
+++ b/spec/components/config_page_spec.rb
@@ -7,9 +7,11 @@ RSpec.describe Components::ConfigPage do
 
   subject(:html) do
     described_class.new(
-      icon: "bell",
-      title: "Reminders",
-      description: "Manage reminders.",
+      header: Components::ConfigPageHeader.new(
+        icon: "bell",
+        title: "Reminders",
+        description: "Manage reminders."
+      ),
       server_configuration: config,
       url: "/servers/900000001/reminders"
     ).render_in(view_context) { "" }

--- a/spec/models/server_configuration_spec.rb
+++ b/spec/models/server_configuration_spec.rb
@@ -46,6 +46,21 @@ RSpec.describe ServerConfiguration do
     end
   end
 
+  describe ".configured_ids_among" do
+    subject(:ids) { described_class.configured_ids_among(discord_ids) }
+
+    let!(:config_a) { create(:server_configuration, discord_id: 111_111_111) }
+    let!(:config_b) { create(:server_configuration, discord_id: 222_222_222) }
+
+    context "with a mix of present and absent discord_ids" do
+      let(:discord_ids) { [111_111_111, 999_999_999] }
+
+      it "returns only the discord_ids present in the database" do
+        expect(ids).to contain_exactly(111_111_111)
+      end
+    end
+  end
+
   describe "#icon_url" do
     subject(:icon_url) { server.icon_url }
 

--- a/spec/operations/roles/configure_spec.rb
+++ b/spec/operations/roles/configure_spec.rb
@@ -107,10 +107,16 @@ RSpec.describe Ops::Roles::Configure do
       expect(setting.role_sets).to be_empty
     end
 
-    it "won't touch a set id that belongs to another server" do
-      other = create(:role_set, name: "Theirs")
-      described_class.call(server_configuration: config, channel_id:, enabled: "0", role_sets: [{id: other.id, name: "Hijacked", selection_mode: "multi", role_ids: []}])
-      expect(other.reload.name).to eq("Theirs")
+    context "with a set id that belongs to another server" do
+      let!(:other) { create(:role_set, name: "Theirs") }
+      let(:role_sets) do
+        [{id: other.id, name: "Hijacked", selection_mode: "multi", role_ids: []}]
+      end
+
+      it "leaves the other server's set untouched" do
+        result
+        expect(other.reload.name).to eq("Theirs")
+      end
     end
   end
 

--- a/spec/presenters/manageable_guilds_spec.rb
+++ b/spec/presenters/manageable_guilds_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ManageableGuilds do
+  describe ".for" do
+    subject(:guilds) { described_class.for("tok") }
+
+    let(:manageable_guild) do
+      instance_double("Discord::Guild", manageable?: true, member_count: 50, id: 1)
+    end
+    let(:unmanageable_guild) do
+      instance_double("Discord::Guild", manageable?: false, member_count: 200, id: 2)
+    end
+    let(:large_manageable_guild) do
+      instance_double("Discord::Guild", manageable?: true, member_count: 500, id: 3)
+    end
+
+    before do
+      allow(Discord::UserGuilds).to receive(:call).with("tok").and_return(
+        [manageable_guild, unmanageable_guild, large_manageable_guild]
+      )
+    end
+
+    it "returns only manageable guilds" do
+      expect(guilds).to contain_exactly(manageable_guild, large_manageable_guild)
+    end
+
+    it "sorts by member_count descending" do
+      expect(guilds.map(&:id)).to eq([3, 1])
+    end
+  end
+end

--- a/spec/presenters/server_dashboard_spec.rb
+++ b/spec/presenters/server_dashboard_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ServerDashboard do
+  let(:target_id) { 900_000_001 }
+  let(:other_id) { 900_000_002 }
+  let(:cached_ids) { [] }
+
+  let(:target_guild) do
+    instance_double("Discord::Guild", id: target_id, manageable?: true, member_count: 100)
+  end
+  let(:other_guild) do
+    instance_double("Discord::Guild", id: other_id, manageable?: true, member_count: 50)
+  end
+
+  subject(:result) do
+    described_class.new(
+      discord_token: "tok",
+      target_id:,
+      cached_ids:
+    ).resolve
+  end
+
+  context "when Discord is reachable and the target guild is manageable" do
+    let!(:config) { create(:server_configuration, discord_id: target_id) }
+    let!(:other_config) { create(:server_configuration, discord_id: other_id) }
+
+    before do
+      allow(Discord::UserGuilds).to receive(:call).with("tok").and_return([target_guild, other_guild])
+    end
+
+    it "returns a Result with the correct guild" do
+      expect(result.guild).to eq(target_guild)
+    end
+
+    it "returns a Result with the correct server_configuration" do
+      expect(result.server_configuration).to eq(config)
+    end
+
+    it "returns configured_guilds containing both manageable configured guilds" do
+      expect(result.configured_guilds).to contain_exactly(target_guild, other_guild)
+    end
+
+    it "returns configured_ids for all configured manageable guilds" do
+      expect(result.configured_ids).to contain_exactly(target_id, other_id)
+    end
+  end
+
+  context "when target guild is not among manageable guilds" do
+    let!(:config) { create(:server_configuration, discord_id: target_id) }
+    let(:other_guild_only) do
+      instance_double("Discord::Guild", id: other_id, manageable?: true, member_count: 50)
+    end
+
+    before do
+      allow(Discord::UserGuilds).to receive(:call).with("tok").and_return([other_guild_only])
+    end
+
+    it "returns nil" do
+      expect(result).to be_nil
+    end
+  end
+
+  context "when Discord::UserGuilds::Unauthorized is raised" do
+    before do
+      allow(Discord::UserGuilds).to receive(:call).and_raise(Discord::UserGuilds::Unauthorized, "token rejected")
+    end
+
+    it "propagates the error" do
+      expect { result }.to raise_error(Discord::UserGuilds::Unauthorized)
+    end
+  end
+
+  context "when Discord::UserGuilds::Error is raised and cache hits" do
+    let(:cached_ids) { [target_id, other_id] }
+    let!(:target_config) { create(:server_configuration, discord_id: target_id, name: "Dev Refuge", member_count: 100) }
+    let!(:other_config) { create(:server_configuration, discord_id: other_id, name: "Other Server", member_count: 50) }
+
+    before do
+      allow(Discord::UserGuilds).to receive(:call).and_raise(Discord::UserGuilds::Error, "timeout")
+    end
+
+    it "returns a Result from the cache" do
+      expect(result).to be_a(ServerDashboard::Result)
+    end
+
+    it "returns the correct server_configuration from cache" do
+      expect(result.server_configuration).to eq(target_config)
+    end
+
+    it "returns configured_ids from the cached_ids" do
+      expect(result.configured_ids).to eq(cached_ids)
+    end
+  end
+
+  context "when Discord::UserGuilds::Error is raised and cache misses" do
+    let(:cached_ids) { [] }
+
+    before do
+      allow(Discord::UserGuilds).to receive(:call).and_raise(Discord::UserGuilds::Error, "timeout")
+    end
+
+    it "re-raises the error" do
+      expect { result }.to raise_error(Discord::UserGuilds::Error)
+    end
+  end
+end


### PR DESCRIPTION
Web-layer SRP cleanup from the review backlog (`review-plans.md` §I3, §I4, §I7 + the §I6 spec-structure fix). One coherent, low-risk chunk.

## Dashboard query object (§I3)
`ServersController#load_dashboard` mixed four concerns: live guild resolution, authorization (is this guild manageable by the user?), sidebar-data assembly, and the Discord-API-failure cache fallback. Extracted:
- **`ServerDashboard`** — owns both the live and cache-fallback paths, returns a `Result` value object. `Unauthorized` propagates (→ `reauthenticate`); a non-auth `Error` falls back to `CachedDashboard`, re-raising on a cache miss (→ `render_error`) — same behaviour as before, now in one place.
- **`ManageableGuilds.for`** — the live "fetch → filter manageable → sort" call, previously duplicated; now shared by `ServerDashboard` and the `index` action.
- **`ServerConfiguration.configured_ids_among`** — the configured-id lookup, likewise shared.

The controller is left with resolve-authorize-assign; `load_dashboard_from_cache`, `manageable_guilds`, and `configured_ids` are gone.

## ConfigPage constructor split (§I4)
`Components::ConfigPage` took **7** keyword params. Grouped the four header-presentation attrs (`icon`, `title`, `description`, `badge`) into a `Components::ConfigPageHeader` value object → **4** params. All four config `show` views updated.

## Config sourcing (§I7)
`Views::Servers::Index#generic_invite_url` read `ENV["CLIENT_ID"]` inline; moved the read to `BotConfig.client_id` alongside the other bot config. (Note: `config/initializers/omniauth.rb` uses a separate `DISCORD_CLIENT_ID` var — left untouched.)

## Spec structure (§I6)
The roles `configure_spec` "belongs to another server" example did inline `create` + `described_class.call` inside the `it`; restructured to a `context` using the named `subject` + `let`s.

## Tests / gates
- New unit specs: `server_dashboard_spec` (live / not-found / unauthorized-propagates / cache-hit / cache-miss), `manageable_guilds_spec`. Discord seam mocked via `instance_double("Discord::Guild", …)`.
- `rspec` 740/0, `standardrb`, `active_record_doctor`, `undercover --compare origin/main` all green. No new locale keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)