### PR TITLE
Add server configuration link to /info

### DIFF
--- a/app/bot/bot_config.rb
+++ b/app/bot/bot_config.rb
@@ -36,4 +36,8 @@ module BotConfig
   def web_base_url
     ENV.fetch("WEB_BASE_URL")
   end
+
+  def server_config_url(discord_id)
+    "#{web_base_url.chomp("/")}/servers/#{discord_id}"
+  end
 end

--- a/app/bot/commands/info.rb
+++ b/app/bot/commands/info.rb
@@ -20,9 +20,29 @@ module Commands
           Discord::Components.text(header),
           Discord::Components.separator,
           Discord::Components.text("**Built with**\n#{credits}"),
+          *configuration_section,
           Discord::Components.separator,
           Discord::Components.text("-# Want to support the project? Use /donate.")
         ]
+      )
+    end
+
+    def configuration_section
+      return [] unless configurable?
+
+      [
+        Discord::Components.separator,
+        Discord::Components.text("**Configure me**\n[Manage this server's settings](#{BotConfig.server_config_url(event.server_id)})")
+      ]
+    end
+
+    def configurable?
+      return false unless event.server_id
+
+      CommandPermissions.permitted?(
+        event:,
+        required: [:manage_server],
+        owner_only: false
       )
     end
 

--- a/app/bot/server_onboarder.rb
+++ b/app/bot/server_onboarder.rb
@@ -24,6 +24,6 @@ module ServerOnboarder
   end
 
   def dashboard_url(server)
-    "#{BotConfig.web_base_url.chomp("/")}/servers/#{server.id}"
+    BotConfig.server_config_url(server.id)
   end
 end

--- a/app/operations/server_configuration/channels/handle_deletion.rb
+++ b/app/operations/server_configuration/channels/handle_deletion.rb
@@ -40,7 +40,7 @@ module Ops
         end
 
         def config_url(plugin)
-          "#{BotConfig.web_base_url.chomp("/")}/servers/#{server_configuration.discord_id}/#{plugin.key}"
+          "#{BotConfig.server_config_url(server_configuration.discord_id)}/#{plugin.key}"
         end
       end
     end

--- a/spec/bot/commands/info_spec.rb
+++ b/spec/bot/commands/info_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Commands::Info do
   subject(:execute) { described_class.new(event).execute }
 
   let(:profile) { double("profile", username: "shrkbot") }
-  let(:event) { double("event", bot: double("bot", profile:), respond: nil) }
+  let(:event) { double("event", bot: double("bot", profile:), respond: nil, server_id: nil) }
 
   def texts(args)
     args[:components].first[:components].filter_map { |block| block[:content] }
@@ -36,5 +36,55 @@ RSpec.describe Commands::Info do
     end
 
     execute
+  end
+
+  context "when the caller can manage the server in a guild" do
+    let(:member) { double("member", permission?: true) }
+    let(:event) do
+      double(
+        "event",
+        bot: double("bot", profile:),
+        respond: nil,
+        member:,
+        server_id: 123
+      )
+    end
+
+    before do
+      allow(BotConfig).to receive(:owner_id).and_return(nil)
+      allow(BotConfig).to receive(:web_base_url).and_return("https://shrk.test/")
+    end
+
+    it "includes a link to the server's configuration page" do
+      expect(event).to receive(:respond) do |args|
+        body = texts(args).join("\n")
+        expect(body).to include("https://shrk.test/servers/123")
+      end
+
+      execute
+    end
+  end
+
+  context "when the caller cannot manage the server" do
+    let(:member) { double("member", permission?: false) }
+    let(:event) do
+      double(
+        "event",
+        bot: double("bot", profile:),
+        respond: nil,
+        member:,
+        server_id: 123
+      )
+    end
+
+    before { allow(BotConfig).to receive(:owner_id).and_return(nil) }
+
+    it "omits the configuration link" do
+      expect(event).to receive(:respond) do |args|
+        expect(texts(args).join("\n")).not_to include("/servers/")
+      end
+
+      execute
+    end
   end
 end


### PR DESCRIPTION
## What

`/info` now shows a **Configure me** section linking to the server's settings page (`/servers/<id>`) — but only for members with `manage_server` in a guild. Omitted in DMs and for members without the permission.

## Why

Admins had no in-Discord path to the web dashboard from `/info`. This gives them a one-click jump to configuration.

## Details

- Permission gate reuses `CommandPermissions.permitted?` (same seam as `requires_permissions`, owner-bypass included), rather than re-inlining a member permission check.
- The link is a conditional section spliced into the components container, so DM/non-admin callers see the unchanged message.
- Extracted `BotConfig.server_config_url(discord_id)` for the shared `/servers/<id>` URL (rule of two → three: `/info`, the channel-deletion notice, and the onboarding DM all built it inline). Migrated all three.

## Tests

New `info_spec` contexts cover link-shown (has `manage_server`) and link-omitted (lacks it). Full suite: 889 examples, 0 failures. standardrb / undercover / active_record_doctor all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)