### PR TITLE
Add the notification bell and dropdown panel

### DIFF
--- a/app/assets/tailwind/utilities.css
+++ b/app/assets/tailwind/utilities.css
@@ -84,6 +84,13 @@ details[open] > .dropdown-menu {
 details[open] > .dropdown-menu.is-closing {
   animation: menuLeave var(--dur-base) var(--ease-exit) forwards;
 }
+/* A menu rendered already-open (e.g. a Turbo Frame reloading the notification
+   bell) must not replay the entrance animation — that reads as a flicker. The
+   dropdown controller adds .no-enter on connect when it wakes up already open;
+   :not(.is-closing) keeps the close animation working. */
+details[open] > .dropdown-menu.no-enter:not(.is-closing) {
+  animation: none;
+}
 
 .dropdown-chevron {
   transition: transform var(--dur-base) var(--ease-standard);

--- a/app/components/app_shell.rb
+++ b/app/components/app_shell.rb
@@ -3,6 +3,7 @@
 class Components::AppShell < Components::Base
   include Phlex::Rails::Helpers::ImageTag
   include Phlex::Rails::Helpers::ButtonTo
+  include Phlex::Rails::Helpers::TurboFrameTag
   include Components::Initials
 
   def initialize(user:, current_server: nil, servers: [], plugin_counts: {}, sidebar: nil)
@@ -34,6 +35,7 @@ class Components::AppShell < Components::Base
       wordmark
       server_switcher if @current_server
       div(class: "flex-1")
+      notification_frame
       theme_toggle
       user_menu
     end
@@ -97,6 +99,26 @@ class Components::AppShell < Components::Base
       span(class: "font-display text-lg font-bold tracking-tight") do
         render Components::Wordmark.new
       end
+    end
+  end
+
+  def notification_frame
+    turbo_frame_tag(
+      "notifications",
+      src: notifications_path(server_id: @current_server&.id),
+      loading: "eager"
+    ) do
+      placeholder_bell
+    end
+  end
+
+  def placeholder_bell
+    button(
+      type: "button",
+      aria_label: t(".notifications"),
+      class: "flex size-9 items-center justify-center rounded-md text-text-secondary transition-colors hover:bg-surface-sunken"
+    ) do
+      render Components::Icon.new("bell", class: "size-5")
     end
   end
 

--- a/app/components/app_shell.rb
+++ b/app/components/app_shell.rb
@@ -6,9 +6,10 @@ class Components::AppShell < Components::Base
   include Phlex::Rails::Helpers::TurboFrameTag
   include Components::Initials
 
-  def initialize(user:, current_server: nil, servers: [], plugin_counts: {}, sidebar: nil)
+  def initialize(user:, current_server: nil, current_server_id: nil, servers: [], plugin_counts: {}, sidebar: nil)
     @user = user
     @current_server = current_server
+    @current_server_id = current_server_id
     @servers = servers
     @plugin_counts = plugin_counts
     @sidebar = sidebar
@@ -96,7 +97,7 @@ class Components::AppShell < Components::Base
   def notification_frame
     turbo_frame_tag(
       "notifications",
-      src: notifications_path(server_id: @current_server&.id),
+      src: notifications_path(server_id: @current_server_id || @current_server&.id),
       loading: "eager"
     ) do
       placeholder_bell

--- a/app/components/app_shell.rb
+++ b/app/components/app_shell.rb
@@ -47,7 +47,7 @@ class Components::AppShell < Components::Base
         data: {action: "click->dropdown#toggle"},
         class: "flex h-9 cursor-pointer list-none items-center gap-2 rounded-md px-2 transition-colors hover:bg-surface-sunken [&::-webkit-details-marker]:hidden"
       ) do
-        server_tile(@current_server, size: :sm)
+        render Components::ServerAvatar.new(server: @current_server, size: :sm)
         span(class: "hidden whitespace-nowrap text-sm font-semibold sm:block") { @current_server.name }
         render Components::Icon.new("caret-down", class: "dropdown-chevron size-4 text-text-muted")
       end
@@ -75,21 +75,12 @@ class Components::AppShell < Components::Base
     current = server.id == @current_server.id
     tone = current ? "bg-accent-soft hover:bg-accent-soft" : "hover:bg-surface-sunken"
     a(href: server_path(server.id), class: "flex items-center gap-3 px-3 py-2 text-left transition-colors #{tone}") do
-      server_tile(server, size: :md)
+      render Components::ServerAvatar.new(server:, size: :md)
       div(class: "min-w-0 flex-1") do
         p(class: "truncate text-sm font-semibold") { server.name }
         p(class: "text-[11px] text-text-secondary") { t(".plugins_on", count: @plugin_counts[server.id].to_i) }
       end
       render Components::Icon.new("check", class: "size-4 flex-none text-accent") if current
-    end
-  end
-
-  def server_tile(server, size:)
-    box = (size == :sm) ? "size-7" : "size-8"
-    if server.icon_url
-      image_tag(server.icon_url, alt: "", loading: "lazy", class: "#{box} flex-none rounded-md object-cover")
-    else
-      span(class: "#{box} flex flex-none items-center justify-center rounded-md bg-accent-soft text-xs font-bold text-accent-soft-fg") { initials(server.name) }
     end
   end
 

--- a/app/components/notification_bell.rb
+++ b/app/components/notification_bell.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class Components::NotificationBell < Components::Base
-  def initialize(authorized:, server_id: nil, open: false)
+  def initialize(authorized:, server_id: nil, scope: "all", open: false)
     @authorized = authorized
     @server_id = server_id
+    @scope = scope
     @open = open
   end
 
@@ -26,7 +27,7 @@ class Components::NotificationBell < Components::Base
         data: {dropdown_target: "menu"},
         class: "dropdown-menu absolute right-0 top-12 z-50 w-[380px] max-w-[calc(100vw-2rem)]"
       ) do
-        render Components::NotificationPanel.new(authorized: @authorized, server_id: @server_id)
+        render Components::NotificationPanel.new(authorized: @authorized, server_id: @server_id, scope: @scope)
       end
     end
   end

--- a/app/components/notification_bell.rb
+++ b/app/components/notification_bell.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class Components::NotificationBell < Components::Base
+  def initialize(authorized:, server_id: nil)
+    @authorized = authorized
+    @server_id = server_id
+  end
+
+  def view_template
+    details(
+      class: "relative",
+      data: {controller: "dropdown"}
+    ) do
+      summary(
+        aria_label: bell_label,
+        data: {action: "click->dropdown#toggle"},
+        class: "relative flex size-9 cursor-pointer list-none items-center justify-center rounded-md text-text-secondary transition-colors hover:bg-surface-sunken [&::-webkit-details-marker]:hidden"
+      ) do
+        render Components::Icon.new("bell", class: "size-5")
+        unread_badge if @authorized.unread_count > 0
+      end
+
+      div(
+        data: {dropdown_target: "menu"},
+        class: "dropdown-menu absolute right-0 top-12 z-50 w-[380px] max-w-[calc(100vw-2rem)]"
+      ) do
+        render Components::NotificationPanel.new(authorized: @authorized, server_id: @server_id)
+      end
+    end
+  end
+
+  private
+
+  def unread_badge
+    span(
+      class: "absolute right-0.5 top-0.5 flex h-4 min-w-[16px] items-center justify-center rounded-full bg-accent-fill px-1 text-[10px] font-bold leading-4 text-white",
+      style: "box-shadow:0 0 0 2px var(--surface-card)"
+    ) { @authorized.unread_count.to_s }
+  end
+
+  def bell_label
+    count = @authorized.unread_count
+    if count > 0
+      t(".unread", count: count)
+    else
+      t(".label")
+    end
+  end
+end

--- a/app/components/notification_bell.rb
+++ b/app/components/notification_bell.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
 class Components::NotificationBell < Components::Base
-  def initialize(authorized:, server_id: nil)
+  def initialize(authorized:, server_id: nil, open: false)
     @authorized = authorized
     @server_id = server_id
+    @open = open
   end
 
   def view_template
     details(
+      open: @open,
       class: "relative",
       data: {controller: "dropdown"}
     ) do

--- a/app/components/notification_item.rb
+++ b/app/components/notification_item.rb
@@ -4,9 +4,10 @@ class Components::NotificationItem < Components::Base
   include Phlex::Rails::Helpers::ButtonTo
   include Components::PluginNav
 
-  def initialize(presenter:, server_id: nil)
+  def initialize(presenter:, server_id: nil, scope: "all")
     @presenter = presenter
     @server_id = server_id
+    @scope = scope
   end
 
   def view_template
