### PR TITLE
Use do…end for single-line before hooks in specs

### DIFF
--- a/spec/bot/activity_log_spec.rb
+++ b/spec/bot/activity_log_spec.rb
@@ -42,7 +42,9 @@ RSpec.describe ActivityLog do
     let(:event) { :role_lost }
     let(:options) { {actor: "<@42>", roles: ["Artist"]} }
 
-    before { server_config.logging_setting.update!(enabled_actions: {"roles.role_lost" => true}) }
+    before do
+      server_config.logging_setting.update!(enabled_actions: {"roles.role_lost" => true})
+    end
 
     it "renders that event's own line" do
       expect(channel).to receive(:send_message).with("<@42> lost Artist.")
@@ -51,7 +53,9 @@ RSpec.describe ActivityLog do
   end
 
   context "when the logging plugin is disabled" do
-    before { PluginActivation.update_all(enabled: false) }
+    before do
+      PluginActivation.update_all(enabled: false)
+    end
 
     it "writes nothing" do
       expect(channel).not_to receive(:send_message)
@@ -60,7 +64,9 @@ RSpec.describe ActivityLog do
   end
 
   context "when this event's toggle is off" do
-    before { server_config.logging_setting.update!(enabled_actions: {"roles.role_lost" => true}) }
+    before do
+      server_config.logging_setting.update!(enabled_actions: {"roles.role_lost" => true})
+    end
 
     it "writes nothing" do
       expect(channel).not_to receive(:send_message)
@@ -69,7 +75,9 @@ RSpec.describe ActivityLog do
   end
 
   context "when no logging channel is set" do
-    before { server_config.logging_setting.update!(channel_id: nil) }
+    before do
+      server_config.logging_setting.update!(channel_id: nil)
+    end
 
     it "writes nothing" do
       expect(channel).not_to receive(:send_message)
@@ -78,7 +86,9 @@ RSpec.describe ActivityLog do
   end
 
   context "when the logging channel no longer exists" do
-    before { allow(bot).to receive(:channel).with(555).and_return(nil) }
+    before do
+      allow(bot).to receive(:channel).with(555).and_return(nil)
+    end
 
     it "writes nothing and doesn't raise" do
       expect { record }.not_to raise_error
@@ -86,7 +96,9 @@ RSpec.describe ActivityLog do
   end
 
   context "when the channel send fails" do
-    before { allow(channel).to receive(:send_message).and_raise("403 missing access") }
+    before do
+      allow(channel).to receive(:send_message).and_raise("403 missing access")
+    end
 
     it "swallows the error so the user's action is unaffected" do
       expect { record }.not_to raise_error
@@ -96,7 +108,9 @@ RSpec.describe ActivityLog do
   context "for an unregistered event" do
     let(:event) { :not_a_real_event }
 
-    before { server_config.logging_setting.update!(enabled_actions: {"roles.not_a_real_event" => true}) }
+    before do
+      server_config.logging_setting.update!(enabled_actions: {"roles.not_a_real_event" => true})
+    end
 
     it "raises so the wiring mistake surfaces" do
       expect { record }.to raise_error(I18n::MissingTranslationData)

--- a/spec/bot/config_bus_spec.rb
+++ b/spec/bot/config_bus_spec.rb
@@ -65,7 +65,9 @@ RSpec.describe ConfigBus do
     context "when BotConfig.redis_url is nil" do
       let(:set) { create(:role_set) }
 
-      before { allow(BotConfig).to receive(:redis_url).and_return(nil) }
+      before do
+        allow(BotConfig).to receive(:redis_url).and_return(nil)
+      end
 
       it "does not instantiate Redis" do
         described_class.post_roles(set)

--- a/spec/bot/guild_metadata_spec.rb
+++ b/spec/bot/guild_metadata_spec.rb
@@ -40,7 +40,9 @@ RSpec.describe GuildMetadata do
     let(:bot) { double("bot", profile: double("profile", id: 99)) }
     let(:server) { double("server") }
 
-    before { allow(server).to receive(:member).with(99).and_return(member) }
+    before do
+      allow(server).to receive(:member).with(99).and_return(member)
+    end
 
     context "when the bot has roles above @everyone" do
       let(:member) { double("member", roles: [double("role", position: 2), double("role", position: 5)]) }

--- a/spec/components/logging/config_form_spec.rb
+++ b/spec/components/logging/config_form_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe Components::Logging::ConfigForm do
   let(:view_context) { ApplicationController.new.view_context }
   let(:config) { create(:server_configuration) }
 
