### PR TITLE
Add the owner-only admin settings page

### DIFF
--- a/app/components/admin/owner_dm_card.rb
+++ b/app/components/admin/owner_dm_card.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Components::Admin::OwnerDmCard < Components::Base
+  def view_template
+    div(id: "owner-dm-card") do
+      render Components::Card.new(class: "flex items-center gap-4") do
+        div(class: "flex-1") do
+          p(class: "text-sm font-semibold") { t(".label") }
+          p(class: "mt-0.5 text-sm text-text-secondary") { t(".description") }
+        end
+        render Components::Toggle.new(
+          name: :owner_error_dms,
+          checked: BotSetting.owner_error_dms?,
+          label: t(".label"),
+          url: admin_settings_path,
+          submit_on_change: true
+        )
+      end
+    end
+  end
+end

--- a/app/components/app_shell.rb
+++ b/app/components/app_shell.rb
@@ -144,6 +144,16 @@ class Components::AppShell < Components::Base
         data: {dropdown_target: "menu"},
         class: "dropdown-menu absolute right-0 top-12 z-40 w-52 rounded-lg border border-border-default bg-surface-card p-1.5 shadow-lg"
       ) do
+        if @user.owner?
+          a(
+            href: admin_settings_path,
+            class: "flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-sm text-text-secondary transition-colors hover:bg-surface-sunken"
+          ) do
+            render Components::Icon.new("shield", class: "size-4")
+            span { t(".admin_settings") }
+          end
+          div(class: "mx-1 my-1 h-px bg-surface-sunken")
+        end
         button_to(
           logout_path,
           method: :delete,

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class Admin::SettingsController < ApplicationController
+  before_action :require_owner
+
+  def show
+    render Views::Admin::Settings::Show.new(user: current_user)
+  end
+
+  def update
+    result = Ops::BotSettings::Update.call(owner_error_dms: params[:owner_error_dms])
+    @toast = {level: "notice", message: t(result.value ? "admin.settings.dms_enabled" : "admin.settings.dms_disabled")}
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to admin_settings_path }
+    end
+  end
+
+  private
+
+  def require_owner
+    redirect_to servers_path, alert: t("admin.owner_only") unless current_user.owner?
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,6 @@ class User < ApplicationRecord
   end
 
   def owner?
-    BotConfig.owner_id.present? && discord_id.to_s == BotConfig.owner_id
+    discord_id.to_s == BotConfig.owner_id
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,4 +24,8 @@ class User < ApplicationRecord
 
     "https://cdn.discordapp.com/avatars/#{discord_id}/#{avatar}.png"
   end
+
+  def owner?
+    BotConfig.owner_id.present? && discord_id.to_s == BotConfig.owner_id
+  end
 end

--- a/app/operations/bot_settings/update.rb
+++ b/app/operations/bot_settings/update.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Ops
+  module BotSettings
+    class Update < ApplicationOperation
+      receives :owner_error_dms
+
+      def call
+        BotSetting.owner_error_dms = truthy?(owner_error_dms)
+        ok(BotSetting.owner_error_dms?)
+      end
+
+      private
+
+      def truthy?(value)
+        ActiveModel::Type::Boolean.new.cast(value)
+      end
+    end
+  end
+end

--- a/app/views/admin/settings/show.rb
+++ b/app/views/admin/settings/show.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class Views::Admin::Settings::Show < Views::Base
+  def initialize(user:)
+    @user = user
+  end
+
+  def view_template
+    render Components::AppShell.new(user: @user) do
+      div(class: "mx-auto max-w-2xl px-6 py-10") do
+        heading
+        render Components::Admin::OwnerDmCard.new
+      end
+    end
+  end
+
+  private
+
+  def heading
+    div(class: "mb-6") do
+      h1(class: "mb-1 font-display text-2xl font-bold tracking-tight") { t(".title") }
+      p(class: "text-text-secondary") { t(".subtitle") }
+    end
+  end
+end

--- a/app/views/admin/settings/update.turbo_stream.erb
+++ b/app/views/admin/settings/update.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%= turbo_stream.replace "owner-dm-card", html: render(Components::Admin::OwnerDmCard.new) %>
+<%= turbo_stream.append "toasts", html: render(Components::Toast.new(**@toast)) %>

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -1,13 +1,23 @@
 ---
 en:
