### PR TITLE
Publish role-menu sync from the dashboard plugin toggle

### DIFF
--- a/app/operations/server_configuration/plugins/toggle.rb
+++ b/app/operations/server_configuration/plugins/toggle.rb
@@ -4,6 +4,8 @@ module Ops
   module ServerConfiguration
     module Plugins
       class Toggle < ApplicationOperation
+        self.transactional = false
+
         receives :server_configuration, :plugin, :enabled
 
         def call
@@ -13,6 +15,7 @@ module Ops
             return failure("#{plugin.name} can't be enabled until its required settings are configured.")
           end
           activation.save!
+          publish_side_effects(activation)
           ok(activation)
         end
 
@@ -21,6 +24,12 @@ module Ops
         def prerequisites_met?
           definition = PluginCatalog.find(plugin.key)
           definition.nil? || definition.prerequisites_met?(server_configuration)
+        end
+
+        def publish_side_effects(activation)
+          return unless plugin.key == :roles
+
+          ::Roles::MenuToggle.publish(server_configuration, enabled: activation.enabled?)
         end
       end
     end

--- a/app/plugins/roles/menu_toggle.rb
+++ b/app/plugins/roles/menu_toggle.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Roles
+  class MenuToggle
+    def self.publish(server_configuration, enabled:)
+      new(server_configuration, enabled:).publish
+    end
+
+    def initialize(server_configuration, enabled:)
+      @server_configuration = server_configuration
+      @enabled = enabled
+    end
+
+    def publish
+      sets.each do |set|
+        if enabled
+          plan.post(set)
+        elsif set.message_id.present?
+          plan.remove(set)
+        end
+      end
+      plan.publish
+    end
+
+    private
+
+    attr_reader :server_configuration, :enabled
+
+    def sets
+      server_configuration.role_setting.role_sets
+    end
+
+    def plan
+      @plan ||= MenuSyncPlan.new
+    end
+  end
+end

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -410,6 +410,12 @@ Delivery is fire-and-forget. On the subscriber side, failing Results are logged
 (they are not silently dropped). If `REDIS_URL` is not set, `ConfigBus.publish`
 logs a warning and drops the event rather than raising.
 