-  before { create(:logging_setting, server_configuration: config) }
+  before do
+    create(:logging_setting, server_configuration: config)
+  end
 
   it "renders the channel card with the required marker" do
     expect(html).to include("This setting is required to enable the plugin")

--- a/spec/components/roles/config_form_spec.rb
+++ b/spec/components/roles/config_form_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe Components::Roles::ConfigForm do
   let(:view_context) { ApplicationController.new.view_context }
   let(:config) { create(:server_configuration) }
 
-  before { create(:role_setting, server_configuration: config) }
+  before do
+    create(:role_setting, server_configuration: config)
+  end
 
   it "renders the default channel card without a required marker" do
     expect(html).not_to include("This setting is required to enable the plugin")

--- a/spec/components/welcomes/config_form_spec.rb
+++ b/spec/components/welcomes/config_form_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe Components::Welcomes::ConfigForm do
   let(:view_context) { ApplicationController.new.view_context }
   let(:config) { create(:server_configuration) }
 
-  before { config.create_welcome_settings! }
+  before do
+    config.create_welcome_settings!
+  end
 
   it "renders the channel card with the required marker" do
     expect(html).to include("This setting is required to enable the plugin")

--- a/spec/operations/roles/configure_spec.rb
+++ b/spec/operations/roles/configure_spec.rb
@@ -65,7 +65,9 @@ RSpec.describe Ops::Roles::Configure do
   context "with an existing set" do
     let!(:existing) { create(:role_set, role_setting: setting, name: "Old", selection_mode: "single") }
 
-    before { create(:assignable_role, role_set: existing, role_id: 10) }
+    before do
+      create(:assignable_role, role_set: existing, role_id: 10)
+    end
 
     let(:role_sets) do
       [{id: existing.id, name: "New", selection_mode: "multi", channel_override: "777", role_ids: ["11"]}]
@@ -165,7 +167,9 @@ RSpec.describe Ops::Roles::Configure do
       let!(:existing) { create(:role_set, role_setting: setting, message_id: 111, channel_override: nil) }
       let(:role_sets) { [{id: existing.id, name: existing.name, selection_mode: existing.selection_mode, channel_override: "", role_ids: []}] }
 
-      before { setting.update!(channel_id: 555) }
+      before do
+        setting.update!(channel_id: 555)
+      end
 
       it "publishes a post event (bot edits in place)" do
         result
@@ -211,7 +215,9 @@ RSpec.describe Ops::Roles::Configure do
         ]
       end
 
-      before { setting.update!(channel_id: 555) }
+      before do
+        setting.update!(channel_id: 555)
+      end
 
       it "publishes remove_roles_menu for each set" do
         result
@@ -263,7 +269,9 @@ RSpec.describe Ops::Roles::Configure do
       let!(:existing) { create(:role_set, role_setting: setting, message_id: 111, channel_override: nil) }
       let(:role_sets) { [] }
 
-      before { setting.update!(channel_id: 555) }
+      before do
+        setting.update!(channel_id: 555)
+      end
 
       it "publishes a delete event for the destroyed set" do
         result
@@ -293,7 +301,9 @@ RSpec.describe Ops::Roles::Configure do
       let(:channel_id) { "555" }
       let(:role_sets) { [{id: existing.id, name: existing.name, selection_mode: existing.selection_mode, channel_override: "", role_ids: []}] }
 
-      before { setting.update!(channel_id: 555) }
+      before do
+        setting.update!(channel_id: 555)
+      end
 
       it "does NOT produce a delete (channel unchanged)" do
         result

--- a/spec/operations/roles/messages/delete_spec.rb
+++ b/spec/operations/roles/messages/delete_spec.rb
@@ -27,7 +27,9 @@ RSpec.describe Ops::Roles::Messages::Delete do
   end
 
   context "when the channel cannot be resolved" do
-    before { allow(bot).to receive(:channel).with(111).and_return(nil) }
+    before do
+      allow(bot).to receive(:channel).with(111).and_return(nil)
+    end
 
     it "succeeds without raising" do
       expect { result }.not_to raise_error

--- a/spec/operations/server_configuration/plugins/toggle_spec.rb
+++ b/spec/operations/server_configuration/plugins/toggle_spec.rb
@@ -13,7 +13,9 @@ RSpec.describe Ops::ServerConfiguration::Plugins::Toggle do
   context "with a raw checkbox value (form param, not yet cast)" do
     let(:plugin) { roles }
 
-    before { server.create_role_setting!(channel_id: 777) }
+    before do
+      server.create_role_setting!(channel_id: 777)
+    end
 
     context "when checked" do
       let(:enabled) { "1" }

