### PR TITLE
Publish role-menu events after Ops::Roles::Configure commits

### DIFF
--- a/app/operations/roles/configure.rb
+++ b/app/operations/roles/configure.rb
@@ -5,6 +5,8 @@ module Ops
     class Configure < ApplicationOperation
       include Ops::PluginConfiguration
 
+      self.transactional = false
+
       receives :server_configuration, :channel_id, :enabled, :role_sets
 
       def call
@@ -15,7 +17,7 @@ module Ops
 
         return failure(messages(setting, activation), value: activation) unless setting.valid? && activation.valid?
 
-        ActiveRecord::Base.transaction do
+        transaction do
           setting.save!
           reconcile_sets(setting)
           activation.save!


### PR DESCRIPTION
Backlog item **C4** (transaction-by-default was already in `ApplicationOperation`; this fixes the one op that fought it).

`ApplicationOperation#execute` wraps `#call` in a transaction by default. `Ops::Roles::Configure` never opted out, yet also manually wrapped its writes — double-wrapped. More importantly, `plan.publish` (which fires the ConfigBus events telling the bot to post/edit the Discord role menus) ran **inside** that transaction, i.e. before the real commit. A commit failure after publish would leave the bot acting on role sets that rolled back.

Fix: `self.transactional = false` so Configure's own `transaction do` is the sole wrapper, and `plan.publish` runs strictly **after** commit. Mirrors the existing `Ops::ServerConfiguration::Ensure` pattern.

Considered `ActiveRecord.after_all_transactions_commit` (keep it fully transactional, defer publish via the hook) — rejected because it never fires under RSpec transactional fixtures, which would break the ~20 `ConfigBus` assertions in `configure_spec` with no post-commit test pattern in the repo. Configure is a top-level web-request op (never composed inside another transaction), so the opt-out gives correct post-commit publish in production while keeping the suite green.

## Gates
rspec 747/0, standardrb, active_record_doctor, undercover no-missing — all green. Behaviour unchanged under transactional fixtures (Configure's transaction is a savepoint there, so publish stays synchronous and the existing assertions hold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)