+  admin:
+    owner_only: Only the bot owner can open that page.
+    settings:
+      dms_disabled: Error DMs disabled.
+      dms_enabled: Error DMs enabled.
   assignable_roles:
     above_bot: Above shrkbot — it ranks below this role.
     managed: Managed by Discord — bots can't assign integration roles.
   authentication:
     login_required: Please sign in to continue.
   components:
+    admin:
+      owner_dm_card:
+        description: Sends you a Discord DM when shrkbot hits an unexpected error.
+        label: DM me on errors
     app_shell:
       add_server: Add another server
+      admin_settings: Admin settings
       log_out: Log out
       notifications: Notifications
       plugins_on:
@@ -180,6 +190,11 @@ en:
     signed_in: Signed in as %{name}.
     signed_out: Signed out.
   views:
+    admin:
+      settings:
+        show:
+          subtitle: Global settings for shrkbot's owner.
+          title: Owner settings
     home:
       configure: Configure
       footer: Free & open source. shrkbot only reads servers you can manage.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,10 @@ Rails.application.routes.draw do
     resource :read, only: :create
   end
 
+  namespace :admin do
+    resource :settings, only: [:show, :update]
+  end
+
   resources :servers, only: [:index, :show], param: :id do
     resources :plugins, only: :update, param: :key, module: :servers
     scope module: :servers do

--- a/spec/components/admin/owner_dm_card_spec.rb
+++ b/spec/components/admin/owner_dm_card_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::Admin::OwnerDmCard do
+  include_context "component view context"
+
+  subject(:html) { described_class.new.render_in(view_context) }
+
+  context "when owner_error_dms is enabled" do
+    before { BotSetting.owner_error_dms = true }
+
+    it "renders the card with a checked toggle" do
+      expect(html).to include("owner-dm-card")
+      expect(html).to include("checked")
+    end
+  end
+
+  context "when owner_error_dms is disabled" do
+    before { BotSetting.owner_error_dms = false }
+
+    it "renders the card with an unchecked toggle" do
+      expect(html).to include("owner-dm-card")
+      expect(html).not_to include('checked="checked"')
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -59,6 +59,34 @@ RSpec.describe User do
     end
   end
 