@@ -70,7 +71,7 @@ class Components::NotificationItem < Components::Base
 
   def dismiss_button
     button_to(
-      notification_path(@presenter.notification.id, server_id: @server_id),
+      notification_path(@presenter.notification.id, server_id: @server_id, scope: @scope),
       method: :patch,
       aria_label: "Dismiss",
       class: "absolute right-2 top-1/2 flex size-6 -translate-y-1/2 items-center justify-center rounded-md text-text-muted transition-colors hover:bg-surface-raised hover:text-text-primary"

--- a/app/components/notification_item.rb
+++ b/app/components/notification_item.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+class Components::NotificationItem < Components::Base
+  include Phlex::Rails::Helpers::ButtonTo
+  include Components::PluginNav
+
+  def initialize(presenter:, server_id: nil)
+    @presenter = presenter
+    @server_id = server_id
+  end
+
+  def view_template
+    li(class: "relative") do
+      item_link
+      dismiss_button
+    end
+  end
+
+  private
+
+  def item_link
+    a(
+      href: deep_link,
+      class: "flex gap-3 py-3 pl-5 pr-9 transition-colors hover:bg-surface-sunken"
+    ) do
+      unread_dot if @presenter.unread?
+      icon_circle
+      item_content
+    end
+  end
+
+  def unread_dot
+    span(
+      class: "absolute left-[7px] top-[27px] size-1.5 rounded-full bg-accent",
+      aria_label: "Unread"
+    )
+  end
+
+  def icon_circle
+    circle_class = @presenter.unread? ? "bg-warning-soft" : "bg-warning-soft opacity-60"
+    span(class: "flex size-8 flex-none items-center justify-center rounded-full #{circle_class}") do
+      render Components::Icon.new(@presenter.icon, class: "size-4 text-warning")
+    end
+  end
+
+  def item_content
+    span(class: "min-w-0 flex-1") do
+      title_line
+      message_line
+      time_line
+    end
+  end
+
+  def title_line
+    weight = @presenter.unread? ? "font-semibold text-text-primary" : "font-medium text-text-secondary"
+    span(class: "block text-[13px] leading-snug #{weight}") do
+      render Components::Icon.new("hash", class: "inline size-3 text-text-muted")
+      plain @presenter.title
+    end
+  end
+
+  def message_line
+    msg_class = @presenter.unread? ? "text-text-secondary" : "text-text-muted"
+    span(class: "mt-0.5 block text-xs leading-snug #{msg_class}") { @presenter.message }
+  end
+
+  def time_line
+    span(class: "mt-1 block text-[11px] text-text-muted") { @presenter.relative_time }
+  end
+
+  def dismiss_button
+    button_to(
+      notification_path(@presenter.notification.id, server_id: @server_id),
+      method: :patch,
+      aria_label: "Dismiss",
+      class: "absolute right-2 top-1/2 flex size-6 -translate-y-1/2 items-center justify-center rounded-md text-text-muted transition-colors hover:bg-surface-raised hover:text-text-primary"
+    ) do
+      render Components::Icon.new("x", class: "size-3.5")
+    end
+  end
+
+  def deep_link
+    plugin_config_path(
+      @presenter.server_configuration.discord_id,
+      @presenter.notification.data["plugin_key"]
+    )
+  end
+end

--- a/app/components/notification_panel.rb
+++ b/app/components/notification_panel.rb
@@ -3,9 +3,10 @@
 class Components::NotificationPanel < Components::Base
   include Phlex::Rails::Helpers::ButtonTo
 
-  def initialize(authorized:, server_id: nil)
+  def initialize(authorized:, server_id: nil, scope: "all")
     @authorized = authorized
     @server_id = server_id
+    @scope = scope
     @groups = authorized.groups
     @presenters = @groups.flat_map { |_config, notifications| notifications.map { |n| NotificationPresenter.new(n) } }
   end
@@ -31,26 +32,26 @@ class Components::NotificationPanel < Components::Base
 
   def mark_all_read_button
     button_to(
-      notifications_read_path(server_id: @server_id),
+      notifications_read_path(server_id: @server_id, scope: @scope),
       method: :post,
       class: "text-xs font-semibold text-text-link hover:underline"
     ) { t(".mark_all_read") }
   end
 
   def scope_toggle
-    div(class: "inline-flex self-start rounded-md bg-surface-sunken p-0.5 text-xs") do
-      this_server_active = @server_id.present?
+    return if @server_id.blank?
 
+    div(class: "inline-flex self-start rounded-md bg-surface-sunken p-0.5 text-xs") do
       a(
-        href: notifications_path(server_id: current_server_id, open: true),
+        href: notifications_path(server_id: @server_id, scope: "server", open: true),
         data: {turbo_frame: "notifications"},
-        class: toggle_tab_class(this_server_active)
+        class: toggle_tab_class(@scope == "server")
       ) { t(".this_server") }
 
       a(
-        href: notifications_path(open: true),
+        href: notifications_path(server_id: @server_id, scope: "all", open: true),
         data: {turbo_frame: "notifications"},
-        class: toggle_tab_class(!this_server_active)
+        class: toggle_tab_class(@scope != "server")
       ) { t(".all_servers") }
     end
   end
@@ -68,7 +69,7 @@ class Components::NotificationPanel < Components::Base
     div(class: "notif-scroll max-h-[330px] overflow-y-auto") do
       if @presenters.empty?
         empty_state
-      elsif @server_id.present?
+      elsif @scope == "server"
         flat_items
       else
         grouped_items
@@ -89,7 +90,7 @@ class Components::NotificationPanel < Components::Base
 
   def flat_items
     ul do
-      @presenters.each { |presenter| render Components::NotificationItem.new(presenter:, server_id: @server_id) }
+      @presenters.each { |presenter| render Components::NotificationItem.new(presenter:, server_id: @server_id, scope: @scope) }
     end
   end
 
@@ -103,7 +104,8 @@ class Components::NotificationPanel < Components::Base
         notifications.each do |notification|
           render Components::NotificationItem.new(
             presenter: NotificationPresenter.new(notification),
-            server_id: @server_id
+            server_id: @server_id,
+            scope: @scope
           )
         end
       end
@@ -113,9 +115,5 @@ class Components::NotificationPanel < Components::Base
   def group_header_class(index)
     base = "flex items-center gap-2 px-4 pb-1.5 pt-3"
     (index > 0) ? "#{base} mt-1 border-t border-border-subtle" : base
-  end
-
-  def current_server_id
-    @server_id
   end
 end

--- a/app/components/notification_panel.rb
+++ b/app/components/notification_panel.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+class Components::NotificationPanel < Components::Base
+  include Phlex::Rails::Helpers::ButtonTo
+  include Components::Initials
+
+  def initialize(authorized:, server_id: nil)
+    @authorized = authorized
+    @server_id = server_id
+    @groups = authorized.groups
+    @presenters = @groups.flat_map { |_config, notifications| notifications.map { |n| NotificationPresenter.new(n) } }
+  end
+
+  def view_template
+    div(class: "overflow-hidden rounded-lg border border-border-default bg-surface-card shadow-lg") do
+      panel_header
+      panel_body
+    end
+  end
+
+  private
+
+  def panel_header
+    div(class: "flex flex-col gap-2.5 border-b border-border-subtle px-4 pb-3 pt-3.5") do
+      div(class: "flex items-center justify-between") do
+        h3(class: "font-display text-sm font-bold tracking-tight") { t(".title") }
+        mark_all_read_button if @presenters.any?
+      end
+      scope_toggle
+    end
+  end
+
+  def mark_all_read_button
+    button_to(
+      notifications_read_path(server_id: @server_id),
+      method: :post,
+      class: "text-xs font-semibold text-text-link hover:underline"
+    ) { t(".mark_all_read") }
+  end
+
+  def scope_toggle
+    div(class: "inline-flex self-start rounded-md bg-surface-sunken p-0.5 text-xs") do
+      this_server_active = @server_id.present?
+
+      a(
+        href: notifications_path(server_id: current_server_id),
+        data: {turbo_frame: "notifications"},
+        class: toggle_tab_class(this_server_active)
+      ) { t(".this_server") }
+
+      a(
+        href: notifications_path,
+        data: {turbo_frame: "notifications"},
+        class: toggle_tab_class(!this_server_active)
+      ) { t(".all_servers") }
+    end
+  end
+
+  def toggle_tab_class(active)
+    base = "rounded-[6px] px-2.5 py-1 transition-colors"
+    if active
+      "#{base} bg-surface-card font-semibold text-text-primary shadow-sm"
+    else
+      "#{base} font-medium text-text-secondary hover:text-text-primary"
+    end
+  end
+
+  def panel_body
+    div(class: "notif-scroll max-h-[330px] overflow-y-auto") do
+      if @presenters.empty?
+        empty_state
+      elsif @server_id.present?
+        flat_items
+      else
+        grouped_items
+      end
+      div(class: "h-2") unless @presenters.empty?
+    end
+  end
+
+  def empty_state
+    div(class: "px-6 py-10 text-center") do
+      span(class: "mx-auto flex size-10 items-center justify-center rounded-full bg-surface-sunken") do
+        render Components::Icon.new("bell", class: "size-5 text-text-muted")
+      end
+      p(class: "mt-3 text-sm font-semibold") { t(".empty_title") }
+      p(class: "mt-1 text-xs text-text-muted") { t(".empty_subtitle") }
+    end
+  end
+
+  def flat_items
+    ul do
+      @presenters.each { |presenter| render Components::NotificationItem.new(presenter:, server_id: @server_id) }
+    end
+  end
+
+  def grouped_items
+    @groups.each_with_index do |(config, notifications), index|
+      div(class: group_header_class(index)) do
+        server_tile(config)
+        span(class: "text-[11px] font-semibold text-text-secondary truncate") { config.name }
+      end
+      ul do
+        notifications.each do |notification|
+          render Components::NotificationItem.new(
+            presenter: NotificationPresenter.new(notification),
+            server_id: @server_id
+          )
+        end
+      end
+    end
+  end
+
+  def group_header_class(index)
+    base = "flex items-center gap-2 px-4 pb-1.5 pt-3"
+    (index > 0) ? "#{base} mt-1 border-t border-border-subtle" : base
+  end
+
+  def server_tile(config)
+    if config.icon_url
+      img(
+        src: config.icon_url,
+        alt: "",
+        loading: "lazy",
+        class: "size-5 flex-none rounded-[5px] object-cover"
+      )
+    else
+      span(class: "flex size-5 flex-none items-center justify-center rounded-[5px] bg-accent-soft text-[9px] font-bold text-accent-soft-fg") do
+        plain initials(config.name.to_s)
+      end
+    end
+  end
+
+  def current_server_id
+    @server_id
+  end
+end

--- a/app/components/notification_panel.rb
+++ b/app/components/notification_panel.rb
@@ -2,7 +2,6 @@
 
 class Components::NotificationPanel < Components::Base
   include Phlex::Rails::Helpers::ButtonTo
-  include Components::Initials
 
   def initialize(authorized:, server_id: nil)
     @authorized = authorized
@@ -43,13 +42,13 @@ class Components::NotificationPanel < Components::Base
       this_server_active = @server_id.present?
 
       a(
-        href: notifications_path(server_id: current_server_id),
+        href: notifications_path(server_id: current_server_id, open: true),
         data: {turbo_frame: "notifications"},
         class: toggle_tab_class(this_server_active)
       ) { t(".this_server") }
 
       a(
-        href: notifications_path,
+        href: notifications_path(open: true),
         data: {turbo_frame: "notifications"},
         class: toggle_tab_class(!this_server_active)
       ) { t(".all_servers") }
@@ -97,7 +96,7 @@ class Components::NotificationPanel < Components::Base
   def grouped_items
     @groups.each_with_index do |(config, notifications), index|
       div(class: group_header_class(index)) do
-        server_tile(config)
+        render Components::ServerAvatar.new(server: config, size: :xs)
         span(class: "text-[11px] font-semibold text-text-secondary truncate") { config.name }
       end
       ul do
@@ -114,21 +113,6 @@ class Components::NotificationPanel < Components::Base
   def group_header_class(index)
     base = "flex items-center gap-2 px-4 pb-1.5 pt-3"
     (index > 0) ? "#{base} mt-1 border-t border-border-subtle" : base
-  end
-
-  def server_tile(config)
-    if config.icon_url
-      img(
-        src: config.icon_url,
-        alt: "",
-        loading: "lazy",
-        class: "size-5 flex-none rounded-[5px] object-cover"
-      )
-    else
-      span(class: "flex size-5 flex-none items-center justify-center rounded-[5px] bg-accent-soft text-[9px] font-bold text-accent-soft-fg") do
-        plain initials(config.name.to_s)
-      end
-    end
   end
 
   def current_server_id

--- a/app/components/plugin_shell.rb
+++ b/app/components/plugin_shell.rb
@@ -10,6 +10,7 @@ class Components::PluginShell < Components::Base
   def view_template(&block)
     render Components::AppShell.new(
       user: @user,
+      current_server_id: @server_configuration.discord_id,
       sidebar: Components::PluginSidebar.new(server_configuration: @server_configuration, active_key: @active_key)
     ), &block
   end

--- a/app/components/server_avatar.rb
+++ b/app/components/server_avatar.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+class Components::ServerAvatar < Components::Base
+  include Components::Initials
+
+  SIZES = {
+    xs: {box: "size-5", radius: "rounded-[5px]", text: "text-[9px]"},
+    sm: {box: "size-7", radius: "rounded-md", text: "text-xs"},
+    md: {box: "size-8", radius: "rounded-md", text: "text-xs"},
+    lg: {box: "size-12", radius: "rounded-lg", text: ""},
+    xl: {box: "size-14", radius: "rounded-xl", text: "text-xl"}
+  }.freeze
+
+  def initialize(server:, size:, tone: :accent, dim: false)
+    @server = server
+    @size = size
+    @tone = tone
+    @dim = dim
+  end
+
+  def view_template
+    if @server.icon_url
+      img(src: @server.icon_url, alt: "", loading: "lazy", class: image_class)
+    else
+      span(class: initials_class) { initials(@server.name.to_s) }
+    end
+  end
+
+  private
+
+  def dims
+    SIZES.fetch(@size)
+  end
+
+  def image_class
+    "#{dims[:box]} #{dims[:radius]} flex-none object-cover#{dim_suffix}"
+  end
+
+  def initials_class
+    [dims[:box], dims[:radius], dims[:text], "flex flex-none items-center justify-center", tone_classes, weight]
+      .reject(&:empty?)
+      .join(" ") + dim_suffix
+  end
+
+  def tone_classes
+    (@tone == :sunken) ? "bg-surface-sunken text-text-secondary" : "bg-accent-soft text-accent-soft-fg"
+  end
+
+  def weight
+    (@tone == :sunken) ? "font-semibold" : "font-bold"
+  end
+
+  def dim_suffix
+    @dim ? " opacity-60" : ""
+  end
+end

--- a/app/controllers/notifications/reads_controller.rb
+++ b/app/controllers/notifications/reads_controller.rb
@@ -6,16 +6,22 @@ class Notifications::ReadsController < ApplicationController
   def create
     configs = authorized_server_configurations
     Ops::Notifications::MarkRead.call(server_configurations: configs)
-    redirect_to notifications_path(server_id: params[:server_id], open: true)
+    redirect_to notifications_path(server_id: params[:server_id], scope: params[:scope], open: true)
   end
 
   private
 
   def authorized_server_configurations
-    if params[:server_id]
-      ServerConfiguration.where(discord_id: [params[:server_id]].select { |id| manageable_server_ids.include?(id.to_i) })
+    if scoped_to_server?
+      ServerConfiguration.where(discord_id: params[:server_id])
     else
       ServerConfiguration.where(discord_id: manageable_server_ids)
     end
+  end
+
+  def scoped_to_server?
+    params[:scope] == "server" &&
+      params[:server_id].present? &&
+      manageable_server_ids.include?(params[:server_id].to_i)
   end
 end

--- a/app/controllers/notifications/reads_controller.rb
+++ b/app/controllers/notifications/reads_controller.rb
@@ -6,7 +6,7 @@ class Notifications::ReadsController < ApplicationController
   def create
     configs = authorized_server_configurations
     Ops::Notifications::MarkRead.call(server_configurations: configs)
-    redirect_to notifications_path(server_id: params[:server_id])
+    redirect_to notifications_path(server_id: params[:server_id], open: true)
   end
 
   private

--- a/app/controllers/notifications/reads_controller.rb
+++ b/app/controllers/notifications/reads_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Notifications::ReadsController < ApplicationController
+  include SetsManageableServers
+
+  def create
+    configs = authorized_server_configurations
+    Ops::Notifications::MarkRead.call(server_configurations: configs)
+    redirect_to notifications_path(server_id: params[:server_id])
+  end
+
+  private
+
+  def authorized_server_configurations
+    if params[:server_id]
+      ServerConfiguration.where(discord_id: [params[:server_id]].select { |id| manageable_server_ids.include?(id.to_i) })
+    else
+      ServerConfiguration.where(discord_id: manageable_server_ids)
+    end
+  end
+end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class NotificationsController < ApplicationController
+  include SetsManageableServers
+
+  def index
+    authorized = AuthorizedNotifications.new(
+      manageable_ids: manageable_server_ids,
+      server_id: params[:server_id]
+    )
+    render Views::Notifications::Index.new(
+      authorized:,
+      server_id: params[:server_id]
+    )
+  end
+
+  def update
+    notification = authorized_notification
+    return head(:not_found) unless notification
+
+    Ops::Notifications::Dismiss.call(notification:)
+    redirect_to notifications_path(server_id: params[:server_id])
+  end
+
+  private
+
+  def authorized_notification
+    Notification
+      .joins(:server_configuration)
+      .where(server_configurations: {discord_id: manageable_server_ids})
+      .find_by(id: params[:id])
+  end
+end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -4,13 +4,15 @@ class NotificationsController < ApplicationController
   include SetsManageableServers
 
   def index
+    scope = notification_scope
     authorized = AuthorizedNotifications.new(
       manageable_ids: manageable_server_ids,
-      server_id: params[:server_id]
+      server_id: (scope == "server") ? params[:server_id] : nil
     )
     render Views::Notifications::Index.new(
       authorized:,
       server_id: params[:server_id],
+      scope:,
       open: params[:open].present?
     )
   end
@@ -20,10 +22,16 @@ class NotificationsController < ApplicationController
     return head(:not_found) unless notification
 
     Ops::Notifications::Dismiss.call(notification:)
-    redirect_to notifications_path(server_id: params[:server_id], open: true)
+    redirect_to notifications_path(server_id: params[:server_id], scope: params[:scope], open: true)
   end
 
   private
+
+  def notification_scope
+    return params[:scope] if params[:scope].present?
+
+    params[:server_id].present? ? "server" : "all"
+  end
 
   def authorized_notification
     Notification

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -10,7 +10,8 @@ class NotificationsController < ApplicationController
     )
     render Views::Notifications::Index.new(
       authorized:,
-      server_id: params[:server_id]
+      server_id: params[:server_id],
+      open: params[:open].present?
     )
   end
 
