### PR TITLE
Link the onboarding DM to the guild's web dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,12 @@ SHARD_COUNT=1
 DISCORD_CLIENT_ID=
 DISCORD_CLIENT_SECRET=
 
+# --- Web ---
+# Public origin of the web dashboard (no trailing path), e.g. https://shrkbot.gg
+# The bot uses it to link owners to their dashboard in the onboarding DM.
+# Leave blank to omit the link (the DM still sends).
+WEB_BASE_URL=
+
 # --- Infrastructure ---
 # Running the app on your host (asdf) with Postgres in Docker: reach it at the
 # published host port — docker-compose maps host 5678 -> container 5432.

--- a/app/bot/bot_config.rb
+++ b/app/bot/bot_config.rb
@@ -32,4 +32,8 @@ module BotConfig
   def client_id
     ENV["CLIENT_ID"]
   end
+
+  def web_base_url
+    ENV["WEB_BASE_URL"]
+  end
 end

--- a/app/bot/server_onboarder.rb
+++ b/app/bot/server_onboarder.rb
@@ -1,20 +1,43 @@
 # frozen_string_literal: true
 
 module ServerOnboarder
-  WELCOME_MESSAGE = <<~MSG.strip
-    👋 Thanks for adding shrkbot!
-
-    shrkbot is configured through a web dashboard — setup details are on the way.
-  MSG
-
   module_function
 
   def notify(bot, server, config)
     return if config.onboarded_at?
 
-    bot.pm_channel(server.owner.id).send_message(WELCOME_MESSAGE)
+    bot.pm_channel(server.owner.id).send_message(message(server))
     config.update!(onboarded_at: Time.current)
   rescue => e
     Rails.logger.error("[ServerOnboarder] could not onboard server #{server.id}: #{e.class}: #{e.message}")
+  end
+
+  def message(server)
+    url = dashboard_url(server)
+    return message_without_link(server) if url.nil?
+
+    <<~MSG.strip
+      👋 Thanks for adding shrkbot!
+
+      shrkbot is configured through the web dashboard. Set up #{server.name} here:
+      #{url}
+
+      Sign in with Discord to enable plugins and manage settings.
+    MSG
+  end
+
+  def message_without_link(server)
+    <<~MSG.strip
+      👋 Thanks for adding shrkbot!
+
+      shrkbot is configured through the web dashboard. Sign in with Discord there to set up #{server.name} — enable plugins and manage settings.
+    MSG
+  end
+
+  def dashboard_url(server)
+    base = BotConfig.web_base_url
+    return if base.blank?
+
+    "#{base.chomp("/")}/servers/#{server.id}"
   end
 end

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -268,8 +268,8 @@ shared sync path, it fires from both triggers — so every server is onboarded e
 once, including servers that were already present when the rewrite first goes live
 (the `:ready` sweep). The `onboarded_at` stamp is what keeps it once-per-server rather
 than once-per-boot, and a send failure (owner blocks DMs) is swallowed and left