+The dashboard's instant plugin toggle (`Ops::ServerConfiguration::Plugins::Toggle`)
+publishes the same `roles_post`/`roles_menu_remove` events via `Roles::MenuToggle`
+when the roles plugin is toggled, so the menu-iff-enabled rule holds on both save
+paths (config-page Save and dashboard toggle). `Roles::MenuToggle` delegates to
+`Roles::MenuSyncPlan` so delivery semantics are identical.
+
 `Roles::MenuReconcile` (a `:ready` event handler) sweeps guilds this shard serves
 in both directions:
 - **Post missing** — `message_id: nil` sets on enabled plugins (catch-up for saves

--- a/spec/operations/server_configuration/plugins/toggle_spec.rb
+++ b/spec/operations/server_configuration/plugins/toggle_spec.rb
@@ -120,4 +120,77 @@ RSpec.describe Ops::ServerConfiguration::Plugins::Toggle do
       expect(server.plugin_activations.where(plugin: logging).count).to eq(1)
     end
   end
+
+  context "toggling roles publishes menu sync" do
+    let(:plugin) { roles }
+
+    before do
+      allow(ConfigBus).to receive(:post_roles)
+      allow(ConfigBus).to receive(:remove_roles_menu)
+      allow(ConfigBus).to receive(:delete_roles_message)
+    end
+
+    context "when enabling with a role_set" do
+      let(:enabled) { true }
+      let!(:role_setting) { create(:role_setting, server_configuration: server) }
+      let!(:role_set) { create(:role_set, role_setting:) }
+
+      it "publishes post_roles for the set" do
+        result
+        expect(ConfigBus).to have_received(:post_roles).with(
+          have_attributes(id: role_set.id)
+        )
+      end
+    end
+
+    context "when disabling with a role_set that has a message" do
+      let(:enabled) { false }
+      let!(:role_setting) { create(:role_setting, server_configuration: server) }
+      let!(:role_set) { create(:role_set, role_setting:, message_id: 111) }
+
+      before do
+        create(:plugin_activation, server_configuration: server, plugin: roles, enabled: true)
+      end
+
+      it "publishes remove_roles_menu for the set" do
+        result
+        expect(ConfigBus).to have_received(:remove_roles_menu).with(
+          have_attributes(id: role_set.id)
+        )
+      end
+    end
+  end
+
+  context "toggling a non-roles plugin" do
+    let(:plugin) { logging }
+    let(:enabled) { true }
+
+    before do
+      allow(ConfigBus).to receive(:post_roles)
+      allow(ConfigBus).to receive(:remove_roles_menu)
+      server.create_logging_setting!(channel_id: 999)
+    end
+
+    it "publishes neither post_roles nor remove_roles_menu" do
+      result
+      expect(ConfigBus).not_to have_received(:post_roles)
+      expect(ConfigBus).not_to have_received(:remove_roles_menu)
+    end
+  end
+
+  context "a refused roles enable (no role_setting)" do
+    let(:plugin) { roles }
+    let(:enabled) { true }
+
+    before do
+      allow(ConfigBus).to receive(:post_roles)
+      allow(ConfigBus).to receive(:remove_roles_menu)
+    end
+
+    it "publishes nothing when the operation is refused" do
+      result
+      expect(ConfigBus).not_to have_received(:post_roles)
+      expect(ConfigBus).not_to have_received(:remove_roles_menu)
+    end
+  end
 end

--- a/spec/plugins/roles/menu_toggle_spec.rb
+++ b/spec/plugins/roles/menu_toggle_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Roles::MenuToggle do
+  subject(:publish) { described_class.publish(server_configuration, enabled:) }
+
+  let(:server_configuration) { create(:server_configuration) }
+  let!(:role_setting) { create(:role_setting, server_configuration:) }
+
+  before do
+    allow(ConfigBus).to receive(:post_roles)
+    allow(ConfigBus).to receive(:remove_roles_menu)
+    allow(ConfigBus).to receive(:delete_roles_message)
+  end
+
+  context "when enabling with two sets (one with message_id, one without)" do
+    let(:enabled) { true }
+    let!(:set_with_message) { create(:role_set, role_setting:, message_id: 111) }
+    let!(:set_without_message) { create(:role_set, role_setting:) }
+
+    it "publishes post_roles for both sets" do
+      publish
+      expect(ConfigBus).to have_received(:post_roles).with(set_with_message)
+      expect(ConfigBus).to have_received(:post_roles).with(set_without_message)
+    end
+
+    it "does not publish remove_roles_menu" do
+      publish
+      expect(ConfigBus).not_to have_received(:remove_roles_menu)
+    end
+  end
+
+  context "when disabling with two sets (one with message_id, one without)" do
+    let(:enabled) { false }
+    let!(:set_with_message) { create(:role_set, role_setting:, message_id: 111) }
+    let!(:set_without_message) { create(:role_set, role_setting:) }
+
+    it "publishes remove_roles_menu only for the set with a message" do
+      publish
+      expect(ConfigBus).to have_received(:remove_roles_menu).with(set_with_message)
+      expect(ConfigBus).not_to have_received(:remove_roles_menu).with(set_without_message)
+    end
+
+    it "does not publish post_roles" do
+      publish
+      expect(ConfigBus).not_to have_received(:post_roles)
+    end
+  end
+
+  context "when enabling with no sets" do
+    let(:enabled) { true }
+
+    it "publishes neither post_roles nor remove_roles_menu" do
+      publish
+      expect(ConfigBus).not_to have_received(:post_roles)
+      expect(ConfigBus).not_to have_received(:remove_roles_menu)
+    end
+  end
+end


### PR DESCRIPTION
## What

The dashboard's instant plugin toggle (`Ops::ServerConfiguration::Plugins::Toggle`) saved the activation but never told the bot, so toggling the roles plugin from the dashboard left role menus stale until the next bot restart (`Roles::MenuReconcile`'s ready sweep). The config-page Save path already published menu events; the dashboard path didn't.

## How

- New `Roles::MenuToggle` collaborator: builds a `Roles::MenuSyncPlan` from the server's role sets — `roles_post` per set on enable, `roles_menu_remove` per set that still has a message on disable — and publishes it. Reuses the existing ConfigBus event types, so `ConfigSubscriber` needs no change.
- `Plugins::Toggle` calls it after a successful save when the toggled plugin is roles. The op opts out of the base-class transaction (`self.transactional = false`) so the publish happens post-commit (same pattern as `Ops::Roles::Configure`, #86); its single `save!` is atomic on its own.
- `docs/architecture.md` config-propagation section notes the menu-iff-enabled rule now holds on both save paths.

## Scope note

BUILD_PLAN flagged a second suspected consequence — guild slash-command re-registration on toggle. Verified moot: no per-plugin guild commands exist (roles works via component handlers; all real commands are `register_in :global`, `:guild` is dev/test-server only). Nothing to re-register.

## Tests

New `Roles::MenuToggle` spec (enable/disable/no-sets) + toggle-op contexts (roles publishes, non-roles doesn't, refused enable doesn't). All gates green: rspec (865), standardrb, active_record_doctor, undercover.