@@ -19,7 +20,7 @@ class NotificationsController < ApplicationController
     return head(:not_found) unless notification
 
     Ops::Notifications::Dismiss.call(notification:)
-    redirect_to notifications_path(server_id: params[:server_id])
+    redirect_to notifications_path(server_id: params[:server_id], open: true)
   end
 
   private

--- a/app/javascript/controllers/dropdown_controller.js
+++ b/app/javascript/controllers/dropdown_controller.js
@@ -14,6 +14,12 @@ export default class extends Controller {
   static values = {dismissOnOutside: {type: Boolean, default: true}}
 
   connect() {
+    // Woke up already open (a Turbo Frame reloaded the panel in place): skip the
+    // entrance animation so it doesn't flicker. Cleared on the next close.
+    if (this.element.open && this.hasMenuTarget) {
+      this.menuTarget.classList.add("no-enter")
+    }
+
     if (!this.dismissOnOutsideValue) return
 
     this.closeOutside = (e) => {
@@ -56,6 +62,7 @@ export default class extends Controller {
       if (event.animationName !== "menuLeave") return
       menu.removeEventListener("animationend", done)
       menu.classList.remove("is-closing")
+      menu.classList.remove("no-enter")
       this.element.open = false
       this.closing = false
     }

--- a/app/operations/notifications/dismiss.rb
+++ b/app/operations/notifications/dismiss.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Ops
+  module Notifications
+    class Dismiss < ApplicationOperation
+      receives :notification
+
+      def call
+        notification.update!(dismissed_at: Time.current)
+        ok(notification)
+      end
+    end
+  end
+end

--- a/app/operations/notifications/mark_read.rb
+++ b/app/operations/notifications/mark_read.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Ops
+  module Notifications
+    class MarkRead < ApplicationOperation
+      receives :server_configurations
+
+      def call
+        Notification.where(server_configuration: server_configurations).unread.update_all(read_at: Time.current)
+        ok
+      end
+    end
+  end
+end

--- a/app/presenters/authorized_notifications.rb
+++ b/app/presenters/authorized_notifications.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class AuthorizedNotifications
+  def initialize(manageable_ids:, server_id: nil)
+    @manageable_ids = manageable_ids
+    @server_id = server_id
+  end
+
+  def groups
+    if @server_id
+      return [] unless @manageable_ids.include?(@server_id.to_i)
+
+      config = ServerConfiguration.find_by(discord_id: @server_id)
+      return [] unless config
+
+      [[config, scoped.where(server_configuration: config).to_a]]
+    else
+      configs = ServerConfiguration
+        .where(discord_id: @manageable_ids)
+        .order(:name)
+        .index_by(&:id)
+
+      scoped
+        .includes(:server_configuration)
+        .group_by(&:server_configuration_id)
+        .filter_map do |config_id, notifications|
+          config = configs[config_id]
+          next unless config
+
+          [config, notifications]
+        end
+        .sort_by { |config, _| config.name.to_s }
+    end
+  end
+
+  def unread_count
+    base_relation.unread.count
+  end
+
+  def scoped
+    base_relation
+  end
+
+  private
+
+  def base_relation
+    Notification
+      .active
+      .recent
+      .joins(:server_configuration)
+      .where(server_configurations: {discord_id: @manageable_ids})
+  end
+end

--- a/app/presenters/notification_presenter.rb
+++ b/app/presenters/notification_presenter.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class NotificationPresenter
+  ICON_BY_KIND = {
+    "channel_deleted" => "warning"
+  }.freeze
+
+  DEFAULT_ICON = "bell"
+
+  attr_reader :notification
+
+  def initialize(notification)
+    @notification = notification
+  end
+
+  def title
+    if notification.kind == "channel_deleted" && notification.data["channel_name"].nil?
+      I18n.t("notifications.kinds.channel_deleted.title_unknown")
+    else
+      I18n.t("notifications.kinds.#{notification.kind}.title", **symbolized_data)
+    end
+  end
+
+  def message
+    I18n.t("notifications.kinds.#{notification.kind}.message", **symbolized_data)
+  end
+
+  def icon
+    ICON_BY_KIND.fetch(notification.kind, DEFAULT_ICON)
+  end
+
+  def unread?
+    notification.read_at.nil?
+  end
+
+  def relative_time
+    "#{ActionController::Base.helpers.time_ago_in_words(notification.created_at)} ago"
+  end
+
+  def server_configuration
+    notification.server_configuration
+  end
+
+  private
+
+  def symbolized_data
+    notification.data.transform_keys(&:to_sym)
+  end
+end

--- a/app/views/notifications/index.rb
+++ b/app/views/notifications/index.rb
@@ -3,15 +3,21 @@
 class Views::Notifications::Index < Views::Base
   include Phlex::Rails::Helpers::TurboFrameTag
 
-  def initialize(authorized:, server_id: nil, open: false)
+  def initialize(authorized:, server_id: nil, scope: "all", open: false)
     @authorized = authorized
     @server_id = server_id
+    @scope = scope
     @open = open
   end
 
   def view_template
     turbo_frame_tag("notifications") do
-      render Components::NotificationBell.new(authorized: @authorized, server_id: @server_id, open: @open)
+      render Components::NotificationBell.new(
+        authorized: @authorized,
+        server_id: @server_id,
+        scope: @scope,
+        open: @open
+      )
     end
   end
 end

--- a/app/views/notifications/index.rb
+++ b/app/views/notifications/index.rb
@@ -3,14 +3,15 @@
 class Views::Notifications::Index < Views::Base
   include Phlex::Rails::Helpers::TurboFrameTag
 
-  def initialize(authorized:, server_id: nil)
+  def initialize(authorized:, server_id: nil, open: false)
     @authorized = authorized
     @server_id = server_id
+    @open = open
   end
 
   def view_template
     turbo_frame_tag("notifications") do
-      render Components::NotificationBell.new(authorized: @authorized, server_id: @server_id)
+      render Components::NotificationBell.new(authorized: @authorized, server_id: @server_id, open: @open)
     end
   end
 end

--- a/app/views/notifications/index.rb
+++ b/app/views/notifications/index.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class Views::Notifications::Index < Views::Base
+  include Phlex::Rails::Helpers::TurboFrameTag
+
+  def initialize(authorized:, server_id: nil)
+    @authorized = authorized
+    @server_id = server_id
+  end
+
+  def view_template
+    turbo_frame_tag("notifications") do
+      render Components::NotificationBell.new(authorized: @authorized, server_id: @server_id)
+    end
+  end
+end

--- a/app/views/servers/index.rb
+++ b/app/views/servers/index.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Views::Servers::Index < Views::Base
-  include Components::Initials
-
   def initialize(present:, absent:, user:, plugin_counts: {}, error: false)
     @present = present
     @absent = absent
@@ -68,12 +66,7 @@ class Views::Servers::Index < Views::Base
   end
 
   def avatar(guild, muted: false)
-    dim = muted ? " opacity-60" : ""
-    if guild.icon_url
-      img(src: guild.icon_url, alt: "", loading: "lazy", class: "size-12 flex-none rounded-lg object-cover#{dim}")
-    else
-      span(class: "flex size-12 flex-none items-center justify-center rounded-lg bg-surface-sunken font-semibold text-text-secondary#{dim}") { initials(guild.name) }
-    end
+    render Components::ServerAvatar.new(server: guild, size: :lg, tone: :sunken, dim: muted)
   end
 
   def plugins_badge(count)

--- a/app/views/servers/show.rb
+++ b/app/views/servers/show.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 class Views::Servers::Show < Views::Base
-  include Phlex::Rails::Helpers::ImageTag
-  include Components::Initials
-
   def initialize(guild:, server_configuration:, plugins:, user:, servers: [], plugin_counts: {})
     @guild = guild
     @server_configuration = server_configuration
@@ -41,11 +38,7 @@ class Views::Servers::Show < Views::Base
   end
 
   def avatar
-    if @guild.icon_url
-      image_tag(@guild.icon_url, alt: "", loading: "lazy", class: "size-14 flex-none rounded-xl object-cover")
-    else
-      span(class: "flex size-14 flex-none items-center justify-center rounded-xl bg-accent-soft text-xl font-bold text-accent-soft-fg") { initials(@guild.name) }
-    end
+    render Components::ServerAvatar.new(server: @guild, size: :xl)
   end
 
   def meta_line

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -9,6 +9,7 @@ en:
     app_shell:
       add_server: Add another server
       log_out: Log out
+      notifications: Notifications
       plugins_on:
         one: "%{count} plugin on"
         other: "%{count} plugins on"
@@ -43,6 +44,16 @@ en:
             roles: Roles
           toggle_all: Toggle all
           toggle_all_label: Toggle all %{plugin} events
+    notification_bell:
+      label: Notifications
+      unread: Notifications, %{count} unread
+    notification_panel:
+      all_servers: All servers
+      empty_subtitle: Alerts about your servers will show up here.
+      empty_title: You're all caught up
+      mark_all_read: Mark all read
+      this_server: This server
+      title: Notifications
     plugin_row:
       configure: Configure
       needs_setup_hint: Complete setup before enabling this plugin.
@@ -138,6 +149,12 @@ en:
           empty: This message is off.
           label: Live preview
           timestamp: Today
+  notifications:
+    kinds:
+      channel_deleted:
+        message: "%{plugin_name} was affected — choose a new channel"
+        title: "%{channel_name} was deleted"
+        title_unknown: A channel was deleted
   servers:
     logging:
       saved: Logging settings saved.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,11 @@ Rails.application.routes.draw do
   get "/auth/failure", to: "sessions#failure"
   delete "/logout", to: "sessions#destroy", as: :logout
 
+  resources :notifications, only: [:index, :update]
+  namespace :notifications do
+    resource :read, only: :create
+  end
+
   resources :servers, only: [:index, :show], param: :id do
     resources :plugins, only: :update, param: :key, module: :servers
     scope module: :servers do

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -422,3 +422,24 @@ doesn't depend on Redis).
 
 `BotSetting` is the global KV/flags table (e.g. `owner_error_dms`) — bot-wide, string
 keys. `ServerConfiguration` is per-server. Don't confuse the two.
+
+## Notifications
+
+Notifications are written by bot-side ops (`Ops::Notifications::Create`) when a
+Discord event invalidates plugin configuration (e.g. a watched channel is deleted).
+The web side reads them cross-server, scoped to the session's authorized server ids.
+
+**Routes:** `resources :notifications, only: [:index, :update]` + a nested
+`namespace :notifications { resource :read, only: :create }`. No server nesting
+— notifications span all manageable servers.
+
+**Auth scope:** `NotificationsController` and `Notifications::ReadsController`
+include `SetsManageableServers`. The query object `AuthorizedNotifications`
+(app/presenters/) joins `server_configurations` and filters by
+`manageable_server_ids` from the session, preventing cross-server data leaks.
+An optional `server_id` param narrows to one server ("this server" scope).
+
+**Ops:** `Ops::Notifications::Dismiss` sets `dismissed_at` on a single
+notification. `Ops::Notifications::MarkRead` bulk-updates `read_at` via
+`update_all` for the caller-supplied `ServerConfiguration` objects (never raw
+ids — the controller loads and authorizes them first).

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -287,3 +287,36 @@ render Components::Icon.new("users-three", weight: :fill, class: "size-5 text-wh
 
 Plugin icons: roles → `users-three`, welcomes → `hand-waving`, logging → `scroll`,
 reminders → `bell-ringing`. Browse names at [phosphoricons.com](https://phosphoricons.com).
+
+## Notification bell
+
+The bell lives in the `Components::AppShell` top bar. It renders as an eager
+Turbo Frame (`id: "notifications"`) that loads `GET /notifications` immediately
+on page load — no data is threaded through other controllers or views. Until the
+frame resolves a placeholder bell button is shown.
+
+**Dropdown pattern:** `Components::NotificationBell` wraps the bell in a native
+`<details>` element with a `data-controller="dropdown"` summary toggle, mirroring
+the server-switcher and user-menu. The summary holds the bell icon and the
+unread-count badge (only when count > 0, solid accent fill with a surface-card
+ring). The menu target holds `Components::NotificationPanel`.
+
+**Panel layout:** header (title, "Mark all read" button_to, scope toggle) +
+scrollable body (grouped by server, or flat for the this-server scope) + empty
+state when no active notifications.
+
+**Scope toggle:** two links targeting the `notifications` frame —
+`notifications_path(server_id: <current>)` for "This server" and
+`notifications_path` (no server_id) for "All servers". Active tab = solid card
+bg + shadow; inactive = muted text.
+
+**Grouping:** "All servers" renders server-tile headers (initials tile + name)
+between groups, sorted by server name. "This server" skips the headers.
+
+**Item:** `Components::NotificationItem` renders a deep link to the plugin config
+page, a warning icon circle (full-opacity unread, 60% opacity read), title
+(hash icon prefix from the mockup), message, relative time, an unread dot on the
+left rail, and a dismiss `button_to` (PATCH to `notification_path`).
+
+**Mobile:** below `sm` the panel becomes a full-width sheet fixed under the app
+bar (CSS only — same HTML structure; no JS changes).

--- a/docs/design/ui_kits/notifications/index.html
+++ b/docs/design/ui_kits/notifications/index.html
@@ -1,0 +1,437 @@
+<!-- @dsCard group="Dashboard" viewport="1360x900" name="Notifications" subtitle="Bell + unread badge · grouped dropdown · empty & mobile states · plugin-config warning banner — light & dark" -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>shrkbot — Notifications surfaces</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" /><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Space+Grotesk:wght@500;600;700&family=Exo+2:wght@400;500;600;700&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="../../tokens/colors.css" />
+<link rel="stylesheet" href="../../tokens/spacing.css" />
+<link rel="stylesheet" href="../../tokens/motion.css" />
+<script src="https://unpkg.com/@phosphor-icons/web@2.1.1"></script>
+<script src="https://cdn.tailwindcss.com"></script>
+<script>
+/* Semantic-token Tailwind wiring — every color maps to a CSS var from
+   tokens/colors.css, so [data-theme="dark"] flips both panes for free.
+   Class names come out as bg-surface-card, text-text-primary, etc. */
+tailwind.config={theme:{extend:{
+  colors:{
+    'surface-page':'var(--surface-page)','surface-card':'var(--surface-card)','surface-raised':'var(--surface-raised)','surface-sunken':'var(--surface-sunken)',
+    'text-primary':'var(--text-primary)','text-secondary':'var(--text-secondary)','text-muted':'var(--text-muted)','text-link':'var(--text-link)',
+    'border-subtle':'var(--border-subtle)','border-default':'var(--border-default)','border-strong':'var(--border-strong)',
+    accent:'var(--accent)','accent-fill':'var(--accent-fill)','accent-soft':'var(--accent-soft)','accent-soft-bd':'var(--accent-soft-bd)','accent-soft-fg':'var(--accent-soft-fg)',
+    'accent-2-text':'var(--accent-2-text)','accent-2-soft':'var(--accent-2-soft)','accent-2-soft-bd':'var(--accent-2-soft-bd)',
+    warning:'var(--warning)','warning-soft':'var(--warning-soft-x)','warning-soft-bd':'var(--warning-soft-bd)',
+    danger:'var(--danger)','danger-soft':'var(--danger-soft-x)','danger-soft-bd':'var(--danger-soft-bd)'
+  },
+  fontFamily:{display:['"Space Grotesk"','system-ui','sans-serif'],sans:['"Exo 2"','system-ui','sans-serif'],mono:['"IBM Plex Mono"','ui-monospace','monospace']},
+  borderRadius:{sm:'5px',md:'8px',lg:'12px',xl:'16px',control:'8px',card:'12px',chip:'5px'},
+  boxShadow:{sm:'0 1px 3px rgba(29,26,21,.08),0 1px 2px rgba(29,26,21,.04)',md:'0 4px 12px rgba(29,26,21,.08),0 2px 4px rgba(29,26,21,.04)',lg:'0 12px 32px rgba(29,26,21,.18),0 4px 8px rgba(29,26,21,.08)'}
+}}};
+</script>
+<style>
+/* ── Local semantic extensions (theme-aware, mirrors dashboard kit) ── */
+:root{
+  --accent-soft-fg: var(--teal-700);            /* text on accent-soft washes */
+  --warning-soft-x: var(--amber-50);
+  --warning-soft-bd:#ecd6a6;
+  --danger-soft-x:  var(--red-50);
+  --danger-soft-bd: #eec3b8;
+  --plugin-tile:    var(--accent-fill);         /* icon identity tiles: white-text-safe teal */
+}
+[data-theme="dark"]{
+  --accent-soft-fg: #6fb3aa;
+  --warning-soft-x: rgba(232,161,58,.12);
+  --warning-soft-bd:rgba(232,161,58,.25);
+  --danger-soft-x:  rgba(224,83,61,.12);
+  --danger-soft-bd: rgba(224,83,61,.28);
+  --plugin-tile:    var(--accent);              /* dark: tiles use patina reference teal */
+}
+
+body{font-family:"Exo 2",system-ui,sans-serif;background:#161310}
+.lbl{font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--text-muted)}
+
+/* App-bar — chamfer lives on a ::before layer so dropdowns hanging below
+   the header are NOT clipped by the clip-path (same as dashboard kit). */
+.app-bar{position:relative;background:transparent}
+.app-bar::before{content:'';position:absolute;inset:0;z-index:0;background:var(--surface-card);border-bottom:1px solid var(--border-default);clip-path:polygon(0 0,100% 0,100% calc(100% - var(--chamfer,12px)),calc(100% - var(--chamfer,12px)) 100%,var(--chamfer,12px) 100%,0 calc(100% - var(--chamfer,12px)))}
+.app-bar>*{position:relative;z-index:1}
+
+/* Chamfer geometry — brand-forward surfaces only */
+.chamfer-tile{--cut:var(--chamfer,12px);clip-path:polygon(var(--cut) 0,calc(100% - var(--cut)) 0,100% var(--cut),100% calc(100% - var(--cut)),calc(100% - var(--cut)) 100%,var(--cut) 100%,0 calc(100% - var(--cut)),0 var(--cut))}
+.chamfer-tile-sm{--cut:var(--chamfer-sm,6px);clip-path:polygon(var(--cut) 0,calc(100% - var(--cut)) 0,100% var(--cut),100% calc(100% - var(--cut)),calc(100% - var(--cut)) 100%,var(--cut) 100%,0 calc(100% - var(--cut)),0 var(--cut))}
+.chamfer-cta{--cut:var(--chamfer-sm,6px);clip-path:polygon(var(--cut) 0,calc(100% - var(--cut)) 0,100% var(--cut),100% calc(100% - var(--cut)),calc(100% - var(--cut)) 100%,var(--cut) 100%,0 calc(100% - var(--cut)),0 var(--cut));border-radius:0 !important}
+
+/* ── Dropdown pattern — native <details> + .dropdown-menu panel.
+   Panel gets .anim-menu (fade + 6px slide, tokens/motion.css) each open;
+   chevron uses .dropdown-chevron rotation from tokens/motion.css. ── */
+details.dropdown{position:relative}
+details.dropdown>summary{list-style:none;cursor:pointer}
+details.dropdown>summary::-webkit-details-marker{display:none}
+details.dropdown[open]>summary>.dropdown-chevron,
+details.dropdown[open] .js-bell-chevron{transform:rotate(0deg)}
+.dropdown-menu{position:absolute;top:calc(100% + 8px);right:0;z-index:50}
+
+/* Phosphor icon sizing */
+i[class*="ph-"]{display:inline-flex;align-items:center;justify-content:center;line-height:1;flex:none;font-style:normal;vertical-align:middle}
+i[class*="ph-"].w-3{font-size:12px;min-width:12px;height:12px}
+i[class*="ph-"].w-3\.5{font-size:14px;min-width:14px;height:14px}
+i[class*="ph-"].w-4{font-size:16px;min-width:16px;height:16px}
+i[class*="ph-"].w-5{font-size:20px;min-width:20px;height:20px}
+i[class*="ph-"].w-\[18px\]{font-size:18px;min-width:18px;height:18px}
+
+/* Panel body scrollbar — quiet */
+.notif-scroll{scrollbar-width:thin;scrollbar-color:var(--border-strong) transparent}
+
+@media(prefers-reduced-motion:reduce){
+  .transition-colors,.transition{transition:none !important}
+}
+</style>
+</head>
+<body class="antialiased">
+
+<!-- ════════════════════════════════════════════════════════════════
+     LIGHT PANE — authored source of truth.
+     The DARK pane at the bottom is a JS clone under [data-theme="dark"];
+     every color below is a semantic token, so it flips automatically.
+     ════════════════════════════════════════════════════════════════ -->
+<section data-theme="light" data-pane-light class="bg-surface-page text-text-primary py-10 px-6">
+  <div class="max-w-[1200px] mx-auto">
+    <p class="font-mono text-xs text-text-muted mb-8">shrkbot · notifications surfaces — LIGHT</p>
+
+    <div data-pane-content class="flex flex-col gap-12">
+
+      <!-- ═══════════════ SURFACE 1a — APP BAR · BELL WITH UNREAD COUNT ("2") ═══════════════
+           Bell sits between the flex spacer and the theme toggle.
+           Unread count = Badge (brand variant, solid fill) ringed with the bar surface. -->
+      <div>
+        <span class="lbl">Surface 1 — bell in app bar · unread count "2"</span>
+        <header class="app-bar h-16 mt-3 flex items-center gap-3 px-5">
+          <a href="#" class="flex items-center gap-2">
+            <img src="../../assets/shrkbot-mascot.png" alt="" class="w-9 h-9 chamfer-tile-sm" />
+            <span class="font-display text-lg font-bold tracking-tight"><span class="text-accent-fill">shrk</span><span class="text-accent-2-text">bot</span></span>
+          </a>
+          <!-- server switcher (context only — closed state, .dropdown-chevron points left when closed) -->
+          <button class="h-10 flex items-center gap-2 pl-1.5 pr-3 rounded-md border border-border-default hover:bg-surface-sunken transition-colors ml-1">
+            <span class="w-7 h-7 rounded-md bg-accent-soft text-accent-soft-fg grid place-items-center text-xs font-bold flex-none">DR</span>
+            <span class="text-sm font-semibold">Dev Refuge</span>
+            <i class="ph ph-caret-down dropdown-chevron w-4 h-4 text-text-muted"></i>
+          </button>
+
+          <div class="flex-1"></div>
+
+          <!-- NOTIFICATION BELL · unread -->
+          <details class="dropdown">
+            <summary class="relative w-9 h-9 rounded-md hover:bg-surface-sunken grid place-items-center text-text-secondary transition-colors" aria-label="Notifications, 2 unread">
+              <i class="ph ph-bell w-5 h-5"></i>
+              <!-- unread-count Badge — brand solid; ring cuts it against the bar -->
+              <span class="absolute top-0.5 right-0.5 min-w-[16px] h-4 px-1 rounded-full bg-accent-fill text-white text-[10px] leading-4 font-bold text-center" style="box-shadow:0 0 0 2px var(--surface-card)">2</span>
+            </summary>
+            <!-- (panel omitted here — see Surface 2 below for the open rendering) -->
+            <div class="dropdown-menu anim-menu w-[380px] bg-surface-card border border-border-default rounded-lg shadow-lg p-6 text-sm text-text-secondary">Panel — see Surface 2.</div>
+          </details>
+
+          <!-- theme toggle -->
+          <button class="w-9 h-9 rounded-md hover:bg-surface-sunken grid place-items-center text-text-secondary transition-colors" aria-label="Toggle dark mode"><i class="ph ph-moon js-theme-icon w-5 h-5"></i></button>
+
+          <!-- user menu (context only) -->
+          <button class="flex items-center gap-2 h-10 pl-1 pr-2.5 rounded-full hover:bg-surface-sunken transition-colors">
+            <span class="w-8 h-8 rounded-full bg-accent-soft text-accent-soft-fg grid place-items-center text-xs font-bold">bb</span>
+            <span class="text-sm font-medium">badBlackShark</span>
+            <i class="ph ph-caret-down dropdown-chevron w-4 h-4 text-text-muted"></i>
+          </button>
+        </header>
+      </div>
+
+      <!-- ═══════════════ SURFACE 1b — APP BAR · BELL WITH NO UNREAD ═══════════════ -->
+      <div>
+        <span class="lbl">Surface 1 — bell in app bar · no unread</span>
+        <header class="app-bar h-16 mt-3 flex items-center gap-3 px-5">
+          <a href="#" class="flex items-center gap-2">
+            <img src="../../assets/shrkbot-mascot.png" alt="" class="w-9 h-9 chamfer-tile-sm" />
+            <span class="font-display text-lg font-bold tracking-tight"><span class="text-accent-fill">shrk</span><span class="text-accent-2-text">bot</span></span>
+          </a>
+          <button class="h-10 flex items-center gap-2 pl-1.5 pr-3 rounded-md border border-border-default hover:bg-surface-sunken transition-colors ml-1">
+            <span class="w-7 h-7 rounded-md bg-accent-soft text-accent-soft-fg grid place-items-center text-xs font-bold flex-none">DR</span>
+            <span class="text-sm font-semibold">Dev Refuge</span>
+            <i class="ph ph-caret-down dropdown-chevron w-4 h-4 text-text-muted"></i>
+          </button>
+          <div class="flex-1"></div>
+          <!-- NOTIFICATION BELL · no badge -->
+          <button class="w-9 h-9 rounded-md hover:bg-surface-sunken grid place-items-center text-text-secondary transition-colors" aria-label="Notifications"><i class="ph ph-bell w-5 h-5"></i></button>
+          <button class="w-9 h-9 rounded-md hover:bg-surface-sunken grid place-items-center text-text-secondary transition-colors" aria-label="Toggle dark mode"><i class="ph ph-moon js-theme-icon w-5 h-5"></i></button>
+          <button class="flex items-center gap-2 h-10 pl-1 pr-2.5 rounded-full hover:bg-surface-sunken transition-colors">
+            <span class="w-8 h-8 rounded-full bg-accent-soft text-accent-soft-fg grid place-items-center text-xs font-bold">bb</span>
+            <span class="text-sm font-medium">badBlackShark</span>
+            <i class="ph ph-caret-down dropdown-chevron w-4 h-4 text-text-muted"></i>
+          </button>
+        </header>
+      </div>
+
+      <!-- ═══════════════ SURFACE 2a — BELL DROPDOWN · OPEN, GROUPED BY SERVER ═══════════════
+           Native <details open> — panel hangs below the .app-bar unclipped
+           (chamfer is on ::before, not the header box). Pinned open for review;
+           clicking the bell still toggles it. Toggle shown set to "This server"
+           per spec; server grouping is how the "All servers" scope renders. -->
+      <div>
+        <span class="lbl">Surface 2 — dropdown panel · open · two server groups · read/unread mix</span>
+        <div class="relative mt-3 pb-[470px]">
+          <header class="app-bar h-16 flex items-center gap-3 px-5">
+            <a href="#" class="flex items-center gap-2">
+              <img src="../../assets/shrkbot-mascot.png" alt="" class="w-9 h-9 chamfer-tile-sm" />
+              <span class="font-display text-lg font-bold tracking-tight"><span class="text-accent-fill">shrk</span><span class="text-accent-2-text">bot</span></span>
+            </a>
+            <div class="flex-1"></div>
+
+            <details class="dropdown" data-pinned open>
+              <summary class="relative w-9 h-9 rounded-md bg-surface-sunken grid place-items-center text-text-primary transition-colors" aria-label="Notifications, 2 unread">
+                <i class="ph ph-bell w-5 h-5"></i>
+                <span class="absolute top-0.5 right-0.5 min-w-[16px] h-4 px-1 rounded-full bg-accent-fill text-white text-[10px] leading-4 font-bold text-center" style="box-shadow:0 0 0 2px var(--surface-card)">2</span>
+              </summary>
+
+              <!-- THE PANEL (.dropdown-menu) — ~380px, internal scroll -->
+              <div class="dropdown-menu anim-menu w-[380px] max-w-[calc(100vw-2rem)] bg-surface-card border border-border-default rounded-lg shadow-lg overflow-hidden">
+
+                <!-- panel header: title · mark-all-read · scope toggle -->
+                <div class="px-4 pt-3.5 pb-3 border-b border-border-subtle flex flex-col gap-2.5">
+                  <div class="flex items-center justify-between">
+                    <h3 class="font-display text-sm font-bold tracking-tight">Notifications</h3>
+                    <button class="text-xs font-semibold text-text-link hover:underline">Mark all read</button>
+                  </div>
+                  <!-- segmented scope toggle — "This server" active -->
+                  <div class="inline-flex self-start p-0.5 rounded-md bg-surface-sunken text-xs">
+                    <button class="px-2.5 py-1 rounded-[6px] bg-surface-card shadow-sm font-semibold text-text-primary">This server</button>
+                    <button class="px-2.5 py-1 rounded-[6px] font-medium text-text-secondary hover:text-text-primary transition-colors">All servers</button>
+                  </div>
+                </div>
+
+                <!-- scrollable body, grouped by server -->
+                <div class="notif-scroll max-h-[330px] overflow-y-auto">
+
+                  <!-- ── server group: Dev Refuge ── -->
+                  <div class="flex items-center gap-2 px-4 pt-3 pb-1.5">
+                    <span class="w-5 h-5 rounded-[5px] bg-accent-soft text-accent-soft-fg grid place-items-center text-[9px] font-bold flex-none">DR</span>
+                    <span class="text-[11px] font-semibold text-text-secondary">Dev Refuge</span>
+                  </div>
+                  <ul>
+                    <!-- item · UNREAD (accent dot on left edge, full-strength text) -->
+                    <li class="relative group/item">
+                      <a href="#" class="flex gap-3 pl-5 pr-9 py-3 hover:bg-surface-sunken transition-colors">
+                        <span class="absolute left-[7px] top-[27px] w-1.5 h-1.5 rounded-full bg-accent" aria-label="Unread"></span>
+                        <span class="w-8 h-8 rounded-full bg-warning-soft grid place-items-center flex-none"><i class="ph ph-warning w-4 h-4 text-warning"></i></span>
+                        <span class="flex-1 min-w-0">
+                          <span class="block text-[13px] font-semibold text-text-primary leading-snug"><i class="ph ph-hash w-3 h-3 text-text-muted"></i>general was deleted</span>
+                          <span class="block text-xs text-text-secondary mt-0.5 leading-snug">Logging was affected — choose a new channel</span>
+                          <span class="block text-[11px] text-text-muted mt-1">2h ago</span>
+                        </span>
+                      </a>
+                      <button class="absolute right-2 top-1/2 -translate-y-1/2 w-6 h-6 rounded-md grid place-items-center text-text-muted hover:text-text-primary hover:bg-surface-raised transition-colors" aria-label="Dismiss"><i class="ph ph-x w-3.5 h-3.5"></i></button>
+                    </li>
+                    <!-- item · READ (muted, no dot) -->
+                    <li class="relative group/item">
+                      <a href="#" class="flex gap-3 pl-5 pr-9 py-3 hover:bg-surface-sunken transition-colors">
+                        <span class="w-8 h-8 rounded-full bg-warning-soft opacity-60 grid place-items-center flex-none"><i class="ph ph-warning w-4 h-4 text-warning"></i></span>
+                        <span class="flex-1 min-w-0">
+                          <span class="block text-[13px] font-medium text-text-secondary leading-snug"><i class="ph ph-hash w-3 h-3 text-text-muted"></i>welcome-hall was deleted</span>
+                          <span class="block text-xs text-text-muted mt-0.5 leading-snug">Welcomes was affected — choose a new channel</span>
+                          <span class="block text-[11px] text-text-muted mt-1">1d ago</span>
+                        </span>
+                      </a>
+                      <button class="absolute right-2 top-1/2 -translate-y-1/2 w-6 h-6 rounded-md grid place-items-center text-text-muted hover:text-text-primary hover:bg-surface-raised transition-colors" aria-label="Dismiss"><i class="ph ph-x w-3.5 h-3.5"></i></button>
+                    </li>
+                  </ul>
+
+                  <!-- ── server group: ShellShock Live ── -->
+                  <div class="flex items-center gap-2 px-4 pt-3 pb-1.5 border-t border-border-subtle mt-1">
+                    <span class="w-5 h-5 rounded-[5px] bg-surface-sunken text-text-secondary grid place-items-center text-[9px] font-bold flex-none">SS</span>
+                    <span class="text-[11px] font-semibold text-text-secondary">ShellShock Live Community Discord</span>
+                  </div>
+                  <ul>
+                    <!-- item · UNREAD — hover state FORCED for illustration (bg-surface-sunken) -->
+                    <li class="relative group/item">
+                      <a href="#" class="flex gap-3 pl-5 pr-9 py-3 bg-surface-sunken transition-colors">
+                        <span class="absolute left-[7px] top-[27px] w-1.5 h-1.5 rounded-full bg-accent" aria-label="Unread"></span>
+                        <span class="w-8 h-8 rounded-full bg-warning-soft grid place-items-center flex-none"><i class="ph ph-warning w-4 h-4 text-warning"></i></span>
+                        <span class="flex-1 min-w-0">
+                          <span class="block text-[13px] font-semibold text-text-primary leading-snug"><i class="ph ph-hash w-3 h-3 text-text-muted"></i>tourney-announcements was deleted</span>
+                          <span class="block text-xs text-text-secondary mt-0.5 leading-snug">Logging was affected — choose a new channel</span>
+                          <span class="block text-[11px] text-text-muted mt-1">3d ago</span>
+                        </span>
+                      </a>
+                      <button class="absolute right-2 top-1/2 -translate-y-1/2 w-6 h-6 rounded-md grid place-items-center text-text-muted hover:text-text-primary hover:bg-surface-raised transition-colors" aria-label="Dismiss"><i class="ph ph-x w-3.5 h-3.5"></i></button>
+                    </li>
+                  </ul>
+                  <div class="h-2"></div>
+                </div>
+              </div>
+            </details>
+
+            <button class="w-9 h-9 rounded-md hover:bg-surface-sunken grid place-items-center text-text-secondary transition-colors" aria-label="Toggle dark mode"><i class="ph ph-moon js-theme-icon w-5 h-5"></i></button>
+            <button class="flex items-center gap-2 h-10 pl-1 pr-2.5 rounded-full hover:bg-surface-sunken transition-colors">
+              <span class="w-8 h-8 rounded-full bg-accent-soft text-accent-soft-fg grid place-items-center text-xs font-bold">bb</span>
+              <span class="text-sm font-medium">badBlackShark</span>
+              <i class="ph ph-caret-down dropdown-chevron w-4 h-4 text-text-muted"></i>
+            </button>
+          </header>
+        </div>
+      </div>
+
+      <!-- ═══════════════ SURFACE 2b + 2c — EMPTY STATE · MOBILE SHEET ═══════════════ -->
+      <div class="flex flex-wrap items-start gap-10">
+
+        <!-- SURFACE 2b — empty state ("You're all caught up") — panel rendered standalone -->
+        <div>
+          <span class="lbl">Surface 2 — empty state</span>
+          <div class="mt-3 w-[380px] bg-surface-card border border-border-default rounded-lg shadow-lg overflow-hidden">
+            <div class="px-4 pt-3.5 pb-3 border-b border-border-subtle flex flex-col gap-2.5">
+              <div class="flex items-center justify-between">
+                <h3 class="font-display text-sm font-bold tracking-tight">Notifications</h3>
+              </div>
+              <div class="inline-flex self-start p-0.5 rounded-md bg-surface-sunken text-xs">
+                <button class="px-2.5 py-1 rounded-[6px] bg-surface-card shadow-sm font-semibold text-text-primary">This server</button>
+                <button class="px-2.5 py-1 rounded-[6px] font-medium text-text-secondary hover:text-text-primary transition-colors">All servers</button>
+              </div>
+            </div>
+            <div class="py-10 px-6 text-center">
+              <span class="w-10 h-10 rounded-full bg-surface-sunken grid place-items-center mx-auto"><i class="ph ph-bell w-5 h-5 text-text-muted"></i></span>
+              <p class="text-sm font-semibold mt-3">You're all caught up</p>
+              <p class="text-xs text-text-muted mt-1">Alerts about your servers will show up here.</p>
+            </div>
+          </div>
+        </div>
+
+        <!-- SURFACE 2c — narrow/mobile rendering.
+             Below the sm breakpoint the panel stops hugging the bell (right:0)
+             and becomes an edge-to-edge sheet pinned under the .app-bar:
+             position:fixed; left:0; right:0; top:<bar height>; max-height:70vh;
+             square top corners, rounded bottom, same internal scroll. -->
+        <div>
+          <span class="lbl">Surface 2 — narrow viewport · full-width sheet under the bar</span>
+          <div class="mt-3 w-[390px] border border-border-strong rounded-xl overflow-hidden bg-surface-page shadow-md">
+            <header class="app-bar h-14 flex items-center gap-2 px-4">
+              <img src="../../assets/shrkbot-mascot.png" alt="" class="w-8 h-8 chamfer-tile-sm" />
+              <span class="font-display text-base font-bold tracking-tight"><span class="text-accent-fill">shrk</span><span class="text-accent-2-text">bot</span></span>
+              <div class="flex-1"></div>
+              <button class="relative w-9 h-9 rounded-md bg-surface-sunken grid place-items-center text-text-primary" aria-label="Notifications, 2 unread">
+                <i class="ph ph-bell w-5 h-5"></i>
+                <span class="absolute top-0.5 right-0.5 min-w-[16px] h-4 px-1 rounded-full bg-accent-fill text-white text-[10px] leading-4 font-bold text-center" style="box-shadow:0 0 0 2px var(--surface-card)">2</span>
+              </button>
+              <span class="w-8 h-8 rounded-full bg-accent-soft text-accent-soft-fg grid place-items-center text-xs font-bold">bb</span>
+            </header>
+            <!-- the sheet: full-width, pinned under the bar -->
+            <div class="bg-surface-card border-b border-border-default shadow-lg rounded-b-lg">
+              <div class="px-4 pt-3.5 pb-3 border-b border-border-subtle flex items-center justify-between">
+                <h3 class="font-display text-sm font-bold tracking-tight">Notifications</h3>
+                <button class="text-xs font-semibold text-text-link hover:underline">Mark all read</button>
+              </div>
+              <div class="flex items-center gap-2 px-4 pt-3 pb-1.5">
+                <span class="w-5 h-5 rounded-[5px] bg-accent-soft text-accent-soft-fg grid place-items-center text-[9px] font-bold flex-none">DR</span>
+                <span class="text-[11px] font-semibold text-text-secondary">Dev Refuge</span>
+              </div>
+              <ul>
+                <li class="relative">
+                  <a href="#" class="flex gap-3 pl-5 pr-9 py-3 hover:bg-surface-sunken transition-colors">
+                    <span class="absolute left-[7px] top-[27px] w-1.5 h-1.5 rounded-full bg-accent" aria-label="Unread"></span>
+                    <span class="w-8 h-8 rounded-full bg-warning-soft grid place-items-center flex-none"><i class="ph ph-warning w-4 h-4 text-warning"></i></span>
+                    <span class="flex-1 min-w-0">
+                      <span class="block text-[13px] font-semibold text-text-primary leading-snug"><i class="ph ph-hash w-3 h-3 text-text-muted"></i>general was deleted</span>
+                      <span class="block text-xs text-text-secondary mt-0.5 leading-snug">Logging was affected — choose a new channel</span>
+                      <span class="block text-[11px] text-text-muted mt-1">2h ago</span>
+                    </span>
+                  </a>
+                  <button class="absolute right-2 top-1/2 -translate-y-1/2 w-6 h-6 rounded-md grid place-items-center text-text-muted hover:text-text-primary hover:bg-surface-raised transition-colors" aria-label="Dismiss"><i class="ph ph-x w-3.5 h-3.5"></i></button>
+                </li>
+              </ul>
+              <div class="h-2"></div>
+            </div>
+            <div class="h-24"></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ═══════════════ SURFACE 3 — PLUGIN CONFIG · INLINE WARNING BANNER ═══════════════
+           Callout (warning) at the top of the Logging settings form.
+           "Choose a new channel below" reads as an inline link to the picker. -->
+      <div>
+        <span class="lbl">Surface 3 — plugin config · channel-deleted warning banner</span>
+        <div class="mt-3 max-w-2xl">
+          <!-- plugin header (context) -->
+          <div class="flex items-start gap-4 mb-5">
+            <span class="w-12 h-12 chamfer-tile text-white grid place-items-center flex-none" style="background:var(--plugin-tile)"><i class="ph ph-scroll w-5 h-5"></i></span>
+            <div class="flex-1">
+              <div class="flex items-center gap-2 flex-wrap">
+                <h1 class="font-display text-2xl font-bold tracking-tight">Logging</h1>
+                <!-- Badge · warning variant with dot -->
+                <span class="inline-flex items-center gap-1.5 text-xs font-semibold text-warning bg-warning-soft px-2.5 py-1 rounded-chip"><span class="w-1.5 h-1.5 rounded-full bg-warning"></span>Needs attention</span>
+              </div>
+              <p class="text-sm text-text-secondary mt-0.5">Record moderation events to a channel of your choice.</p>
+            </div>
+          </div>
+
+          <div class="bg-surface-card border border-border-default rounded-card shadow-sm p-5 flex flex-col gap-4">
+            <!-- THE BANNER — Callout (warning) -->
+            <div class="flex gap-3 bg-warning-soft border border-warning-soft-bd rounded-md px-4 py-3">
+              <i class="ph ph-warning w-[18px] h-[18px] text-warning flex-none mt-0.5"></i>
+              <p class="text-sm leading-relaxed text-text-primary">The channel you configured for Logging was deleted. <a href="#" class="font-semibold text-text-link underline underline-offset-2 hover:no-underline">Choose a new channel below</a> to keep it working.</p>
+            </div>
+
+            <!-- setting row: the channel picker the banner points at -->
+            <div>
+              <label class="block text-sm font-semibold mb-1.5">Log channel</label>
+              <div class="h-10 px-3 rounded-control border-[1.5px] border-border-strong bg-surface-card flex items-center gap-2 text-sm w-64 cursor-pointer">
+                <span class="font-mono text-text-muted">#</span>
+                <span class="text-text-muted">Choose a channel…</span>
+                <i class="ph ph-caret-down w-4 h-4 text-text-muted ml-auto"></i>
+              </div>
+              <p class="text-xs text-text-muted mt-1.5">Moderation events will be posted here.</p>
+            </div>
+
+            <div class="flex justify-end border-t border-border-subtle pt-4">
+              <button class="h-10 px-4 inline-flex items-center chamfer-cta bg-accent-fill hover:brightness-110 text-white text-sm font-semibold transition">Save changes</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+    </div><!-- /pane-content -->
+  </div>
+</section>
+
+<!-- ════════════════════════════════════════════════════════════════
+     DARK PANE — same markup cloned under [data-theme="dark"];
+     semantic tokens flip everything (espresso surfaces, patina teal,
+     copper eyebrows, translucent warning washes).
+     ════════════════════════════════════════════════════════════════ -->
+<section data-theme="dark" data-pane-dark class="bg-surface-page text-text-primary py-10 px-6">
+  <div class="max-w-[1200px] mx-auto">
+    <p class="font-mono text-xs text-text-muted mb-8">shrkbot · notifications surfaces — DARK</p>
+    <div data-pane-slot></div>
+  </div>
+</section>
+
+<script>
+// Clone the light pane's content into the dark pane so both stay identical.
+(function(){
+  var src = document.querySelector('[data-pane-content]');
+  var slot = document.querySelector('[data-pane-slot]');
+  var clone = src.cloneNode(true);
+  clone.removeAttribute('data-pane-content');
+  // theme toggle shows sun in dark mode
+  clone.querySelectorAll('.js-theme-icon').forEach(function(i){ i.classList.remove('ph-moon'); i.classList.add('ph-sun'); });
+  slot.appendChild(clone);
+})();
+
+// Close open dropdowns on outside click / Escape (pinned demos stay open).
+document.addEventListener('click', function(e){
+  document.querySelectorAll('details.dropdown[open]:not([data-pinned])').forEach(function(d){
+    if(!d.contains(e.target)) d.removeAttribute('open');
+  });
+});
+document.addEventListener('keydown', function(e){
+  if(e.key === 'Escape') document.querySelectorAll('details.dropdown[open]:not([data-pinned])').forEach(function(d){ d.removeAttribute('open'); });
+});
+</script>
+</body>
+</html>

--- a/spec/components/notification_bell_spec.rb
+++ b/spec/components/notification_bell_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::NotificationBell do
+  include_context "component view context"
+
+  let(:config) { create(:server_configuration) }
+  let(:manageable_ids) { [config.discord_id] }
+  let(:authorized) { AuthorizedNotifications.new(manageable_ids:) }
+
+  subject(:html) { described_class.new(authorized:).render_in(view_context) }
+
+  context "when unread_count is zero" do
+    it "renders the bell aria-label without a count" do
+      expect(html).to include("aria-label")
+      expect(html).not_to include("unread notification")
+    end
+
+    it "does not render the unread badge" do
+      # The badge span has a distinctive class that only appears when count > 0
+      expect(html).not_to include("bg-accent-fill")
+    end
+  end
+
+  context "when there are unread notifications" do
+    let!(:notification) do
+      create(
+        :notification,
+        server_configuration: config,
+        read_at: nil,
+        data: {"plugin_key" => "logging", "plugin_name" => "Logging", "channel_name" => "general"}
+      )
+    end
+
+    it "renders the unread badge" do
+      expect(html).to include("bg-accent-fill")
+    end
+
+    it "renders the notification count in the badge" do
+      expect(html).to include("1")
+    end
+
+    it "includes the summary element with aria-label" do
+      expect(html).to include("aria-label")
+    end
+  end
+end

--- a/spec/components/notification_item_spec.rb
+++ b/spec/components/notification_item_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::NotificationItem do
+  include_context "component view context"
+
+  let(:config) { create(:server_configuration) }
+  let(:notification_data) { {"plugin_key" => "logging", "plugin_name" => "Logging", "channel_name" => "general"} }
+
+  subject(:html) { described_class.new(presenter:, server_id: config.discord_id).render_in(view_context) }
+
+  context "when the notification is unread" do
+    let(:notification) { create(:notification, server_configuration: config, read_at: nil, data: notification_data) }
+    let(:presenter) { NotificationPresenter.new(notification) }
+
+    it "renders the title with bold styling" do
+      expect(html).to include("font-semibold text-text-primary")
+    end
+
+    it "renders the message with secondary text styling" do
+      expect(html).to include("text-text-secondary")
+    end
+
+    it "renders the icon circle with full opacity" do
+      expect(html).to include("bg-warning-soft")
+      expect(html).not_to include("opacity-60")
+    end
+
+    it "renders the notification title text" do
+      expect(html).to include("general was deleted")
+    end
+
+    it "renders the dismiss button" do
+      expect(html).to include("Dismiss")
+    end
+
+    it "renders a deep-link href to the logging plugin page" do
+      expect(html).to include("/servers/#{config.discord_id}/logging")
+    end
+  end
+
+  context "when the notification is read" do
+    let(:notification) { create(:notification, server_configuration: config, read_at: Time.current, data: notification_data) }
+    let(:presenter) { NotificationPresenter.new(notification) }
+
+    it "renders the title with muted styling" do
+      expect(html).to include("font-medium text-text-secondary")
+    end
+
+    it "renders the message with muted text styling" do
+      expect(html).to include("text-text-muted")
+    end
+
+    it "renders the icon circle with reduced opacity" do
+      expect(html).to include("opacity-60")
+    end
+
+    it "renders the notification title text" do
+      expect(html).to include("general was deleted")
+    end
+
+    it "renders the dismiss button" do
+      expect(html).to include("Dismiss")
+    end
+
+    it "renders a deep-link href to the logging plugin page" do
+      expect(html).to include("/servers/#{config.discord_id}/logging")
+    end
+  end
+end

--- a/spec/components/notification_panel_spec.rb
+++ b/spec/components/notification_panel_spec.rb
@@ -41,4 +41,38 @@ RSpec.describe Components::NotificationPanel do
       expect(html).to include("general was deleted")
     end
   end
+
+  context "when rendered in all-servers scope (server_id: nil) with grouped notifications" do
+    let(:config_a) { create(:server_configuration, name: "Alpha Server") }
+    let(:config_b) { create(:server_configuration, name: "Beta Server", icon_hash: "abc123hash") }
+    let(:manageable_ids) { [config_a.discord_id, config_b.discord_id] }
+    let(:notification_data) { {"plugin_key" => "logging", "plugin_name" => "Logging", "channel_name" => "general"} }
+    let!(:notification_a) { create(:notification, server_configuration: config_a, data: notification_data) }
+    let!(:notification_b) { create(:notification, server_configuration: config_b, data: notification_data) }
+
+    subject(:html) { described_class.new(authorized:).render_in(view_context) }
+
+    it "renders grouped notifications for all servers" do
+      expect(html).to include("general was deleted")
+    end
+
+    it "renders the mark-all-read button when items exist" do
+      expect(html).to include("Mark all read")
+    end
+
+    it "renders server group headers" do
+      expect(html).to include("Alpha Server")
+      expect(html).to include("Beta Server")
+    end
+
+    it "renders an img tag for a server with an icon_hash" do
+      expect(html).to include("<img")
+      expect(html).to include("abc123hash")
+    end
+
+    it "renders initials fallback for a server without an icon_hash" do
+      # config_a has no icon_hash — falls back to initials span
+      expect(html).to include("bg-accent-soft")
+    end
+  end
 end

--- a/spec/components/notification_panel_spec.rb
+++ b/spec/components/notification_panel_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::NotificationPanel do
+  include_context "component view context"
+
+  let(:manageable_ids) { [] }
+  let(:authorized) { AuthorizedNotifications.new(manageable_ids:) }
+
+  subject(:html) { described_class.new(authorized:).render_in(view_context) }
+
+  it "renders the panel title" do
+    expect(html).to include("Notifications")
+  end
+
+  context "when there are no notifications" do
+    it "renders the empty state" do
+      expect(html).to include("You&#39;re all caught up").or include("You're all caught up")
+    end
+
+    it "renders the empty subtitle" do
+      expect(html).to include("Alerts about your servers will show up here")
+    end
+
+    it "does not render the mark-all-read button" do
+      expect(html).not_to include("Mark all read")
+    end
+  end
+
+  context "when there are notifications" do
+    let(:config) { create(:server_configuration, name: "Dev Server") }
+    let(:manageable_ids) { [config.discord_id] }
+    let!(:notification) { create(:notification, server_configuration: config, data: {"plugin_key" => "logging", "plugin_name" => "Logging", "channel_name" => "general"}) }
+
+    it "renders the mark-all-read button" do
+      expect(html).to include("Mark all read")
+    end
+
+    it "renders the notification title" do
+      expect(html).to include("general was deleted")
+    end
+  end
+end

--- a/spec/components/server_avatar_spec.rb
+++ b/spec/components/server_avatar_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::ServerAvatar do
+  include_context "component view context"
+
+  let(:server_with_icon) { double("server", name: "Alpha Server", icon_url: "https://cdn.example.com/abc.png") }
+  let(:server_no_icon) { double("server", name: "Beta Server", icon_url: nil) }
+
+  subject(:html) { described_class.new(server: server_with_icon, size: :md).render_in(view_context) }
+
+  context "when the server has an icon_url" do
+    it "renders an img tag with the icon src" do
+      expect(html).to include("<img")
+      expect(html).to include("https://cdn.example.com/abc.png")
+    end
+
+    it "applies the correct size and radius classes for :md" do
+      expect(html).to include("size-8")
+      expect(html).to include("rounded-md")
+    end
+
+    it "does not render an initials span" do
+      expect(html).not_to include("<span")
+    end
+  end
+
+  context "when the server has no icon_url" do
+    subject(:html) { described_class.new(server: server_no_icon, size: :md).render_in(view_context) }
+
+    it "renders an initials span" do
+      expect(html).to include("<span")
+      expect(html).to include("BS")
+    end
+
+    it "does not render an img tag" do
+      expect(html).not_to include("<img")
+    end
+  end
+
+  context "size variants" do
+    it "applies xs size classes" do
+      html = described_class.new(server: server_with_icon, size: :xs).render_in(view_context)
+      expect(html).to include("size-5")
+      expect(html).to include("rounded-[5px]")
+    end
+
+    it "applies sm size classes" do
+      html = described_class.new(server: server_with_icon, size: :sm).render_in(view_context)
+      expect(html).to include("size-7")
+      expect(html).to include("rounded-md")
+    end
+
+    it "applies lg size classes for no-icon fallback" do
+      html = described_class.new(server: server_no_icon, size: :lg).render_in(view_context)
+      expect(html).to include("size-12")
+      expect(html).to include("rounded-lg")
+    end
+
+    it "applies xl size classes for no-icon fallback" do
+      html = described_class.new(server: server_no_icon, size: :xl).render_in(view_context)
+      expect(html).to include("size-14")
+      expect(html).to include("rounded-xl")
+      expect(html).to include("text-xl")
+    end
+  end
+
+  context "tone variants" do
+    it "uses accent tone classes by default" do
+      html = described_class.new(server: server_no_icon, size: :md).render_in(view_context)
+      expect(html).to include("bg-accent-soft")
+      expect(html).to include("text-accent-soft-fg")
+      expect(html).to include("font-bold")
+    end
+
+    it "uses sunken tone classes when tone: :sunken" do
+      html = described_class.new(server: server_no_icon, size: :md, tone: :sunken).render_in(view_context)
+      expect(html).to include("bg-surface-sunken")
+      expect(html).to include("text-text-secondary")
+      expect(html).to include("font-semibold")
+    end
+  end
+
+  context "dim: true" do
+    it "adds opacity-60 to img when dim" do
+      html = described_class.new(server: server_with_icon, size: :md, dim: true).render_in(view_context)
+      expect(html).to include("opacity-60")
+    end
+
+    it "adds opacity-60 to initials span when dim" do
+      html = described_class.new(server: server_no_icon, size: :md, dim: true).render_in(view_context)
+      expect(html).to include("opacity-60")
+    end
+
+    it "does not add opacity-60 when dim is false" do
+      html = described_class.new(server: server_with_icon, size: :md, dim: false).render_in(view_context)
+      expect(html).not_to include("opacity-60")
+    end
+  end
+end

--- a/spec/operations/notifications/dismiss_spec.rb
+++ b/spec/operations/notifications/dismiss_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Ops::Notifications::Dismiss do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:notification) { create(:notification) }
+
+  subject(:result) { described_class.call(notification:) }
+
+  it "sets dismissed_at" do
+    travel_to(Time.current) do
+      result
+      expect(notification.reload.dismissed_at).to eq(Time.current)
+    end
+  end
+
+  it "returns the notification in result.value" do
+    expect(result.value).to eq(notification)
+  end
+
+  it "returns a success result" do
+    expect(result).to be_success
+  end
+end

--- a/spec/operations/notifications/mark_read_spec.rb
+++ b/spec/operations/notifications/mark_read_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Ops::Notifications::MarkRead do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:config) { create(:server_configuration) }
+  let!(:unread) { create(:notification, server_configuration: config) }
+  let!(:already_read) { create(:notification, server_configuration: config, read_at: 1.hour.ago) }
+
+  subject(:result) { described_class.call(server_configurations: [config]) }
+
+  it "returns a success result" do
+    expect(result).to be_success
+  end
+
+  it "sets read_at on unread notifications" do
+    travel_to(Time.current) do
+      result
+      expect(unread.reload.read_at).to eq(Time.current)
+    end
+  end
+
+  it "does not change already-read notifications" do
+    original_read_at = already_read.read_at
+    result
+    expect(already_read.reload.read_at).to eq(original_read_at)
+  end
+
+  context "with notifications from a different server" do
+    let(:other_config) { create(:server_configuration) }
+    let!(:other_notification) { create(:notification, server_configuration: other_config) }
+
+    it "does not mark notifications from other servers" do
+      result
+      expect(other_notification.reload.read_at).to be_nil
+    end
+  end
+end

--- a/spec/presenters/authorized_notifications_spec.rb
+++ b/spec/presenters/authorized_notifications_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AuthorizedNotifications do
+  let(:config_a) { create(:server_configuration, name: "Bravo Server") }
+  let(:config_b) { create(:server_configuration, name: "Alpha Server") }
+  let(:config_other) { create(:server_configuration) }
+
+  let!(:notif_a1) { create(:notification, server_configuration: config_a) }
+  let!(:notif_a2) { create(:notification, server_configuration: config_a) }
+  let!(:notif_b1) { create(:notification, server_configuration: config_b) }
+  let!(:notif_other) { create(:notification, server_configuration: config_other) }
+
+  let(:manageable_ids) { [config_a.discord_id, config_b.discord_id] }
+
+  subject(:authorized) { described_class.new(manageable_ids:) }
+
+  describe "#groups" do
+    it "excludes notifications from non-authorized servers" do
+      all_notifications = authorized.groups.flat_map { |_c, ns| ns }
+      expect(all_notifications).not_to include(notif_other)
+    end
+
+    it "includes notifications from authorized servers" do
+      all_notifications = authorized.groups.flat_map { |_c, ns| ns }
+      expect(all_notifications).to include(notif_a1, notif_a2, notif_b1)
+    end
+
+    it "groups by server configuration" do
+      groups = authorized.groups
+      expect(groups.map { |c, _| c }).to contain_exactly(config_a, config_b)
+    end
+
+    it "orders groups by server name alphabetically" do
+      groups = authorized.groups
+      expect(groups.map { |c, _| c.name }).to eq(["Alpha Server", "Bravo Server"])
+    end
+
+    context "when scoped to a server_id" do
+      subject(:scoped) { described_class.new(manageable_ids:, server_id: config_a.discord_id) }
+
+      it "returns one group for that server" do
+        expect(scoped.groups.length).to eq(1)
+      end
+
+      it "returns only notifications for that server" do
+        notifications = scoped.groups.flat_map { |_c, ns| ns }
+        expect(notifications).to all(have_attributes(server_configuration: config_a))
+      end
+
+      it "returns empty when the server_id is not manageable" do
+        other_scoped = described_class.new(manageable_ids:, server_id: config_other.discord_id)
+        expect(other_scoped.groups).to be_empty
+      end
+    end
+
+    context "when a notification is dismissed" do
+      before { notif_a1.update!(dismissed_at: Time.current) }
+
+      it "excludes dismissed notifications" do
+        all_notifications = authorized.groups.flat_map { |_c, ns| ns }
+        expect(all_notifications).not_to include(notif_a1)
+      end
+    end
+  end
+
+  describe "#unread_count" do
+    it "counts unread notifications across authorized servers" do
+      expect(authorized.unread_count).to eq(3)
+    end
+
+    it "excludes notifications from non-authorized servers" do
+      all_authorized = described_class.new(manageable_ids: [config_a.discord_id, config_b.discord_id, config_other.discord_id])
+      expect(all_authorized.unread_count).to eq(4)
+
+      expect(authorized.unread_count).to eq(3)
+    end
+
+    context "when some notifications are already read" do
+      before { notif_a1.update!(read_at: Time.current) }
+
+      it "does not count read notifications" do
+        expect(authorized.unread_count).to eq(2)
+      end
+    end
+
+    context "when some notifications are dismissed" do
+      before { notif_b1.update!(dismissed_at: Time.current) }
+
+      it "does not count dismissed notifications" do
+        expect(authorized.unread_count).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/presenters/authorized_notifications_spec.rb
+++ b/spec/presenters/authorized_notifications_spec.rb
@@ -53,6 +53,26 @@ RSpec.describe AuthorizedNotifications do
         other_scoped = described_class.new(manageable_ids:, server_id: config_other.discord_id)
         expect(other_scoped.groups).to be_empty
       end
+
+      it "returns empty when server_id is manageable but no ServerConfiguration row exists" do
+        phantom_id = 999_888_777
+        phantom_scoped = described_class.new(manageable_ids: [phantom_id], server_id: phantom_id)
+        expect(phantom_scoped.groups).to be_empty
+      end
+    end
+
+    context "when a notification's server_configuration_id is not in the configs index" do
+      it "skips the orphaned group via the next-unless-config guard" do
+        # Force configs to return an empty hash while scoped still returns notifications.
+        # This exercises the `next unless config` branch (a defensive guard).
+        ordered_double = double("relation", index_by: {})
+        relation_double = double("relation", order: ordered_double)
+        allow(ServerConfiguration).to receive(:where).and_call_original
+        allow(ServerConfiguration).to receive(:where).with(discord_id: manageable_ids).and_return(relation_double)
+
+        groups = authorized.groups
+        expect(groups).to be_empty
+      end
     end
 
     context "when a notification is dismissed" do

--- a/spec/presenters/notification_presenter_spec.rb
+++ b/spec/presenters/notification_presenter_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe NotificationPresenter do
+  let(:notification) do
+    build(
+      :notification,
+      kind: "channel_deleted",
+      data: {"plugin_name" => "Logging", "channel_name" => "mod-log", "plugin_key" => "logging"}
+    )
+  end
+
+  subject(:presenter) { described_class.new(notification) }
+
+  describe "#title" do
+    it "interpolates the channel name" do
+      expect(presenter.title).to eq("mod-log was deleted")
+    end
+
+    context "when channel_name is nil" do
+      before { notification.data = {"plugin_name" => "Logging", "plugin_key" => "logging"} }
+
+      it "falls back to the title_unknown key" do
+        expect(presenter.title).to eq("A channel was deleted")
+      end
+    end
+  end
+
+  describe "#message" do
+    it "returns the localised message" do
+      expect(presenter.message).to eq("Logging was affected — choose a new channel")
+    end
+  end
+
+  describe "#icon" do
+    it "returns warning for channel_deleted" do
+      expect(presenter.icon).to eq("warning")
+    end
+
+    context "with an unknown kind" do
+      before { notification.kind = "unknown_kind" }
+
+      it "falls back to bell" do
+        expect(presenter.icon).to eq("bell")
+      end
+    end
+  end
+
+  describe "#unread?" do
+    it "returns true when read_at is nil" do
+      notification.read_at = nil
+      expect(presenter.unread?).to be(true)
+    end
+
+    it "returns false when read_at is set" do
+      notification.read_at = Time.current
+      expect(presenter.unread?).to be(false)
+    end
+  end
+end

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -71,6 +71,27 @@ RSpec.describe "Notifications", type: :request do
           expect(response.body).not_to include("general was deleted")
         end
       end
+
+      context "with a server context but the all-servers scope" do
+        it "shows notifications from every authorized server" do
+          get notifications_path(server_id: guild_a.id, scope: "all")
+          expect(response.body).to include("mod-log was deleted")
+          expect(response.body).to include("general was deleted")
+        end
+      end
+
+      context "the scope toggle" do
+        it "renders both scope links when a server context is present" do
+          get notifications_path(server_id: guild_a.id)
+          expect(response.body).to include("scope=server")
+          expect(response.body).to include("scope=all")
+        end
+
+        it "is omitted without a server context (no this-server link)" do
+          get notifications_path
+          expect(response.body).not_to include("scope=server")
+        end
+      end
     end
 
     describe "PATCH /notifications/:id (dismiss)" do
@@ -104,11 +125,19 @@ RSpec.describe "Notifications", type: :request do
         expect(notif_other.reload.read_at).to be_nil
       end
 
-      context "with server_id param" do
+      context "scoped to the current server" do
         it "marks only that server's notifications as read" do
-          post notifications_read_path(server_id: guild_a.id)
+          post notifications_read_path(server_id: guild_a.id, scope: "server")
           expect(notif_a.reload.read_at).not_to be_nil
           expect(notif_b.reload.read_at).to be_nil
+        end
+      end
+
+      context "with a server context but the all-servers scope" do
+        it "marks every authorized server's notifications as read" do
+          post notifications_read_path(server_id: guild_a.id, scope: "all")
+          expect(notif_a.reload.read_at).not_to be_nil
+          expect(notif_b.reload.read_at).not_to be_nil
         end
       end
     end

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -50,6 +50,20 @@ RSpec.describe "Notifications", type: :request do
         expect(response.body).not_to include("chat was deleted")
       end
 
+      context "with open param" do
+        it "renders the details element with the open attribute" do
+          get notifications_path(open: true)
+          expect(response.body).to match(/<details[^>]*\bopen\b/)
+        end
+      end
+
+      context "without open param" do
+        it "renders the details element without the open attribute" do
+          get notifications_path
+          expect(response.body).not_to match(/<details[^>]*\bopen\b/)
+        end
+      end
+
       context "with server_id param (this-server scope)" do
         it "shows only notifications for that server" do
           get notifications_path(server_id: guild_a.id)
@@ -60,9 +74,9 @@ RSpec.describe "Notifications", type: :request do
     end
 
     describe "PATCH /notifications/:id (dismiss)" do
-      it "dismisses the notification and redirects" do
+      it "dismisses the notification and redirects with open: true" do
         patch notification_path(notif_a)
-        expect(response).to redirect_to(notifications_path(server_id: nil))
+        expect(response).to redirect_to(notifications_path(server_id: nil, open: true))
         expect(notif_a.reload.dismissed_at).not_to be_nil
       end
 
@@ -73,14 +87,14 @@ RSpec.describe "Notifications", type: :request do
 
       it "preserves the server_id param in the redirect" do
         patch notification_path(notif_a, server_id: guild_a.id)
-        expect(response).to redirect_to(notifications_path(server_id: guild_a.id))
+        expect(response).to redirect_to(notifications_path(server_id: guild_a.id, open: true))
       end
     end
 
     describe "POST /notifications/read (mark all read)" do
-      it "marks all authorized notifications as read and redirects" do
+      it "marks all authorized notifications as read and redirects with open: true" do
         post notifications_read_path
-        expect(response).to redirect_to(notifications_path(server_id: nil))
+        expect(response).to redirect_to(notifications_path(server_id: nil, open: true))
         expect(notif_a.reload.read_at).not_to be_nil
         expect(notif_b.reload.read_at).not_to be_nil
       end

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Notifications", type: :request do
+  include_context "discord auth"
+
+  let(:guild_a) { Discord::Guild.new(id: 900_000_010, name: "Alpha Server", owner: true, permissions: 0, icon: nil, member_count: 10) }
+  let(:guild_b) { Discord::Guild.new(id: 900_000_011, name: "Beta Server", owner: true, permissions: 0, icon: nil, member_count: 5) }
+  let(:guild_other) { Discord::Guild.new(id: 900_000_012, name: "Other Server", owner: true, permissions: 0, icon: nil, member_count: 3) }
+
+  let!(:config_a) { create(:server_configuration, discord_id: guild_a.id) }
+  let!(:config_b) { create(:server_configuration, discord_id: guild_b.id) }
+  let!(:config_other) { create(:server_configuration, discord_id: guild_other.id) }
+
+  let!(:notif_a) { create(:notification, server_configuration: config_a, data: {"plugin_key" => "logging", "plugin_name" => "Logging", "channel_name" => "mod-log"}) }
+  let!(:notif_b) { create(:notification, server_configuration: config_b, data: {"plugin_key" => "logging", "plugin_name" => "Logging", "channel_name" => "general"}) }
+  let!(:notif_other) { create(:notification, server_configuration: config_other, data: {"plugin_key" => "logging", "plugin_name" => "Logging", "channel_name" => "chat"}) }
+
+  context "when signed out" do
+    it "redirects to root" do
+      get notifications_path
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  context "when signed in" do
+    before do
+      post "/auth/discord/callback"
+      # Authorize guild_a and guild_b but NOT guild_other
+      allow(Discord::UserGuilds).to receive(:call).and_return([guild_a, guild_b])
+      get server_path(guild_a.id)
+    end
+
+    describe "GET /notifications" do
+      it "renders a turbo frame with the bell" do
+        get notifications_path
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("notifications")
+      end
+
+      it "includes notifications from authorized servers" do
+        get notifications_path
+        expect(response.body).to include("mod-log was deleted")
+        expect(response.body).to include("general was deleted")
+      end
+
+      it "excludes notifications from non-authorized servers" do
+        get notifications_path
+        expect(response.body).not_to include("chat was deleted")
+      end
+
+      context "with server_id param (this-server scope)" do
+        it "shows only notifications for that server" do
+          get notifications_path(server_id: guild_a.id)
+          expect(response.body).to include("mod-log was deleted")
+          expect(response.body).not_to include("general was deleted")
+        end
+      end
+    end
+
+    describe "PATCH /notifications/:id (dismiss)" do
+      it "dismisses the notification and redirects" do
+        patch notification_path(notif_a)
+        expect(response).to redirect_to(notifications_path(server_id: nil))
+        expect(notif_a.reload.dismissed_at).not_to be_nil
+      end
+
+      it "returns 404 for a notification on a non-authorized server" do
+        patch notification_path(notif_other)
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "preserves the server_id param in the redirect" do
+        patch notification_path(notif_a, server_id: guild_a.id)
+        expect(response).to redirect_to(notifications_path(server_id: guild_a.id))
+      end
+    end
+
+    describe "POST /notifications/read (mark all read)" do
+      it "marks all authorized notifications as read and redirects" do
+        post notifications_read_path
+        expect(response).to redirect_to(notifications_path(server_id: nil))
+        expect(notif_a.reload.read_at).not_to be_nil
+        expect(notif_b.reload.read_at).not_to be_nil
+      end
+
+      it "does not mark non-authorized notifications as read" do
+        post notifications_read_path
+        expect(notif_other.reload.read_at).to be_nil
+      end
+
+      context "with server_id param" do
+        it "marks only that server's notifications as read" do
+          post notifications_read_path(server_id: guild_a.id)
+          expect(notif_a.reload.read_at).not_to be_nil
+          expect(notif_b.reload.read_at).to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Second of three PRs for the F3 website notification system. PR1 added the model + `Ops::Notifications::Create` and recorded channel-delete notifications; this PR surfaces them in the web UI.

## What
- **App-bar bell** with an unread-count badge, loaded via an **eager Turbo Frame** (`turbo_frame_tag "notifications"`) — the count is server-rendered and no notification data is threaded through other controllers/views.
- **Dropdown panel** (reuses the existing `dropdown` Stimulus pattern): grouped by server in "All servers" scope, flat + filtered in "This server" scope. Scope toggle + per-item dismiss + mark-all-read are plain frame-targeted links/forms, so a `PATCH`/`POST` just re-renders the frame — no bespoke turbo-stream partials. Items deep-link to the affected plugin's config page (`PluginNav#plugin_config_path`).
- **Cross-server + authorized**: `AuthorizedNotifications` query scopes to the session's `manageable_server_ids` (same trust boundary as `CachedDashboard`); dismiss authorizes the notification's server (404 otherwise). Badge is a global unread count (awareness); the panel list respects the scope toggle.
- `NotificationsController` + `Notifications::ReadsController`, `Ops::Notifications::{Dismiss,MarkRead}`, `NotificationPresenter` (i18n copy, kind→icon, relative time). Small single-purpose components: `NotificationBell` / `NotificationPanel` / `NotificationItem`.
- Commits the approved design mockup (`docs/design/ui_kits/notifications/`) and documents the pattern in `docs/design-system.md` + `docs/architecture.md`.

The notify-only channel-delete flip + the inline "channel deleted" warning banner land in PR 3.

## Gates
rspec 830/0, standardrb, i18n-tasks (missing + check-normalized), undercover no-missing — all green.

## Follow-up flagged (not in this PR)
The img-or-initials **server tile** is now duplicated across `AppShell`, `NotificationPanel`, and the `servers` views — a `Components::ServerAvatar` extraction candidate (rule of two+), deferred to keep this PR bounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)