### PR TITLE
Add notification model and record channel-delete in-app

### DIFF
--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Notification < ApplicationRecord
+  belongs_to :server_configuration
+
+  validates :kind, presence: true
+
+  scope :active, -> { where(dismissed_at: nil) }
+  scope :unread, -> { where(read_at: nil, dismissed_at: nil) }
+  scope :recent, -> { order(created_at: :desc) }
+end

--- a/app/models/server_configuration.rb
+++ b/app/models/server_configuration.rb
@@ -8,6 +8,7 @@ class ServerConfiguration < ApplicationRecord
   has_one :role_setting, class_name: "Roles::Settings", dependent: :destroy
   has_one :welcome_settings, class_name: "Welcomes::Settings", dependent: :delete
 
+  has_many :notifications, dependent: :delete_all
   has_many :server_channels, dependent: :destroy
   has_many :server_roles, dependent: :delete_all
 

--- a/app/operations/notifications/create.rb
+++ b/app/operations/notifications/create.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Ops
+  module Notifications
+    class Create < ApplicationOperation
+      receives :server_configuration, :kind
+      receives :data, default: {}
+
+      def call
+        ok(server_configuration.notifications.create!(kind:, data:))
+      end
+    end
+  end
+end

--- a/app/operations/server_configuration/channels/disable_plugins.rb
+++ b/app/operations/server_configuration/channels/disable_plugins.rb
@@ -21,10 +21,16 @@ module Ops
           return unless setting&.channel_id == channel_id
 
           plugin = Plugin.find_by(key: definition.key)
+          channel_name = server_configuration.server_channels.find_by(discord_id: channel_id)&.name
           transaction do
             setting.update!(channel_id: nil)
             Plugins::Toggle.call(server_configuration:, plugin:, enabled: false)
           end
+          Ops::Notifications::Create.call(
+            server_configuration:,
+            kind: "channel_deleted",
+            data: {plugin_key: definition.key.to_s, plugin_name: plugin.name, channel_name:}
+          )
           plugin
         end
 

--- a/db/migrate/20260704155534_create_notifications.rb
+++ b/db/migrate/20260704155534_create_notifications.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CreateNotifications < ActiveRecord::Migration[8.1]
+  def change
+    create_table :notifications, id: false do |t|
+      t.string :id, null: false, primary_key: true
+      t.references :server_configuration, null: false, foreign_key: true, type: :string, index: false
+      t.string :kind, null: false
+      t.jsonb :data, null: false, default: {}
+      t.datetime :read_at
+      t.datetime :dismissed_at
+      t.timestamps
+    end
+    add_index :notifications, [:server_configuration_id, :created_at]
+
+    reversible do |dir|
+      dir.up { execute "ALTER TABLE notifications ALTER COLUMN id SET DEFAULT ('ntf_' || gen_random_uuid())" }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_03_232733) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_04_155534) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -52,6 +52,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_03_232733) do
     t.string "server_configuration_id", null: false
     t.datetime "updated_at", null: false
     t.index ["server_configuration_id"], name: "index_logging_settings_on_server_configuration_id", unique: true
+  end
+
+  create_table "notifications", id: :string, default: -> { "('ntf_'::text || gen_random_uuid())" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.jsonb "data", default: {}, null: false
+    t.datetime "dismissed_at"
+    t.string "kind", null: false
+    t.datetime "read_at"
+    t.string "server_configuration_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["server_configuration_id", "created_at"], name: "index_notifications_on_server_configuration_id_and_created_at"
   end
 
   create_table "plugin_activations", id: :string, default: -> { "('pac_'::text || gen_random_uuid())" }, force: :cascade do |t|
@@ -288,6 +299,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_03_232733) do
   add_foreign_key "assignable_roles", "role_sets"
   add_foreign_key "channel_overwrites", "server_channels"
   add_foreign_key "logging_settings", "server_configurations"
+  add_foreign_key "notifications", "server_configurations"
   add_foreign_key "plugin_activations", "plugins"
   add_foreign_key "plugin_activations", "server_configurations"
   add_foreign_key "role_sets", "role_settings"

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :notification do
+    kind { "channel_deleted" }
+    data { {} }
+    association :server_configuration
+  end
+end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Notification do
+  describe "primary key" do
+    subject(:id) { create(:notification).id }
+
+    it "generates a prefixed-uuid" do
+      expect(id).to match(/\Antf_\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/)
+    end
+  end
+
+  describe "validations" do
+    subject(:notification) { build(:notification, kind: nil) }
+
+    it "is invalid without kind" do
+      expect(notification).not_to be_valid
+    end
+  end
+
+  describe "associations" do
+    subject(:notification) { build(:notification) }
+
+    it "belongs to server_configuration" do
+      expect(notification.server_configuration).to be_a(ServerConfiguration)
+    end
+  end
+
+  describe ".active" do
+    subject(:active) { described_class.active }
+
+    let!(:live) { create(:notification) }
+    let!(:dismissed) { create(:notification, dismissed_at: 1.hour.ago) }
+
+    it "excludes dismissed notifications" do
+      expect(active).to include(live)
+      expect(active).not_to include(dismissed)
+    end
+  end
+
+  describe ".unread" do
+    subject(:unread) { described_class.unread }
+
+    let!(:fresh) { create(:notification) }
+    let!(:read) { create(:notification, read_at: 1.hour.ago) }
+    let!(:dismissed) { create(:notification, dismissed_at: 1.hour.ago) }
+
+    it "excludes read notifications" do
+      expect(unread).not_to include(read)
+    end
+
+    it "excludes dismissed notifications" do
+      expect(unread).not_to include(dismissed)
+    end
+
+    it "includes unread, undismissed notifications" do
+      expect(unread).to include(fresh)
+    end
+  end
+end