+  describe "#owner?" do
+    subject(:user) { build(:user, discord_id: 99_999) }
+
+    context "when OWNER_ID matches the user's discord_id" do
+      before { allow(BotConfig).to receive(:owner_id).and_return("99999") }
+
+      it "is true" do
+        expect(user.owner?).to be(true)
+      end
+    end
+
+    context "when OWNER_ID does not match" do
+      before { allow(BotConfig).to receive(:owner_id).and_return("11111") }
+
+      it "is false" do
+        expect(user.owner?).to be(false)
+      end
+    end
+
+    context "when OWNER_ID is nil" do
+      before { allow(BotConfig).to receive(:owner_id).and_return(nil) }
+
+      it "is false" do
+        expect(user.owner?).to be(false)
+      end
+    end
+  end
+
   describe "validations" do
     subject(:user) { build(:user) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -63,7 +63,9 @@ RSpec.describe User do
     subject(:user) { build(:user, discord_id: 99_999) }
 
     context "when OWNER_ID matches the user's discord_id" do
-      before { allow(BotConfig).to receive(:owner_id).and_return("99999") }
+      before do
+        allow(BotConfig).to receive(:owner_id).and_return("99999")
+      end
 
       it "is true" do
         expect(user.owner?).to be(true)
@@ -71,15 +73,9 @@ RSpec.describe User do
     end
 
     context "when OWNER_ID does not match" do
-      before { allow(BotConfig).to receive(:owner_id).and_return("11111") }
-
-      it "is false" do
-        expect(user.owner?).to be(false)
+      before do
+        allow(BotConfig).to receive(:owner_id).and_return("11111")
       end
-    end
-
-    context "when OWNER_ID is nil" do
-      before { allow(BotConfig).to receive(:owner_id).and_return(nil) }
 
       it "is false" do
         expect(user.owner?).to be(false)

--- a/spec/operations/bot_settings/update_spec.rb
+++ b/spec/operations/bot_settings/update_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Ops::BotSettings::Update do
+  subject(:result) { described_class.call(owner_error_dms:) }
+
+  context "when given a truthy checkbox value" do
+    let(:owner_error_dms) { "1" }
+
+    it "sets the flag to true and returns true" do
+      expect(result.value).to be(true)
+      expect(BotSetting.owner_error_dms?).to be(true)
+    end
+  end
+
+  context "when given a falsy checkbox value" do
+    let(:owner_error_dms) { "0" }
+
+    before do
+      BotSetting.owner_error_dms = true
+    end
+
+    it "sets the flag to false and returns false" do
+      expect(result.value).to be(false)
+      expect(BotSetting.owner_error_dms?).to be(false)
+    end
+  end
+end

--- a/spec/requests/admin/settings_spec.rb
+++ b/spec/requests/admin/settings_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin settings", type: :request do
+  include_context "discord auth"
+
+  let(:turbo) { {headers: {"Accept" => "text/vnd.turbo-stream.html"}} }
+
+  context "when signed out" do
+    it "redirects to the sign-in page" do
+      get admin_settings_path
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  context "when signed in as a non-owner" do
+    before do
+      allow(BotConfig).to receive(:owner_id).and_return("99999")
+      post "/auth/discord/callback"
+    end
+
+    describe "GET /admin/settings" do
+      it "redirects to the server picker with an alert" do
+        get admin_settings_path
+        expect(response).to redirect_to(servers_path)
+        expect(flash[:alert]).to be_present
+      end
+    end
+
+    describe "PATCH /admin/settings" do
+      it "redirects without changing the setting" do
+        BotSetting.owner_error_dms = false
+        patch admin_settings_path, params: {owner_error_dms: "1"}, **turbo
+        expect(response).to redirect_to(servers_path)
+        expect(BotSetting.owner_error_dms?).to be(false)
+      end
+    end
+  end
+
+  context "when signed in as the owner" do
+    before do
+      allow(BotConfig).to receive(:owner_id).and_return("12345")
+      post "/auth/discord/callback"
+    end
+
+    describe "GET /admin/settings" do
+      it "renders the settings page with the toggle card" do
+        get admin_settings_path
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("owner-dm-card")
+      end
+    end
+
+    describe "PATCH /admin/settings" do
+      context "with turbo-stream" do
+        it "flips the setting and responds with turbo-stream" do
+          BotSetting.owner_error_dms = false
+          patch admin_settings_path, params: {owner_error_dms: "1"}, **turbo
+          expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+          expect(BotSetting.owner_error_dms?).to be(true)
+        end
+
+        it "turns the setting back off" do
+          BotSetting.owner_error_dms = true
+          patch admin_settings_path, params: {owner_error_dms: "0"}, **turbo
+          expect(response.body).to include(I18n.t("admin.settings.dms_disabled"))
+          expect(BotSetting.owner_error_dms?).to be(false)
+        end
+      end
+
+      context "without turbo-stream" do
+        it "redirects back to the settings page" do
+          patch admin_settings_path, params: {owner_error_dms: "1"}
+          expect(response).to redirect_to(admin_settings_path)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

Closes the last Phase 7 chunk: `BotSetting.owner_error_dms` (DM the owner on bot errors) was settable only via Rails console. Now there's an owner-only page at `/admin/settings` with an instant-save toggle, linked from the user menu (shield icon) — visible and accessible only to the bot owner.

## How

- `User#owner?` compares the session user's `discord_id` to `BotConfig.owner_id` (`OWNER_ID` env; unset means nobody is owner). Used by both the controller guard and the shell link.
- `Admin::SettingsController` (namespaced singular resource, show/update) with `require_owner`; non-owners get redirected to the picker with an explanatory alert.
- `Ops::BotSettings::Update` casts the checkbox param and flips the flag.
- `Components::Admin::OwnerDmCard` reads the global state itself and renders the standard instant-save toggle (own form, submit on change) — same pattern as the dashboard plugin rows; the update responds with a Turbo Stream that replaces the card and appends a toast.

## Tests

Request spec (signed-out, non-owner GET/PATCH, owner GET/PATCH both directions, turbo-stream + HTML fallback), op spec, `User#owner?` examples, card component spec. All gates green: rspec (879), standardrb, active_record_doctor, undercover, i18n-tasks missing + check-normalized.