### PR TITLE
Disable Redis persistence (fix overcommit warning)

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -69,5 +69,4 @@ accessories:
     image: redis:7
     host: <%= ENV["DEPLOY_HOST"] %>
     network: kamal
-    volumes:
-      - shrkbot_redis_data:/data
+    cmd: redis-server --save ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
 
   redis:
     image: redis:7
+    command: redis-server --save ""
     restart: always
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]


### PR DESCRIPTION
## What

Run the production Redis accessory with `--save ""` and drop its data volume.

## Why

The `redis-1 | WARNING Memory overcommit must be enabled!` warning comes from Redis's default RDB snapshotting: it forks to write a background save, and that fork is what the `vm.overcommit_memory` setting guards.

We don't need any of that. Redis here is **only** ephemeral pub/sub for web→bot config propagation (`ConfigBus` / `config_subscriber`). Nothing durable lives in Redis:

- Per-guild config lives in Postgres.
- Cache = `solid_cache`, Action Cable = `solid_cable`, jobs = Solid Queue — all Postgres.

A Redis bounce just means the bot re-reads config from Postgres. So persistence is pure overhead. Disabling saves (`--save ""`) removes the fork entirely, which:

- silences the warning at the root, and
- means we **don't** need to set `vm.overcommit_memory=1` on the host.

Also removed the now-pointless `shrkbot_redis_data` volume.

## Not included

The same one-liner belongs on the local `docker-compose.yml` redis service (`command: redis-server --save ""`) — that's the container that actually emitted the warning locally. It's bind-mounted read-only in my environment, so it needs to be added by hand; trivial and can go on this branch.

## Alternative considered

Setting `vm.overcommit_memory=1` on the host (Redis's suggested fix) — rejected: it's the fix for *keeping* persistence we don't want, and it's a host-provisioning concern rather than a repo change. Disabling the save we never use is simpler and self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)