### PR TITLE
Make notification clicks navigate and mark read

### DIFF
--- a/app/components/notification_item.rb
+++ b/app/components/notification_item.rb
@@ -2,7 +2,6 @@
 
 class Components::NotificationItem < Components::Base
   include Phlex::Rails::Helpers::ButtonTo
-  include Components::PluginNav
 
   def initialize(presenter:, server_id: nil, scope: "all")
     @presenter = presenter
@@ -21,7 +20,8 @@ class Components::NotificationItem < Components::Base
 
   def item_link
     a(
-      href: deep_link,
+      href: notification_path(@presenter.notification.id),
+      data: {turbo_frame: "_top"},
       class: "flex gap-3 py-3 pl-5 pr-9 transition-colors hover:bg-surface-sunken"
     ) do
       unread_dot if @presenter.unread?
@@ -74,16 +74,9 @@ class Components::NotificationItem < Components::Base
       notification_path(@presenter.notification.id, server_id: @server_id, scope: @scope),
       method: :patch,
       aria_label: "Dismiss",
-      class: "absolute right-2 top-1/2 flex size-6 -translate-y-1/2 items-center justify-center rounded-md text-text-muted transition-colors hover:bg-surface-raised hover:text-text-primary"
+      class: "absolute right-2 top-1/2 flex size-6 -translate-y-1/2 cursor-pointer items-center justify-center rounded-md text-text-muted transition-colors hover:bg-surface-raised hover:text-text-primary"
     ) do
       render Components::Icon.new("x", class: "size-3.5")
     end
-  end
-
-  def deep_link
-    plugin_config_path(
-      @presenter.server_configuration.discord_id,
-      @presenter.notification.data["plugin_key"]
-    )
   end
 end

--- a/app/components/notification_panel.rb
+++ b/app/components/notification_panel.rb
@@ -34,7 +34,7 @@ class Components::NotificationPanel < Components::Base
     button_to(
       notifications_read_path(server_id: @server_id, scope: @scope),
       method: :post,
-      class: "text-xs font-semibold text-text-link hover:underline"
+      class: "cursor-pointer text-xs font-semibold text-text-link hover:underline"
     ) { t(".mark_all_read") }
   end
 

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -17,6 +17,14 @@ class NotificationsController < ApplicationController
     )
   end
 
+  def show
+    notification = authorized_notification
+    return head(:not_found) unless notification
+
+    Ops::Notifications::Read.call(notification:)
+    redirect_to plugin_config_path_for(notification)
+  end
+
   def update
     notification = authorized_notification
     return head(:not_found) unless notification
@@ -26,6 +34,16 @@ class NotificationsController < ApplicationController
   end
 
   private
+
+  CONFIGURABLE_PLUGINS = %w[roles welcomes logging reminders].freeze
+
+  def plugin_config_path_for(notification)
+    discord_id = notification.server_configuration.discord_id
+    key = notification.data["plugin_key"].to_s
+    return server_path(discord_id) unless CONFIGURABLE_PLUGINS.include?(key)
+
+    public_send("server_#{key}_path", discord_id)
+  end
 
   def notification_scope
     return params[:scope] if params[:scope].present?

--- a/app/operations/notifications/read.rb
+++ b/app/operations/notifications/read.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Ops
+  module Notifications
+    class Read < ApplicationOperation
+      receives :notification
+
+      def call
+        notification.update!(read_at: Time.current) if notification.read_at.nil?
+        ok(notification)
+      end
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,6 +15,8 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="application-name" content="shrkbot">
     <meta name="mobile-web-app-capable" content="yes">
+    <%# Notification links are GET click-throughs that mark the notification read; hover-prefetch would fire that side effect early. %>
+    <meta name="turbo-prefetch" content="false">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   get "/auth/failure", to: "sessions#failure"
   delete "/logout", to: "sessions#destroy", as: :logout
 
-  resources :notifications, only: [:index, :update]
+  resources :notifications, only: [:index, :show, :update]
   namespace :notifications do
     resource :read, only: :create
   end