--- a/spec/operations/notifications/create_spec.rb
+++ b/spec/operations/notifications/create_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Ops::Notifications::Create do
+  let(:server) { create(:server_configuration) }
+
+  describe "with explicit data" do
+    subject(:result) do
+      described_class.call(
+        server_configuration: server,
+        kind: "channel_deleted",
+        data: {plugin_key: "welcomes", channel_name: "general"}
+      )
+    end
+
+    it "creates a Notification row" do
+      expect { result }.to change(Notification, :count).by(1)
+    end
+
+    it "returns the created notification in result.value" do
+      expect(result.value).to be_a(Notification)
+    end
+
+    it "persists the correct kind" do
+      expect(result.value.kind).to eq("channel_deleted")
+    end
+
+    it "persists the correct data" do
+      expect(result.value.data).to eq("plugin_key" => "welcomes", "channel_name" => "general")
+    end
+  end
+
+  describe "data defaults to {}" do
+    subject(:result) { described_class.call(server_configuration: server, kind: "channel_deleted") }
+
+    it "stores empty data when omitted" do
+      expect(result.value.data).to eq({})
+    end
+  end
+end

--- a/spec/operations/server_configuration/channels/disable_plugins_spec.rb
+++ b/spec/operations/server_configuration/channels/disable_plugins_spec.rb
@@ -27,6 +27,34 @@ RSpec.describe Ops::ServerConfiguration::Channels::DisablePlugins do
       expect(server.welcome_settings.reload.channel_id).to be_nil
       expect(OwnerNotifier).to have_received(:notify).with(hash_including(bot:))
     end
+
+    it "creates a channel_deleted notification for the server" do
+      expect { result }.to change(Notification, :count).by(1)
+
+      notification = server.notifications.last
+      expect(notification.kind).to eq("channel_deleted")
+      expect(notification.data["plugin_key"]).to eq("welcomes")
+    end
+
+    context "when the server_channels row exists for the deleted channel" do
+      before do
+        create(:server_channel, server_configuration: server, discord_id: 555, name: "general")
+      end
+
+      it "stores the channel_name in the notification data" do
+        result
+
+        expect(server.notifications.last.data["channel_name"]).to eq("general")
+      end
+    end
+
+    context "when the server_channels row is absent (offline delete)" do
+      it "stores nil channel_name in the notification data" do
+        result
+
+        expect(server.notifications.last.data["channel_name"]).to be_nil
+      end
+    end
   end
 
   context "when the deleted channel isn't used by any plugin" do
@@ -39,6 +67,10 @@ RSpec.describe Ops::ServerConfiguration::Channels::DisablePlugins do
 
       expect(server.welcome_settings.reload.channel_id).to eq(999)
       expect(OwnerNotifier).not_to have_received(:notify)
+    end
+
+    it "creates no notifications" do
+      expect { result }.not_to change(Notification, :count)
     end
   end
 end


### PR DESCRIPTION
First of three PRs building the F3 website notification system (the locked sequence: notification center → flip channel-delete to notify-only). This PR is the backend slice.

## What
- **`notifications` table** — server-scoped (`ntf_`-prefixed UUID PK, `server_configuration_id` FK), a `kind` string + `data` jsonb payload (rendered i18n-style later, like `ActivityLog`), and `read_at` / `dismissed_at` timestamps. Indexed on `(server_configuration_id, created_at)` for the per-server read path.
- **`Notification`** model — `belongs_to :server_configuration`, `kind` presence, `active` / `unread` / `recent` scopes.
- **`Ops::Notifications::Create`** — the write seam (bot already writes the DB via Ops).
- **Channel-delete wiring** — `Ops::ServerConfiguration::Channels::DisablePlugins` now records a `channel_deleted` notification (data: `plugin_key`, `plugin_name`, best-effort `channel_name`) alongside the existing owner DM. Disabling behaviour is unchanged in this PR; the notify-only flip lands in PR 3.

Web display (bell + panel) is PR 2; the notify-only flip + inline banner is PR 3.

## Gates
rspec 763/0, standardrb, active_record_doctor, undercover no-missing — all green. (Convention pass self-reviewed — the reviewer agent hit an unrelated infra limit; diff is a standard model+op+migration mirroring existing patterns.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)