--- a/spec/plugins/roles/events/menu_reconcile_spec.rb
+++ b/spec/plugins/roles/events/menu_reconcile_spec.rb
@@ -43,7 +43,9 @@ RSpec.describe Roles::MenuReconcile do
   end
 
   context "when the roles plugin is disabled and the set has a message_id" do
-    before { activation.update!(enabled: false) }
+    before do
+      activation.update!(enabled: false)
+    end
 
     let!(:set) { create(:role_set, role_setting: setting, message_id: 777) }
 
@@ -59,7 +61,9 @@ RSpec.describe Roles::MenuReconcile do
   end
 
   context "when the roles plugin is disabled but the set has no message_id" do
-    before { activation.update!(enabled: false) }
+    before do
+      activation.update!(enabled: false)
+    end
 
     let!(:set) { create(:role_set, role_setting: setting, message_id: nil) }
 
@@ -70,7 +74,9 @@ RSpec.describe Roles::MenuReconcile do
   end
 
   context "when the guild is not in bot.servers" do
-    before { allow(bot).to receive(:servers).and_return({}) }
+    before do
+      allow(bot).to receive(:servers).and_return({})
+    end
 
     let!(:set) { create(:role_set, role_setting: setting, message_id: nil) }
 

--- a/spec/plugins/roles/menu_sync_plan_spec.rb
+++ b/spec/plugins/roles/menu_sync_plan_spec.rb
@@ -50,7 +50,9 @@ RSpec.describe Roles::MenuSyncPlan do
     end
 
     context "when channel_id is nil" do
-      before { plan.delete(channel_id: nil, message_id: 456) }
+      before do
+        plan.delete(channel_id: nil, message_id: 456)
+      end
 
       it "skips the delete" do
         plan.publish
@@ -59,7 +61,9 @@ RSpec.describe Roles::MenuSyncPlan do
     end
 
     context "when message_id is nil" do
-      before { plan.delete(channel_id: 123, message_id: nil) }
+      before do
+        plan.delete(channel_id: 123, message_id: nil)
+      end
 
       it "skips the delete" do
         plan.publish

--- a/spec/presenters/cached_dashboard_spec.rb
+++ b/spec/presenters/cached_dashboard_spec.rb
@@ -36,7 +36,9 @@ RSpec.describe CachedDashboard do
     end
 
     context "when the matching config has a nil name" do
-      before { config.update!(name: nil) }
+      before do
+        config.update!(name: nil)
+      end
 
       it { is_expected.to be_nil }
     end

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -16,7 +16,9 @@ RSpec.describe "Authentication", type: :request do
   end
 
   describe "signing out" do
-    before { post "/auth/discord/callback" }
+    before do
+      post "/auth/discord/callback"
+    end
 
     it "clears the session" do
       delete logout_path

--- a/spec/requests/logging_config_spec.rb
+++ b/spec/requests/logging_config_spec.rb
@@ -34,7 +34,9 @@ RSpec.describe "Logging config", type: :request do
     end
 
     context "after loading the dashboard authorizes the server" do
-      before { get server_path(guild.id) }
+      before do
+        get server_path(guild.id)
+      end
 
       describe "GET /servers/:server_id/logging" do
         it "renders the config page with the event matrix" do
@@ -62,7 +64,9 @@ RSpec.describe "Logging config", type: :request do
       end
 
       describe "PATCH /servers/:server_id/logging" do
-        before { create(:server_channel, server_configuration: config, name: "mod-log", discord_id: 200) }
+        before do
+          create(:server_channel, server_configuration: config, name: "mod-log", discord_id: 200)
+        end
 
         it "saves the channel, event toggles, and enables the plugin" do
           patch server_logging_path(guild.id),

--- a/spec/requests/reminders_config_spec.rb
+++ b/spec/requests/reminders_config_spec.rb
@@ -31,7 +31,9 @@ RSpec.describe "Reminders config", type: :request do
     end
 
     context "after loading the dashboard authorizes the server" do
-      before { get server_path(guild.id) }
+      before do
+        get server_path(guild.id)
+      end
 
       describe "GET /servers/:server_id/reminders" do
         it "renders the config page with the force-DM toggle and callout" do

--- a/spec/requests/roles_config_spec.rb
+++ b/spec/requests/roles_config_spec.rb
@@ -36,7 +36,9 @@ RSpec.describe "Roles config", type: :request do
     end
 
     context "after loading the dashboard authorizes the server" do
-      before { get server_path(guild.id) }
+      before do
+        get server_path(guild.id)
+      end
 
       describe "GET /servers/:server_id/roles" do
         it "renders the config page in the app shell" do