--- a/spec/components/notification_item_spec.rb
+++ b/spec/components/notification_item_spec.rb
@@ -35,8 +35,9 @@ RSpec.describe Components::NotificationItem do
       expect(html).to include("Dismiss")
     end
 
-    it "renders a deep-link href to the logging plugin page" do
-      expect(html).to include("/servers/#{config.discord_id}/logging")
+    it "links to the notification show path, escaping the turbo frame" do
+      expect(html).to include("/notifications/#{notification.id}")
+      expect(html).to include('data-turbo-frame="_top"')
     end
   end
 
@@ -64,8 +65,9 @@ RSpec.describe Components::NotificationItem do
       expect(html).to include("Dismiss")
     end
 
-    it "renders a deep-link href to the logging plugin page" do
-      expect(html).to include("/servers/#{config.discord_id}/logging")
+    it "links to the notification show path, escaping the turbo frame" do
+      expect(html).to include("/notifications/#{notification.id}")
+      expect(html).to include('data-turbo-frame="_top"')
     end
   end
 end

--- a/spec/operations/notifications/read_spec.rb
+++ b/spec/operations/notifications/read_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Ops::Notifications::Read do
+  subject(:result) { described_class.call(notification:) }
+
+  context "when the notification is unread" do
+    let(:notification) { create(:notification, read_at: nil) }
+
+    it "marks it read" do
+      expect { result }.to change { notification.reload.read_at }.from(nil)
+    end
+
+    it "returns the notification" do
+      expect(result.value).to eq(notification)
+    end
+  end
+
+  context "when the notification is already read" do
+    let(:notification) { create(:notification, read_at: 1.day.ago) }
+
+    it "leaves the timestamp untouched" do
+      expect { result }.not_to change { notification.reload.read_at }
+    end
+  end
+end

--- a/spec/requests/notifications_spec.rb
+++ b/spec/requests/notifications_spec.rb
@@ -94,6 +94,25 @@ RSpec.describe "Notifications", type: :request do
       end
     end
 
+    describe "GET /notifications/:id (click-through)" do
+      it "marks the notification read and redirects to the plugin config page" do
+        get notification_path(notif_a)
+        expect(notif_a.reload.read_at).not_to be_nil
+        expect(response).to redirect_to(server_logging_path(guild_a.id))
+      end
+
+      it "returns 404 for a notification on a non-authorized server" do
+        get notification_path(notif_other)
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "falls back to the server dashboard for an unrecognised plugin key" do
+        stray = create(:notification, server_configuration: config_a, data: {"plugin_key" => "mystery"})
+        get notification_path(stray)
+        expect(response).to redirect_to(server_path(guild_a.id))
+      end
+    end
+
     describe "PATCH /notifications/:id (dismiss)" do
       it "dismisses the notification and redirects with open: true" do
         patch notification_path(notif_a)


### PR DESCRIPTION
Bug fixes for the notification dropdown (follow-up to the merged notification-center PRs).

## Bugs
1. **Clicking a notification went nowhere.** The item was an `<a>` *inside* the `notifications` Turbo Frame, so the click navigated the frame — Turbo loaded the destination page's bell frame (a non-interactive placeholder) into it. Result: the menu vanished, couldn't reopen, and the unread count blanked (without being read, so it reappeared on the next page).
2. **Read-on-click didn't happen.** Viewing a notification left it unread.
3. **"Mark all read" had no pointer cursor** — `button_to` renders a `<button>`, and Tailwind v4 drops the default `cursor: pointer`.

## Fixes
- New **`notifications#show`**: marks the one notification read (`Ops::Notifications::Read`) and redirects to the affected plugin's config page. The item links here with **`data-turbo-frame="_top"`** so it escapes the frame and does a real top-level navigation.
- **Turbo hover-prefetch disabled globally** (`<meta name="turbo-prefetch" content="false">`) so the GET click-through's read side effect can't fire on hover-prefetch before an actual click.
- `cursor-pointer` added to the **mark-all-read** and **dismiss** `button_to` controls.

The redirect maps `plugin_key → server_<key>_path` with a dashboard fallback for an unrecognised key (forged/stale data).

## Gates
rspec 855/0, standardrb, i18n-tasks, undercover no-missing — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)