-un-stamped so a later boot retries. The welcome copy is a placeholder until the config
-website ships, when it gains the real setup link.
+un-stamped so a later boot retries. The DM links the owner to `WEB_BASE_URL/servers/:discord_id`
+(their guild's dashboard); the link is omitted when `WEB_BASE_URL` is unset.
 
 ## Roles self-assignment
 

--- a/spec/bot/bot_config_spec.rb
+++ b/spec/bot/bot_config_spec.rb
@@ -30,6 +30,12 @@ RSpec.describe BotConfig do
     end
   end
 
+  describe ".web_base_url" do
+    it "reads WEB_BASE_URL from the environment" do
+      with_env("WEB_BASE_URL", "https://shrkbot.gg") { expect(described_class.web_base_url).to eq("https://shrkbot.gg") }
+    end
+  end
+
   describe ".rest_token" do
     subject(:rest_token) { described_class.rest_token }
 

--- a/spec/bot/server_onboarder_spec.rb
+++ b/spec/bot/server_onboarder_spec.rb
@@ -7,14 +7,52 @@ RSpec.describe ServerOnboarder do
 
   let(:config) { create(:server_configuration) }
   let(:owner) { double("owner", id: 999) }
-  let(:server) { double("server", id: 77, owner:) }
+  let(:server) { double("server", id: 77, name: "Dev Refuge", owner:) }
   let(:pm_channel) { double("pm_channel", send_message: nil) }
   let(:bot) { double("bot", pm_channel:) }
 
-  context "when the server has not been onboarded" do
-    it "DMs the guild owner the welcome message" do
+  context "when the server has not been onboarded and WEB_BASE_URL is set" do
+    before do
+      allow(BotConfig).to receive(:web_base_url).and_return("https://shrkbot.gg")
+    end
+
+    it "DMs the guild owner" do
       expect(bot).to receive(:pm_channel).with(999).and_return(pm_channel)
-      expect(pm_channel).to receive(:send_message).with(described_class::WELCOME_MESSAGE)
+      notify
+    end
+
+    it "includes the deep dashboard link in the message" do
+      expect(pm_channel).to receive(:send_message).with(include("https://shrkbot.gg/servers/77"))
+      notify
+    end
+
+    it "includes the server name in the message" do
+      expect(pm_channel).to receive(:send_message).with(include("Dev Refuge"))
+      notify
+    end
+
+    it "records when the server was onboarded" do
+      expect { notify }.to change { config.reload.onboarded_at }.from(nil)
+    end
+  end
+
+  context "when the server has not been onboarded and WEB_BASE_URL is unset" do
+    before do
+      allow(BotConfig).to receive(:web_base_url).and_return(nil)
+    end
+
+    it "DMs the guild owner" do
+      expect(bot).to receive(:pm_channel).with(999).and_return(pm_channel)
+      notify
+    end
+
+    it "does not include an http link in the message" do
+      expect(pm_channel).to receive(:send_message).with(satisfy { |m| !m.include?("http") })
+      notify
+    end
+
+    it "includes the server name in the message" do
+      expect(pm_channel).to receive(:send_message).with(include("Dev Refuge"))
       notify
     end
 
@@ -25,6 +63,7 @@ RSpec.describe ServerOnboarder do
 
   context "when the server has already been onboarded" do
     before do
+      allow(BotConfig).to receive(:web_base_url).and_return("https://shrkbot.gg")
       config.update!(onboarded_at: 1.day.ago)
     end
 
@@ -40,6 +79,7 @@ RSpec.describe ServerOnboarder do
 
   context "when the owner cannot be DMed" do
     before do
+      allow(BotConfig).to receive(:web_base_url).and_return("https://shrkbot.gg")
       allow(bot).to receive(:pm_channel).and_raise(StandardError, "Cannot send messages to this user")
     end
 


### PR DESCRIPTION
Finishes the H4 onboarding flow — the one remaining gap after the settings-always-exist invariant, `default_enabled` removal, and offline-join onboarding all shipped. `ServerOnboarder` previously DMed a static "setup details are on the way" placeholder; it now links the owner to their dashboard.

## What changed
- **`BotConfig.web_base_url`** — reads a new `WEB_BASE_URL` env var (the web dashboard's public origin).
- **`ServerOnboarder`** — builds a per-guild message deep-linking to `WEB_BASE_URL/servers/<discord_id>` (the guild's dashboard). Trailing slash on the base is chomped. When `WEB_BASE_URL` is blank/unset the DM still sends, just without the link. The `onboarded_at` once-per-server guard and swallow-on-DM-failure behaviour are unchanged.
- **Config/docs** — `WEB_BASE_URL` added to `.env.example` (with a note it's optional and the DM degrades gracefully); the onboarding section of `docs/architecture.md` updated to describe the link.

The DM fires from both the live `server_create` join and the `:ready` backfill sweep (unchanged), so guilds joined while the bot was offline get the linked DM once on next boot.

## Tests / gates
- `server_onboarder_spec` covers both the with-link and no-link (unset base URL) paths plus the existing guard/error contexts; `bot_config_spec` covers the new reader.
- `rspec` 747/0, `standardrb`, `active_record_doctor`, `undercover --compare origin/main` all green.

## Deployment note
Set `WEB_BASE_URL` (e.g. `https://shrkbot.gg`) on the **bot** process in prod for the link to appear. Without it, onboarding DMs send link-less — no breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)