--- a/spec/requests/server_dashboard_spec.rb
+++ b/spec/requests/server_dashboard_spec.rb
@@ -100,7 +100,9 @@ RSpec.describe "Server dashboard", type: :request do
       end
 
       context "when the server is not manageable by the user" do
-        before { allow(Discord::UserGuilds).to receive(:call).and_return([]) }
+        before do
+          allow(Discord::UserGuilds).to receive(:call).and_return([])
+        end
 
         it "redirects back to the picker" do
           get_dashboard
@@ -109,7 +111,9 @@ RSpec.describe "Server dashboard", type: :request do
       end
 
       context "when the Discord token has expired" do
-        before { allow(Discord::UserGuilds).to receive(:call).and_raise(Discord::UserGuilds::Unauthorized) }
+        before do
+          allow(Discord::UserGuilds).to receive(:call).and_raise(Discord::UserGuilds::Unauthorized)
+        end
 
         it "kicks off re-authentication" do
           get_dashboard
@@ -125,7 +129,9 @@ RSpec.describe "Server dashboard", type: :request do
         end
 
         context "when cached metadata is present" do
-          before { config.update!(name: "Dev Refuge", icon_hash: "icyhash", member_count: 2481) }
+          before do
+            config.update!(name: "Dev Refuge", icon_hash: "icyhash", member_count: 2481)
+          end
 
           it "serves a 200 from the cache" do
             get_dashboard
@@ -166,7 +172,9 @@ RSpec.describe "Server dashboard", type: :request do
 
       # Loading the dashboard is what proves the user manages this server and
       # caches that authorization for the toggle that follows.
-      before { get server_path(guild.id) }
+      before do
+        get server_path(guild.id)
+      end
 
       it "enables a plugin in place without re-contacting Discord" do
         config.create_role_setting!(channel_id: 7)

--- a/spec/requests/server_picker_spec.rb
+++ b/spec/requests/server_picker_spec.rb
@@ -99,7 +99,9 @@ RSpec.describe "Server picker", type: :request do
       end
 
       context "with no manageable servers" do
-        before { allow(Discord::UserGuilds).to receive(:call).and_return([unmanaged_guild]) }
+        before do
+          allow(Discord::UserGuilds).to receive(:call).and_return([unmanaged_guild])
+        end
 
         it "shows the empty state" do
           get_servers
@@ -108,7 +110,9 @@ RSpec.describe "Server picker", type: :request do
       end
 
       context "when Discord cannot be reached" do
-        before { allow(Discord::UserGuilds).to receive(:call).and_raise(Discord::UserGuilds::Error) }
+        before do
+          allow(Discord::UserGuilds).to receive(:call).and_raise(Discord::UserGuilds::Error)
+        end
 
         it "renders the error state without raising" do
           get_servers
@@ -118,7 +122,9 @@ RSpec.describe "Server picker", type: :request do
       end
 
       context "when the Discord access token has expired" do
-        before { allow(Discord::UserGuilds).to receive(:call).and_raise(Discord::UserGuilds::Unauthorized) }
+        before do
+          allow(Discord::UserGuilds).to receive(:call).and_raise(Discord::UserGuilds::Unauthorized)
+        end
 
         it "kicks off automatic re-authentication" do
           get_servers

--- a/spec/requests/welcomes_config_spec.rb
+++ b/spec/requests/welcomes_config_spec.rb
@@ -34,7 +34,9 @@ RSpec.describe "Welcomes config", type: :request do
     end
 
     context "after loading the dashboard authorizes the server" do
-      before { get server_path(guild.id) }
+      before do
+        get server_path(guild.id)
+      end
 
       describe "GET /servers/:server_id/welcomes" do
         it "renders the config page in the app shell" do
@@ -82,7 +84,9 @@ RSpec.describe "Welcomes config", type: :request do
       end
 
       describe "PATCH /servers/:server_id/welcomes" do
-        before { create(:server_channel, server_configuration: config, name: "general", discord_id: 111) }
+        before do
+          create(:server_channel, server_configuration: config, name: "general", discord_id: 111)
+        end
 
         it "saves the settings and enables the plugin in one request" do
           patch server_welcomes_path(guild.id),


### PR DESCRIPTION
Backlog item **D2**: non-enumerator blocks (`before`, `transaction`) use `do…end`, not braces (enumerator blocks like `map`/`each` may keep `{ }`).

Reformats the 39 single-line `before { … }` hooks across 19 spec files to `before do … end`. Pure formatting — no behaviour change, only `before` blocks touched (`let`/`subject`/`it`/`map` left as-is).

## Gates
`grep -rn "before {" spec/` → 0 matches. standardrb clean. rspec 747/0. undercover no-missing (spec-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)