### PR TITLE
Move API_VERSION into BotConfig; match accent to brand teal

### DIFF
--- a/app/bot/bot_config.rb
+++ b/app/bot/bot_config.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module BotConfig
-  ACCENT_COLOR = 0x39afe5
+  ACCENT_COLOR = 0x37a79e
   API_VERSION = "v10"
 
   module_function

--- a/app/bot/bot_config.rb
+++ b/app/bot/bot_config.rb
@@ -2,6 +2,7 @@
 
 module BotConfig
   ACCENT_COLOR = 0x39afe5
+  API_VERSION = "v10"
 
   module_function
 

--- a/app/bot/discord/user_guilds.rb
+++ b/app/bot/discord/user_guilds.rb
@@ -5,7 +5,8 @@ require "json"
 
 module Discord
   class UserGuilds
-    ENDPOINT = URI("https://discord.com/api/v10/users/@me/guilds?with_counts=true")
+    API_VERSION = "v10"
+    ENDPOINT = URI("https://discord.com/api/#{API_VERSION}/users/@me/guilds?with_counts=true")
 
     class Error < StandardError; end
 

--- a/app/bot/discord/user_guilds.rb
+++ b/app/bot/discord/user_guilds.rb
@@ -5,8 +5,7 @@ require "json"
 
 module Discord
   class UserGuilds
-    API_VERSION = "v10"
-    ENDPOINT = URI("https://discord.com/api/#{API_VERSION}/users/@me/guilds?with_counts=true")
+    ENDPOINT = URI("https://discord.com/api/#{BotConfig::API_VERSION}/users/@me/guilds?with_counts=true")
 
     class Error < StandardError; end
 

--- a/spec/bot/discord/user_guilds_spec.rb
+++ b/spec/bot/discord/user_guilds_spec.rb
@@ -23,6 +23,10 @@ RSpec.describe Discord::UserGuilds do
     expect(fetch.first).to have_attributes(id: 42, name: "Dev Refuge", owner: true, permissions: 8, member_count: 2481)
   end
 
+  it "targets the pinned Discord API version" do
+    expect(described_class::ENDPOINT.to_s).to include("/api/#{described_class::API_VERSION}/")
+  end
+
   context "when Discord rejects the access token" do
     let(:code) { "401" }
     let(:body) { "" }

--- a/spec/bot/discord/user_guilds_spec.rb
+++ b/spec/bot/discord/user_guilds_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Discord::UserGuilds do
   end
 
   it "targets the pinned Discord API version" do
-    expect(described_class::ENDPOINT.to_s).to include("/api/#{described_class::API_VERSION}/")
+    expect(described_class::ENDPOINT.to_s).to include("/api/#{BotConfig::API_VERSION}/")
   end
 
   context "when Discord rejects the access token" do


### PR DESCRIPTION
## What

Hoist the hardcoded `v10` from `Discord::UserGuilds`'s endpoint into `BotConfig::API_VERSION`, and build the URL from it. Adds a spec pinning the endpoint to the constant.

## Why

Addresses the "how do we notice the Discord API version needs updating?" note. The version was buried mid-string in one URL. Now:

- It lives in `BotConfig` alongside the other bot constants — the API version *is* bot configuration, and it's reachable from anywhere that needs it, not just `UserGuilds`.
- A Discord version bump is a one-line, deliberate edit in one greppable place.
- The spec pins the endpoint to `BotConfig::API_VERSION`, so a bump is a visible, intentional change in review.

`UserGuilds` is the **only** hand-rolled Discord REST call in the codebase (the bot side rides discordrb's own version, bumped when we update the gem; CDN/oauth URLs are unversioned).

### On detection

No repo-side auto-detector is warranted: Discord announces version sunsets well ahead via their changelog/dev dashboard, and there's no reliable per-request deprecation signal to key off. When a version is finally sunset the endpoint errors, and `UserGuilds` already raises (logged + owner-notified) — so a stale version fails loudly rather than silently.

## Tests

New example asserts the endpoint targets `BotConfig::API_VERSION`. Full suite: 890 examples, 0 failures. standardrb / undercover green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)