### PR TITLE
Pre-deploy copy pass + activity-log restyle

### DIFF
--- a/app/bot/activity_log.rb
+++ b/app/bot/activity_log.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 module ActivityLog
+  SUPPRESS_MENTIONS = {parse: []}.freeze
+
   module_function
 
-  def record(server_configuration, plugin, event, bot:, **options)
-    return unless enabled?(server_configuration, "#{plugin}.#{event}")
-
+  def post(server_configuration, bot:, title:, body:, meta:)
     channel_id = server_configuration.logging_setting.channel_id
     return unless channel_id
 
-    deliver(bot, channel_id, render(plugin, event, options))
+    deliver(bot, channel_id, entry(title, body, meta))
   end
 
   def enabled?(server_configuration, action)
@@ -18,21 +18,17 @@ module ActivityLog
     server_configuration.logging_setting.action_enabled?(action)
   end
 
-  def render(plugin, event, options)
-    I18n.t("activity_log.#{plugin}.#{event}", locale: :en, raise: true, **humanize(options))
+  def entry(title, body, meta)
+    Discord::Components.container(
+      [Discord::Components.text("**#{title}**\n#{body}\n-# #{meta}")]
+    )
   end
 
-  def humanize(options)
-    options.transform_values do |value|
-      value.is_a?(Array) ? value.to_sentence : value
-    end
-  end
-
-  def deliver(bot, channel_id, text)
-    bot.channel(channel_id)&.send_message(text)
+  def deliver(bot, channel_id, entry)
+    bot.channel(channel_id)&.send_message(nil, false, nil, nil, SUPPRESS_MENTIONS, nil, entry[:components], entry[:flags])
   rescue => e
     Rails.logger.warn("[ActivityLog] could not write to ##{channel_id}: #{e.class}: #{e.message}")
   end
 
-  private_class_method :enabled?, :render, :humanize, :deliver
+  private_class_method :entry, :deliver
 end

--- a/app/bot/activity_log.rb
+++ b/app/bot/activity_log.rb
@@ -25,7 +25,10 @@ module ActivityLog
   end
 
   def deliver(bot, channel_id, entry)
-    bot.channel(channel_id)&.send_message(nil, false, nil, nil, SUPPRESS_MENTIONS, nil, entry[:components], entry[:flags])
+    channel = bot.channel(channel_id)
+    return unless channel
+
+    Discord::Components.send_to(channel, entry, allowed_mentions: SUPPRESS_MENTIONS)
   rescue => e
     Rails.logger.warn("[ActivityLog] could not write to ##{channel_id}: #{e.class}: #{e.message}")
   end

--- a/app/bot/announce_modal.rb
+++ b/app/bot/announce_modal.rb
@@ -9,7 +9,7 @@ class AnnounceModal < BaseEvent
     event.defer(ephemeral: true)
     result = OwnerBroadcast.call(bots: BotRegistry.all, content:)
     event.edit_response(
-      content: "📣 Sent to #{result.sent}/#{result.owner_count} unique owner(s) across #{result.server_count} server(s)."
+      content: "Sent to #{result.sent}/#{result.owner_count} unique owner(s) across #{result.server_count} server(s)."
     )
   end
 

--- a/app/bot/bot_presence.rb
+++ b/app/bot/bot_presence.rb
@@ -6,7 +6,7 @@ module BotPresence
   module_function
 
   def activity_text(server_count)
-    "/help • #{server_count} #{"server".pluralize(server_count)}"
+    "/info • #{server_count} #{"server".pluralize(server_count)}"
   end
 
   def update(bot, server_count)

--- a/app/bot/commands/donate.rb
+++ b/app/bot/commands/donate.rb
@@ -10,9 +10,9 @@ module Commands
       Thank you for considering supporting the shrkbot project! For full transparency, here's what it currently costs to keep shrkbot running:
       • Hosting: 10.60€ / month
 
-      That's the entire monthly cost as things stand. I'd love to keep growing the project — adding features and improving the ones that are there — and any support makes that easier.
+      That's the entire monthly cost as things stand. I'd love to keep growing the project - adding features and improving the ones that are there - and any support makes that easier.
 
-      To be clear: shrkbot is and always will be completely free and open source. You are never obligated to donate — just using shrkbot is more than enough :) And please only ever give money you don't otherwise need.
+      To be clear: shrkbot is and always will be completely free and open source. You are never obligated to donate - just using shrkbot is more than enough :) And please only ever give money you don't otherwise need.
 
       Thank you for using shrkbot! If you'd like to chip in:
       • PayPal: https://paypal.me/trueblackshark

--- a/app/bot/commands/donate.rb
+++ b/app/bot/commands/donate.rb
@@ -6,23 +6,41 @@ module Commands
     description "Find out what it costs to run shrkbot and how you can support the project."
     register_in :global
 
-    MESSAGE = <<~DONATE
-      Thank you for considering supporting the shrkbot project! For full transparency, here's what it currently costs to keep shrkbot running:
-      • Hosting: 10.60€ / month
+    COSTS = <<~COSTS.strip
+      ### Support shrkbot
+      Thank you for considering supporting the project! For full transparency, here's what it currently costs to keep shrkbot running:
+      - Hosting: 10.60€ / month
 
       That's the entire monthly cost as things stand. I'd love to keep growing the project - adding features and improving the ones that are there - and any support makes that easier.
+    COSTS
 
-      To be clear: shrkbot is and always will be completely free and open source. You are never obligated to donate - just using shrkbot is more than enough :) And please only ever give money you don't otherwise need.
+    PLEDGE = "To be clear: shrkbot is and always will be completely free and open source. " \
+      "You are never obligated to donate - just using shrkbot is more than enough :) " \
+      "And please only ever give money you don't otherwise need."
 
-      Thank you for using shrkbot! If you'd like to chip in:
-      • PayPal: https://paypal.me/trueblackshark
-      • Liberapay: https://liberapay.com/badBlackShark
+    LINKS = "**If you'd like to chip in:**\n" \
+      "[PayPal](https://paypal.me/trueblackshark) · [Liberapay](https://liberapay.com/badBlackShark)"
 
-      All donations are non-refundable. Thanks for the support! <3
-    DONATE
+    FOOTER = "-# All donations are non-refundable. Thanks for the support! <3"
 
     def execute
-      event.respond(content: MESSAGE, ephemeral: true)
+      event.respond(components: message[:components], ephemeral: true, has_components: true)
+    end
+
+    private
+
+    def message
+      Discord::Components.container(
+        [
+          Discord::Components.text(COSTS),
+          Discord::Components.separator,
+          Discord::Components.text(PLEDGE),
+          Discord::Components.separator,
+          Discord::Components.text(LINKS),
+          Discord::Components.separator,
+          Discord::Components.text(FOOTER)
+        ]
+      )
     end
   end
 end

--- a/app/bot/commands/donate.rb
+++ b/app/bot/commands/donate.rb
@@ -10,8 +10,10 @@ module Commands
       ### Support shrkbot
       Thank you for considering supporting the project! For full transparency, here's what it currently costs to keep shrkbot running:
       - Hosting: 10.60€ / month
+      - Email hosting: 4.99€ / month
+      - Website domain: 17.37€ / year
 
-      That's the entire monthly cost as things stand. I'd love to keep growing the project - adding features and improving the ones that are there - and any support makes that easier.
+      That's everything as things stand - roughly 17€ a month all told. I'd love to keep growing the project - adding features and improving the ones that are there - and any support makes that easier.
     COSTS
 
     PLEDGE = "To be clear: shrkbot is and always will be completely free and open source. " \

--- a/app/bot/commands/info.rb
+++ b/app/bot/commands/info.rb
@@ -3,7 +3,7 @@
 module Commands
   class Info < BaseCommand
     command_name :info
-    description "Show information about shrkbot — its code, stack, and how to add it to your server."
+    description "Show information about shrkbot - its code, stack, and how to add it to your server."
     register_in :global
 
     INVITE_URL = "https://discord.com/oauth2/authorize?client_id=346043915142561793"

--- a/app/bot/commands/info.rb
+++ b/app/bot/commands/info.rb
@@ -55,10 +55,7 @@ module Commands
     def credits
       [
         "**[discordrb](https://github.com/shardlab/discordrb)** *by shardlab*",
-        "**[Ruby on Rails](https://rubyonrails.org/)** *by the Rails team*",
-        "**[Solid Queue](https://github.com/rails/solid_queue)** *by the Rails team*",
-        "**[pg](https://github.com/ged/ruby-pg)** *by Michael Granger et al.*",
-        "**[redis-rb](https://github.com/redis/redis-rb)** *by the redis-rb team*"
+        "**[Ruby on Rails](https://rubyonrails.org/)** *by the Rails team*"
       ].join("\n")
     end
   end

--- a/app/bot/discord/components.rb
+++ b/app/bot/discord/components.rb
@@ -20,5 +20,9 @@ module Discord
     def separator
       {type: SEPARATOR, divider: true}
     end
+
+    def send_to(channel, rendered, allowed_mentions: nil)
+      channel.send_message(nil, false, nil, nil, allowed_mentions, nil, rendered[:components], rendered[:flags])
+    end
   end
 end

--- a/app/bot/owner_broadcast.rb
+++ b/app/bot/owner_broadcast.rb
@@ -16,8 +16,7 @@ module OwnerBroadcast
   end
 
   def deliver(bot, owner_id, content)
-    rendered = message(content)
-    bot.pm_channel(owner_id).send_message(nil, false, nil, nil, nil, nil, rendered[:components], rendered[:flags])
+    Discord::Components.send_to(bot.pm_channel(owner_id), message(content))
     true
   rescue => e
     Rails.logger.warn("[OwnerBroadcast] could not DM owner #{owner_id}: #{e.class}: #{e.message}")

--- a/app/bot/server_onboarder.rb
+++ b/app/bot/server_onboarder.rb
@@ -6,8 +6,7 @@ module ServerOnboarder
   def notify(bot, server, config)
     return if config.onboarded_at?
 
-    rendered = message(server)
-    bot.pm_channel(server.owner.id).send_message(nil, false, nil, nil, nil, nil, rendered[:components], rendered[:flags])
+    Discord::Components.send_to(bot.pm_channel(server.owner.id), message(server))
     config.update!(onboarded_at: Time.current)
   rescue => e
     Rails.logger.error("[ServerOnboarder] could not onboard server #{server.id}: #{e.class}: #{e.message}")

--- a/app/bot/server_onboarder.rb
+++ b/app/bot/server_onboarder.rb
@@ -6,21 +6,27 @@ module ServerOnboarder
   def notify(bot, server, config)
     return if config.onboarded_at?
 
-    bot.pm_channel(server.owner.id).send_message(message(server))
+    rendered = message(server)
+    bot.pm_channel(server.owner.id).send_message(nil, false, nil, nil, nil, nil, rendered[:components], rendered[:flags])
     config.update!(onboarded_at: Time.current)
   rescue => e
     Rails.logger.error("[ServerOnboarder] could not onboard server #{server.id}: #{e.class}: #{e.message}")
   end
 
   def message(server)
-    <<~MSG.strip
-      👋 Thanks for adding shrkbot!
+    Discord::Components.container(
+      [
+        Discord::Components.text(body(server)),
+        Discord::Components.separator,
+        Discord::Components.text("-# Sign in with Discord to enable plugins and manage settings.")
+      ]
+    )
+  end
 
-      shrkbot is configured through the web dashboard. Set up #{server.name} here:
-      #{dashboard_url(server)}
-
-      Sign in with Discord to enable plugins and manage settings.
-    MSG
+  def body(server)
+    "### Thanks for adding shrkbot!\n" \
+      "shrkbot is set up entirely through the web dashboard. Configure **#{server.name}** here:\n" \
+      "#{dashboard_url(server)}"
   end
 
   def dashboard_url(server)

--- a/app/operations/roles/messages/post.rb
+++ b/app/operations/roles/messages/post.rb
@@ -13,7 +13,7 @@ module Ops
 
           ::Roles::MessagePoster.post(bot, role_set)
 
-          return failure("Could not post the role message — check the channel.") if role_set.message_id.nil?
+          return failure("Could not post the role message - check the channel.") if role_set.message_id.nil?
 
           ok(role_set)
         end

--- a/app/operations/roles/messages/repost.rb
+++ b/app/operations/roles/messages/repost.rb
@@ -13,7 +13,7 @@ module Ops
           role_set.update!(message_id: nil)
           ::Roles::MessagePoster.post(bot, role_set)
 
-          return failure("Could not post the role message — check the channel.") if role_set.message_id.nil?
+          return failure("Could not post the role message - check the channel.") if role_set.message_id.nil?
 
           ok(role_set)
         end

--- a/app/plugins/reminders/commands/list.rb
+++ b/app/plugins/reminders/commands/list.rb
@@ -12,9 +12,17 @@ module Reminders
       if reminders.empty?
         event.respond(content: "You have no active reminders.", ephemeral: true)
       else
-        lines = reminders.map { |r| "• <t:#{r.remind_at.to_i}:R> - #{Discord::Truncate.call(r.message, 80)}" }
-        event.respond(content: lines.join("\n"), ephemeral: true)
+        event.respond(components: message(reminders)[:components], ephemeral: true, has_components: true)
       end
+    end
+
+    private
+
+    def message(reminders)
+      lines = reminders.map { |r| "- <t:#{r.remind_at.to_i}:R> - #{Discord::Truncate.call(r.message, 80)}" }
+      Discord::Components.container(
+        [Discord::Components.text("### Your reminders\n#{lines.join("\n")}")]
+      )
     end
   end
 end

--- a/app/plugins/reminders/commands/list.rb
+++ b/app/plugins/reminders/commands/list.rb
@@ -12,7 +12,7 @@ module Reminders
       if reminders.empty?
         event.respond(content: "You have no active reminders.", ephemeral: true)
       else
-        lines = reminders.map { |r| "• <t:#{r.remind_at.to_i}:R> — #{Discord::Truncate.call(r.message, 80)}" }
+        lines = reminders.map { |r| "• <t:#{r.remind_at.to_i}:R> - #{Discord::Truncate.call(r.message, 80)}" }
         event.respond(content: lines.join("\n"), ephemeral: true)
       end
     end

--- a/app/plugins/reminders/commands/remind.rb
+++ b/app/plugins/reminders/commands/remind.rb
@@ -23,7 +23,7 @@ module Reminders
       )
 
       if result.success?
-        event.respond(content: "👍 I'll remind you <t:#{result.value.remind_at.to_i}:R>.", ephemeral: true)
+        event.respond(content: "I'll remind you <t:#{result.value.remind_at.to_i}:R>.", ephemeral: true)
       else
         event.respond(content: "⚠️ #{result.errors.first}", ephemeral: true)
       end

--- a/app/plugins/reminders/commands/unremind.rb
+++ b/app/plugins/reminders/commands/unremind.rb
@@ -14,7 +14,7 @@ module Reminders
       return event.respond(content: "⚠️ That reminder doesn't exist.", ephemeral: true) unless reminder
 
       Ops::Reminders::Delete.call(reminder:)
-      event.respond(content: "🗑️ Reminder cancelled.", ephemeral: true)
+      event.respond(content: "Reminder canceled.", ephemeral: true)
     end
 
     def autocomplete

--- a/app/plugins/reminders/deliver_job.rb
+++ b/app/plugins/reminders/deliver_job.rb
@@ -18,7 +18,24 @@ module Reminders
 
     def deliver(reminder)
       channel_id = deliver_via_dm?(reminder) ? dm_channel_id(reminder.user_id) : reminder.channel_id
-      Discordrb::API::Channel.create_message(BotConfig.rest_token, channel_id, content(reminder))
+      rendered = message(reminder)
+      Discordrb::API::Channel.create_message(
+        BotConfig.rest_token,
+        channel_id,
+        nil,
+        false,
+        nil,
+        nil,
+        nil,
+        nil,
+        nil,
+        rendered[:components],
+        rendered[:flags]
+      )
+    end
+
+    def message(reminder)
+      Discord::Components.container([Discord::Components.text(content(reminder))])
     end
 
     def deliver_via_dm?(reminder)

--- a/app/plugins/reminders/deliver_job.rb
+++ b/app/plugins/reminders/deliver_job.rb
@@ -34,7 +34,7 @@ module Reminders
 
     def content(reminder)
       ago = distance_of_time_in_words(reminder.created_at, reminder.remind_at)
-      "⏰ <@#{reminder.user_id}> you asked me #{ago} ago to remind you:\n> #{reminder.message}"
+      "<@#{reminder.user_id}>, you asked me #{ago} ago to remind you:\n> #{reminder.message}"
     end
   end
 end

--- a/app/plugins/roles/activity_entry.rb
+++ b/app/plugins/roles/activity_entry.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Roles
+  module ActivityEntry
+    module_function
+
+    def build(set:, actor:, gained:, lost:)
+      {
+        title: I18n.t("activity_log.roles.title", locale: :en, raise: true),
+        body: body(actor, gained, lost),
+        meta: I18n.t("activity_log.roles.source", set: set.name, locale: :en, raise: true)
+      }
+    end
+
+    def body(actor, gained, lost)
+      if gained.any? && lost.any?
+        I18n.t("activity_log.roles.role_gained_and_lost", actor:, gained: sentence(gained), lost: sentence(lost), locale: :en, raise: true)
+      elsif gained.any?
+        I18n.t("activity_log.roles.role_gained", actor:, roles: sentence(gained), locale: :en, raise: true)
+      else
+        I18n.t("activity_log.roles.role_lost", actor:, roles: sentence(lost), locale: :en, raise: true)
+      end
+    end
+
+    def sentence(names)
+      names.map { |name| "**#{name}**" }.to_sentence
+    end
+
+    private_class_method :body, :sentence
+  end
+end

--- a/app/plugins/roles/events/component_handler.rb
+++ b/app/plugins/roles/events/component_handler.rb
@@ -28,14 +28,21 @@ module Roles
 
     def log_assignment(had, diff)
       names = role_names(diff[:add] + diff[:remove])
-      log_role_change(:role_gained, label(diff[:add] - had, names))
-      log_role_change(:role_lost, label(diff[:remove] & had, names))
+      gained = logged_roles(:role_gained, diff[:add] - had, names)
+      lost = logged_roles(:role_lost, diff[:remove] & had, names)
+      return if gained.empty? && lost.empty?
+
+      ActivityLog.post(
+        server_configuration,
+        bot: event.bot,
+        **ActivityEntry.build(set:, actor: member.mention, gained:, lost:)
+      )
     end
 
-    def log_role_change(name, roles)
-      return if roles.empty?
+    def logged_roles(name, role_ids, names)
+      return [] unless ActivityLog.enabled?(server_configuration, "roles.#{name}")
 
-      ActivityLog.record(server_configuration, :roles, name, bot: event.bot, actor: member.mention, roles:)
+      label(role_ids, names)
     end
 
     def member_set_role_ids

--- a/app/plugins/roles/events/pick.rb
+++ b/app/plugins/roles/events/pick.rb
@@ -13,7 +13,7 @@ module Roles
       diff = Assignment.single(set_role_ids, picked)
       had = member_set_role_ids
       apply(diff)
-      event.respond(content: Message.selection_summary(set, [picked]), ephemeral: true)
+      event.respond(content: Message.pick_confirmation(set, picked, had), ephemeral: true)
       log_assignment(had, diff)
     end
   end

--- a/app/plugins/roles/message.rb
+++ b/app/plugins/roles/message.rb
@@ -40,7 +40,7 @@ module Roles
     def manage_section(set)
       {
         type: SECTION,
-        components: [Discord::Components.text("-# Click this button to edit your roles ->")],
+        components: [Discord::Components.text("-# Manage your roles with the button.")],
         accessory: manage_button(set)
       }
     end
@@ -50,13 +50,13 @@ module Roles
     end
 
     def single_content(set)
-      "### #{set.name}\nPick a role below — you can only have one, so choosing a role replaces your current one."
+      "### #{set.name}\nPick a role below - you can only have one, so choosing a role replaces your current one."
     end
 
     def multi_content(set)
       names = role_names(set)
       roles = set.assignable_roles.map { |role| "- **#{role_label(role, names)}**" }.join("\n")
-      "### #{set.name}\nSelect all roles that apply. You will have the following options:\n#{roles}"
+      "### #{set.name}\nPick any of these roles - as many as you like:\n#{roles}"
     end
 
     def picker_content(set)

--- a/app/plugins/roles/message.rb
+++ b/app/plugins/roles/message.rb
@@ -29,12 +29,18 @@ module Roles
       )
     end
 
-    def selection_summary(set, active_role_ids)
+    def pick_confirmation(set, picked_id, had_role_ids)
       names = role_names(set)
-      chosen = set.assignable_roles
-        .select { |role| active_role_ids.include?(role.role_id) }
-        .map { |role| names[role.role_id] || UNKNOWN_ROLE }
-      "**#{set.name}**: #{chosen.any? ? chosen.join(", ") : "none"}"
+      picked = "**#{names[picked_id] || UNKNOWN_ROLE}**"
+      replaced = (had_role_ids - [picked_id]).map { |role_id| "**#{names[role_id] || UNKNOWN_ROLE}**" }
+
+      if replaced.any?
+        "You now have #{picked} - swapped out #{replaced.to_sentence}."
+      elsif had_role_ids.include?(picked_id)
+        "No change - you already have #{picked}."
+      else
+        "You now have #{picked}."
+      end
     end
 
     def manage_section(set)

--- a/app/plugins/roles/message_poster.rb
+++ b/app/plugins/roles/message_poster.rb
@@ -24,7 +24,7 @@ module Roles
     private
 
     def create(channel, rendered)
-      message = channel.send_message(nil, false, nil, nil, nil, nil, rendered[:components], rendered[:flags])
+      message = Discord::Components.send_to(channel, rendered)
       @set.update!(message_id: message.id)
     end
 

--- a/config/locales/activity_log.en.yml
+++ b/config/locales/activity_log.en.yml
@@ -3,4 +3,7 @@ en:
   activity_log:
     roles:
       role_gained: "%{actor} gained %{roles}."
+      role_gained_and_lost: "%{actor} gained %{gained} and lost %{lost}."
       role_lost: "%{actor} lost %{roles}."
+      source: Self-assigned via the "%{set}" role menu
+      title: Roles updated

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -6,8 +6,8 @@ en:
       dms_disabled: Error DMs disabled.
       dms_enabled: Error DMs enabled.
   assignable_roles:
-    above_bot: Above shrkbot — it ranks below this role.
-    managed: Managed by Discord — bots can't assign integration roles.
+    above_bot: Above shrkbot - it ranks below this role.
+    managed: Managed by Discord - bots can't assign integration roles.
   authentication:
     login_required: Please sign in to continue.
   components:
@@ -94,7 +94,7 @@ en:
     reminders:
       config_form:
         callout:
-          after: "— there's nothing more to configure here."
+          after: "- there's nothing more to configure here."
           before: Reminders are triggered by members using
         force_dm:
           help: Deliver every reminder in DMs, ignoring channel preferences set by
@@ -127,7 +127,7 @@ en:
             other: "%{count} roles"
           label: Assignable roles
           placeholder: Choose roles members can pick
-          unassignable: Greyed-out roles can't be assigned. shrkbot can only assign
+          unassignable: Grayed-out roles can't be assigned. shrkbot can only assign
             roles below its own highest role, and never Discord-managed ones.
         selection:
           label: Selection type
@@ -165,7 +165,7 @@ en:
   notifications:
     kinds:
       channel_deleted:
-        message: "%{plugin_name} was affected — choose a new channel"
+        message: "%{plugin_name} was affected - choose a new channel"
         title: "%{channel_name} was deleted"
         title_unknown: A channel was deleted
   servers:
@@ -187,7 +187,7 @@ en:
     welcomes:
       saved: Welcomes settings saved.
   sessions:
-    failed: Sign-in failed or was cancelled.
+    failed: Sign-in failed or was canceled.
     signed_in: Signed in as %{name}.
     signed_out: Signed out.
   views:

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -203,11 +203,12 @@ en:
       footer_mid: ". Made with "
       footer_post: " by badBlackShark."
       footer_pre: 'shrkbot is '
-      headline: Turn features
-      headline_end: on.
-      headline_muted: Or off.
-      lede: shrkbot is a modular Discord bot. Enable just the plugins your server
-        needs, nothing more, nothing less. Configure everything in one dashboard.
+      headline: You pick the parts.
+      headline_end: shrkbot
+      headline_muted: does the rest.
+      lede: 'shrkbot is your server''s mechanic: a modular Discord bot that keeps
+        exactly the plugins you want running, nothing more, nothing less. Configure
+        everything from one dashboard.'
       more_plugins: More plugins are on the way.
       plugins:
         logging: 'Record moderation events to a private staff channel: role changes,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -302,6 +302,10 @@ the `CONTAINER`/`TEXT_DISPLAY`/`SEPARATOR` type ids, the `COMPONENTS_V2` flag, a
 `container`/`text`/`separator` builders — so every sender (role messages, `/info`, the
 owner broadcast, the onboarding DM, activity-log entries) renders the same way and the
 brand colour lives in one place (`BotConfig::ACCENT_COLOR`, the container default).
+`Components.send_to(channel, rendered, allowed_mentions:)` owns the positional
+`channel.send_message` shape (nil content + components + flags), so call sites never
+enumerate the discordrb signature; only `Reminders::DeliverJob` sends over raw REST
+(no gateway in the jobs process) and keeps its own `create_message` call.
 
 `Roles::Message` composes those builders into a **Components V2** payload, so
 `public_message`/`multi_picker` return `{components:, flags:}` with the `COMPONENTS_V2`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -300,8 +300,8 @@ pure `Roles::Assignment` diff with `member.modify_roles` as the seam.
 `Discord::Components` (`app/bot/discord/`) holds the shared Components V2 primitives —
 the `CONTAINER`/`TEXT_DISPLAY`/`SEPARATOR` type ids, the `COMPONENTS_V2` flag, and the
 `container`/`text`/`separator` builders — so every sender (role messages, `/info`, the
-owner broadcast) renders the same way and the brand colour lives in one place
-(`BotConfig::ACCENT_COLOR`, the container default).
+owner broadcast, the onboarding DM, activity-log entries) renders the same way and the
+brand colour lives in one place (`BotConfig::ACCENT_COLOR`, the container default).
 
 `Roles::Message` composes those builders into a **Components V2** payload, so
 `public_message`/`multi_picker` return `{components:, flags:}` with the `COMPONENTS_V2`
@@ -318,32 +318,38 @@ placeholder so a component is never empty.
 
 ## Activity logging
 
-`ActivityLog.record(server_configuration, plugin, event, bot:, **options)` (`app/bot/`) is
-the one-line API for writing a user action to a server's logging channel. It's gated twice:
-the logging plugin must be enabled, and the specific event must be toggled on.
+`ActivityLog` (`app/bot/`) is the seam for writing a user action to a server's logging
+channel, split into two queries: `ActivityLog.enabled?(server_configuration, action)` answers
+whether an event should be logged (the logging plugin must be enabled *and* the specific
+event toggled on), and `ActivityLog.post(server_configuration, bot:, title:, body:, meta:)`
+renders and delivers one entry. The split lets a consumer gate the *parts* of a composite
+entry individually while still sending a single message.
 
-One toggle per event, keyed `"<plugin>.<event>"` (e.g. `"roles.role_gained"`) — the same
-string is the toggle key, derived directly from the `plugin`/`event` args, so there's no
-separate event→action map to maintain. Toggles live in `logging_settings.enabled_actions`
-(a jsonb map, default `{}` = everything off); `LoggingSetting#action_enabled?` reads it. The
-Phase 7 web UI gives each plugin a logging tab listing its events as independent toggles, and
-greys the lot out when the logging plugin is off.
+One toggle per event, keyed `"<plugin>.<event>"` (e.g. `"roles.role_gained"`) — a plain
+string, so there's no separate event→action map to maintain. Toggles live in
+`logging_settings.enabled_actions` (a jsonb map, default `{}` = everything off);
+`LoggingSetting#action_enabled?` reads it. The Phase 7 web UI gives each plugin a logging
+tab listing its events as independent toggles, and greys the lot out when the logging
+plugin is off.
 
-Events are **atomic**, never composite: a role swap emits two lines (`role_gained` +
-`role_lost`), each gated by its own toggle, rather than a combined `roles_changed` — so the
-toggles compose cleanly with no hidden "swap logs nothing" gap, and each message stays a flat
-i18n string with no conditionals.
+Entries render as the shared **accent container** (`Discord::Components`), one text block in
+three parts: a bold **title** (the action), a **body** sentence (who was affected and what
+happened), and a muted `-#` **meta** line (who/what triggered it — e.g. `Self-assigned via
+the "Pronouns" role menu`). Mention pings are suppressed (`allowed_mentions: {parse: []}`)
+so logging a member's action never notifies them. Toggles still gate atomically, but
+delivery is composite: one interaction = one entry. A role swap with both toggles on logs a
+single "gained X and lost Y" sentence; turn one toggle off and only the other side renders —
+so the toggles compose with no "swap logs nothing" gap and no double message.
 
-Message text is `config/locales/activity_log.en.yml`, nested by plugin, looked up with
-`I18n.t("activity_log.#{plugin}.#{event}", locale: :en, raise: true)` — the bot is
-English-only, so I18n is a string registry here, not localization. `**options` are
-interpolation values; Array values are run through `to_sentence` so `roles: ["A", "B"]`
-renders "A and B". Adding a loggable event = a key in the locale file + a `record` call. A
-bad plugin/event **raises** (missing translation surfaces in the consumer's spec;
-owner-reported in prod via `BaseEvent`); only the channel send is rescued, so a delivery
-failure never breaks the user's action. Welcomes are excluded by design. Roles assignment is
-the first consumer — `Roles::ComponentHandler#log_assignment` diffs gained/lost from the
-pre-apply roles and emits one atomic event per non-empty side.
+Message text is `config/locales/activity_log.en.yml`, nested by plugin — the bot is
+English-only, so I18n is a string registry here, not localization. Per-plugin entry
+builders (e.g. `Roles::ActivityEntry`) look the strings up with `raise: true`, so a bad key
+**raises** (surfaces in the consumer's spec; owner-reported in prod via `BaseEvent`); only
+the channel send is rescued, so a delivery failure never breaks the user's action. Welcomes
+are excluded by design. Roles assignment is the first consumer —
+`Roles::ComponentHandler#log_assignment` diffs gained/lost from the pre-apply roles, drops
+any side whose toggle is off via `enabled?`, and posts one entry built by
+`Roles::ActivityEntry`.
 
 The enumerable catalog of each plugin's loggable events (so the web tab can render the toggle
 list) is a Phase 7 concern — a per-plugin declaration added when that UI is built. The bot

--- a/spec/bot/activity_log_spec.rb
+++ b/spec/bot/activity_log_spec.rb
@@ -3,12 +3,7 @@
 require "rails_helper"
 
 RSpec.describe ActivityLog do
-  subject(:record) { described_class.record(server_config, :roles, event, bot:, **options) }
-
   let(:server_config) { create(:server_configuration) }
-  let(:event) { :role_gained }
-  let(:options) { {actor: "<@42>", roles: ["Gamer"]} }
-
   let(:channel) { double("channel", send_message: nil) }
   let(:bot) { double("bot") }
 
@@ -24,96 +19,92 @@ RSpec.describe ActivityLog do
     allow(bot).to receive(:channel).with(555).and_return(channel)
   end
 
-  it "writes the rendered line to the logging channel" do
-    expect(channel).to receive(:send_message).with("<@42> gained Gamer.")
-    record
-  end
+  describe ".post" do
+    subject(:post) do
+      described_class.post(
+        server_config,
+        bot:,
+        title: "Roles updated",
+        body: "<@42> gained **Gamer**.",
+        meta: 'Self-assigned via the "Pronouns" role menu'
+      )
+    end
 
-  context "with several roles" do
-    let(:options) { {actor: "<@42>", roles: ["Gamer", "Artist"]} }
+    it "writes a branded container with title, body, and muted meta line" do
+      expect(channel).to receive(:send_message) do |*args|
+        expect(args[7]).to eq(Discord::Components::COMPONENTS_V2)
+        content = args[6].first[:components].first[:content]
+        expect(content).to eq(
+          "**Roles updated**\n<@42> gained **Gamer**.\n-# Self-assigned via the \"Pronouns\" role menu"
+        )
+      end
+      post
+    end
 
-    it "joins the list into a sentence" do
-      expect(channel).to receive(:send_message).with("<@42> gained Gamer and Artist.")
-      record
+    it "suppresses mention pings in the log channel" do
+      expect(channel).to receive(:send_message) do |*args|
+        expect(args[4]).to eq({parse: []})
+      end
+      post
+    end
+
+    context "when no logging channel is set" do
+      before do
+        server_config.logging_setting.update!(channel_id: nil)
+      end
+
+      it "writes nothing" do
+        expect(channel).not_to receive(:send_message)
+        post
+      end
+    end
+
+    context "when the logging channel no longer exists" do
+      before do
+        allow(bot).to receive(:channel).with(555).and_return(nil)
+      end
+
+      it "writes nothing and doesn't raise" do
+        expect { post }.not_to raise_error
+      end
+    end
+
+    context "when the channel send fails" do
+      before do
+        allow(channel).to receive(:send_message).and_raise("403 missing access")
+      end
+
+      it "swallows the error so the user's action is unaffected" do
+        expect { post }.not_to raise_error
+      end
     end
   end
 
-  context "for an event gated by its own toggle" do
-    let(:event) { :role_lost }
-    let(:options) { {actor: "<@42>", roles: ["Artist"]} }
+  describe ".enabled?" do
+    subject(:enabled) { described_class.enabled?(server_config, action) }
 
-    before do
-      server_config.logging_setting.update!(enabled_actions: {"roles.role_lost" => true})
+    let(:action) { "roles.role_gained" }
+
+    it "is true when the plugin is on and the action is toggled on" do
+      expect(enabled).to be(true)
     end
 
-    it "renders that event's own line" do
-      expect(channel).to receive(:send_message).with("<@42> lost Artist.")
-      record
-    end
-  end
+    context "when the logging plugin is disabled" do
+      before do
+        PluginActivation.update_all(enabled: false)
+      end
 
-  context "when the logging plugin is disabled" do
-    before do
-      PluginActivation.update_all(enabled: false)
-    end
-
-    it "writes nothing" do
-      expect(channel).not_to receive(:send_message)
-      record
-    end
-  end
-
-  context "when this event's toggle is off" do
-    before do
-      server_config.logging_setting.update!(enabled_actions: {"roles.role_lost" => true})
+      it "is false" do
+        expect(enabled).to be(false)
+      end
     end
 
-    it "writes nothing" do
-      expect(channel).not_to receive(:send_message)
-      record
-    end
-  end
+    context "when the action's toggle is off" do
+      let(:action) { "roles.role_lost" }
 
-  context "when no logging channel is set" do
-    before do
-      server_config.logging_setting.update!(channel_id: nil)
-    end
-
-    it "writes nothing" do
-      expect(channel).not_to receive(:send_message)
-      record
-    end
-  end
-
-  context "when the logging channel no longer exists" do
-    before do
-      allow(bot).to receive(:channel).with(555).and_return(nil)
-    end
-
-    it "writes nothing and doesn't raise" do
-      expect { record }.not_to raise_error
-    end
-  end
-
-  context "when the channel send fails" do
-    before do
-      allow(channel).to receive(:send_message).and_raise("403 missing access")
-    end
-
-    it "swallows the error so the user's action is unaffected" do
-      expect { record }.not_to raise_error
-    end
-  end
-
-  context "for an unregistered event" do
-    let(:event) { :not_a_real_event }
-
-    before do
-      server_config.logging_setting.update!(enabled_actions: {"roles.not_a_real_event" => true})
-    end
-
-    it "raises so the wiring mistake surfaces" do
-      expect { record }.to raise_error(I18n::MissingTranslationData)
+      it "is false" do
+        expect(enabled).to be(false)
+      end
     end
   end
 end

--- a/spec/bot/bot_presence_spec.rb
+++ b/spec/bot/bot_presence_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe BotPresence do
       let(:count) { 0 }
 
       it "pluralizes correctly" do
-        expect(activity_text).to eq("/help • 0 servers")
+        expect(activity_text).to eq("/info • 0 servers")
       end
     end
 
@@ -18,7 +18,7 @@ RSpec.describe BotPresence do
       let(:count) { 1 }
 
       it "uses singular form" do
-        expect(activity_text).to eq("/help • 1 server")
+        expect(activity_text).to eq("/info • 1 server")
       end
     end
 
@@ -26,7 +26,7 @@ RSpec.describe BotPresence do
       let(:count) { 5 }
 
       it "uses plural form" do
-        expect(activity_text).to eq("/help • 5 servers")
+        expect(activity_text).to eq("/info • 5 servers")
       end
     end
   end
@@ -37,7 +37,7 @@ RSpec.describe BotPresence do
     let(:bot) { double("bot") }
 
     it "pushes a Listening status with the given server count" do
-      expect(bot).to receive(:update_status).with("online", "/help • 3 servers", nil, 0, false, 2)
+      expect(bot).to receive(:update_status).with("online", "/info • 3 servers", nil, 0, false, 2)
       update
     end
   end

--- a/spec/bot/commands/donate_spec.rb
+++ b/spec/bot/commands/donate_spec.rb
@@ -7,13 +7,19 @@ RSpec.describe Commands::Donate do
 
   let(:event) { double("event", respond: nil) }
 
-  it "responds with the donation message, ephemerally" do
-    expect(event).to receive(:respond).with(hash_including(content: described_class::MESSAGE, ephemeral: true))
+  it "responds with a branded container, ephemerally" do
+    expect(event).to receive(:respond) do |components:, ephemeral:, has_components:|
+      expect(ephemeral).to be(true)
+      expect(has_components).to be(true)
+      expect(components.first[:type]).to eq(Discord::Components::CONTAINER)
+    end
     execute
   end
 
   describe "the message content" do
-    subject(:message) { described_class::MESSAGE }
+    subject(:message) do
+      [described_class::COSTS, described_class::PLEDGE, described_class::LINKS, described_class::FOOTER].join("\n")
+    end
 
     it { is_expected.to include("https://paypal.me/trueblackshark") }
     it { is_expected.to include("https://liberapay.com/badBlackShark") }

--- a/spec/bot/commands/donate_spec.rb
+++ b/spec/bot/commands/donate_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe Commands::Donate do
     it { is_expected.to include("https://paypal.me/trueblackshark") }
     it { is_expected.to include("https://liberapay.com/badBlackShark") }
     it { is_expected.to include("10.60€") }
+    it { is_expected.to include("4.99€") }
+    it { is_expected.to include("17.37€") }
     it { is_expected.not_to match(/yahoo/i) }
   end
 end

--- a/spec/bot/server_onboarder_spec.rb
+++ b/spec/bot/server_onboarder_spec.rb
@@ -21,13 +21,14 @@ RSpec.describe ServerOnboarder do
       notify
     end
 
-    it "includes the deep dashboard link in the message" do
-      expect(pm_channel).to receive(:send_message).with(include("https://shrkbot.gg/servers/77"))
-      notify
-    end
-
-    it "includes the server name in the message" do
-      expect(pm_channel).to receive(:send_message).with(include("Dev Refuge"))
+    it "sends a branded container with the deep dashboard link and server name" do
+      expect(pm_channel).to receive(:send_message) do |*args|
+        components = args[6]
+        flags = args[7]
+        expect(flags).to eq(Discord::Components::COMPONENTS_V2)
+        expect(components.to_s).to include("https://shrkbot.gg/servers/77")
+        expect(components.to_s).to include("Dev Refuge")
+      end
       notify
     end
 

--- a/spec/plugins/reminders/commands/list_spec.rb
+++ b/spec/plugins/reminders/commands/list_spec.rb
@@ -19,8 +19,14 @@ RSpec.describe Reminders::List do
       create(:reminder, user_id: 1, channel_id: 2, remind_at: 1.hour.from_now, message: "buy milk")
     end
 
-    it "lists them" do
-      expect(event).to receive(:respond).with(hash_including(content: a_string_including("buy milk")))
+    it "lists them in a branded container" do
+      expect(event).to receive(:respond) do |components:, ephemeral:, has_components:|
+        expect(ephemeral).to be(true)
+        expect(has_components).to be(true)
+        content = components.first[:components].first[:content]
+        expect(content).to include("### Your reminders")
+        expect(content).to include("buy milk")
+      end
       execute
     end
   end

--- a/spec/plugins/reminders/commands/unremind_spec.rb
+++ b/spec/plugins/reminders/commands/unremind_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Reminders::Unremind do
 
     context "when the requester owns the reminder" do
       it "cancels it" do
-        expect(event).to receive(:respond).with(hash_including(content: a_string_including("cancelled")))
+        expect(event).to receive(:respond).with(hash_including(content: a_string_including("canceled")))
         execute
         expect(Reminders::Reminder.exists?(reminder.id)).to be(false)
       end
@@ -62,7 +62,7 @@ RSpec.describe Reminders::Unremind do
         create(:reminder, user_id: 999, message: "not mine")
       end
 
-      it "offers only the requesting user's reminders, labelled with message + absolute time" do
+      it "offers only the requesting user's reminders, labeled with message + absolute time" do
         expect(ac_event).to receive(:respond) do |choices:|
           expect(choices).to match([{name: a_string_including("walk dog", "14:30"), value: mine.id}])
         end

--- a/spec/plugins/reminders/deliver_job_spec.rb
+++ b/spec/plugins/reminders/deliver_job_spec.rb
@@ -6,7 +6,6 @@ require "discordrb" # the job sends over REST; load the client so we can stub it
 RSpec.describe Reminders::DeliverJob do
   subject(:perform) { described_class.perform_now(reminder_id) }
 
-  # REST calls must use the "Bot <token>" form (BotConfig.rest_token).
   let(:reminder) do
     create(:reminder, user_id: 10, channel_id: 20, server_id: 30, remind_at: 1.minute.ago, message: "hello")
   end
@@ -17,8 +16,16 @@ RSpec.describe Reminders::DeliverJob do
   end
 
   context "in a channel" do
-    it "posts the reminder to its channel and then deletes it" do
-      expect(Discordrb::API::Channel).to receive(:create_message).with("Bot tok", 20, a_string_including("hello"))
+    it "posts the reminder as a branded container and then deletes it" do
+      expect(Discordrb::API::Channel).to receive(:create_message) do |token, channel_id, content, _tts, _embeds, _nonce, _attachments, _allowed_mentions, _message_reference, components, flags|
+        expect(token).to eq("Bot tok")
+        expect(channel_id).to eq(20)
+        expect(content).to be_nil
+        expect(flags).to eq(Discord::Components::COMPONENTS_V2)
+        body = components.first[:components].first[:content]
+        expect(body).to include("<@10>")
+        expect(body).to include("hello")
+      end
       perform
       expect(Reminders::Reminder.exists?(reminder.id)).to be(false)
     end
@@ -39,7 +46,7 @@ RSpec.describe Reminders::DeliverJob do
     end
 
     it "delivers to the original channel" do
-      expect(Discordrb::API::Channel).to receive(:create_message).with("Bot tok", 20, anything)
+      expect(Discordrb::API::Channel).to receive(:create_message).with("Bot tok", 20, any_args)
       perform
     end
   end
@@ -51,7 +58,7 @@ RSpec.describe Reminders::DeliverJob do
     end
 
     it "delivers via DM" do
-      expect(Discordrb::API::Channel).to receive(:create_message).with("Bot tok", 77, anything)
+      expect(Discordrb::API::Channel).to receive(:create_message).with("Bot tok", 77, any_args)
       perform
     end
   end
@@ -63,7 +70,7 @@ RSpec.describe Reminders::DeliverJob do
     end
 
     it "delivers via DM" do
-      expect(Discordrb::API::Channel).to receive(:create_message).with("Bot tok", 88, anything)
+      expect(Discordrb::API::Channel).to receive(:create_message).with("Bot tok", 88, any_args)
       perform
     end
   end

--- a/spec/plugins/roles/activity_entry_spec.rb
+++ b/spec/plugins/roles/activity_entry_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Roles::ActivityEntry do
+  subject(:entry) { described_class.build(set:, actor: "<@42>", gained:, lost:) }
+
+  let(:set) { create(:role_set, name: "Pronouns") }
+  let(:gained) { ["Gamer"] }
+  let(:lost) { [] }
+
+  it "titles the entry" do
+    expect(entry[:title]).to eq("Roles updated")
+  end
+
+  it "names the source menu in the meta line" do
+    expect(entry[:meta]).to eq('Self-assigned via the "Pronouns" role menu')
+  end
+
+  context "with gained roles only" do
+    let(:gained) { ["Gamer", "Artist"] }
+
+    it "renders a gained sentence with bold role names" do
+      expect(entry[:body]).to eq("<@42> gained **Gamer** and **Artist**.")
+    end
+  end
+
+  context "with lost roles only" do
+    let(:gained) { [] }
+    let(:lost) { ["Viewer"] }
+
+    it "renders a lost sentence" do
+      expect(entry[:body]).to eq("<@42> lost **Viewer**.")
+    end
+  end
+
+  context "with roles gained and lost in one interaction" do
+    let(:lost) { ["Viewer"] }
+
+    it "renders one combined sentence" do
+      expect(entry[:body]).to eq("<@42> gained **Gamer** and lost **Viewer**.")
+    end
+  end
+end

--- a/spec/plugins/roles/events/pick_spec.rb
+++ b/spec/plugins/roles/events/pick_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe Roles::Pick do
   end
 
   before do
-    allow(ActivityLog).to receive(:record)
+    allow(ActivityLog).to receive(:enabled?).and_return(true)
+    allow(ActivityLog).to receive(:post)
   end
 
   it "adds the picked role and removes the other roles in the set" do
@@ -34,8 +35,12 @@ RSpec.describe Roles::Pick do
   end
 
   it "logs the role the user gained" do
-    expect(ActivityLog).to receive(:record).with(
-      server_config, :roles, :role_gained, bot:, actor: "<@42>", roles: ["Blue"]
+    expect(ActivityLog).to receive(:post).with(
+      server_config,
+      bot:,
+      title: "Roles updated",
+      body: "<@42> gained **Blue**.",
+      meta: "Self-assigned via the \"#{set.name}\" role menu"
     )
     handle
   end

--- a/spec/plugins/roles/events/pick_spec.rb
+++ b/spec/plugins/roles/events/pick_spec.rb
@@ -45,9 +45,18 @@ RSpec.describe Roles::Pick do
     handle
   end
 
-  it "confirms the new selection ephemerally" do
-    expect(event).to receive(:respond).with(content: "**#{set.name}**: Blue", ephemeral: true)
+  it "confirms what changed ephemerally" do
+    expect(event).to receive(:respond).with(content: "You now have **Blue**.", ephemeral: true)
     handle
+  end
+
+  context "when the pick replaces a role the member has" do
+    let(:member) { double("member", roles: [double("role", id: 100)], modify_roles: nil, mention: "<@42>") }
+
+    it "names the swapped-out role in the confirmation" do
+      expect(event).to receive(:respond).with(content: "You now have **Blue** - swapped out **Red**.", ephemeral: true)
+      handle
+    end
   end
 
   context "when the custom id references a role outside the set" do

--- a/spec/plugins/roles/events/select_spec.rb
+++ b/spec/plugins/roles/events/select_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Roles::Select do
   before do
     create(:server_role, server_configuration: server_config, discord_id: 100, name: "News")
     create(:server_role, server_configuration: server_config, discord_id: 200, name: "Events")
-    allow(ActivityLog).to receive(:record)
+    allow(ActivityLog).to receive(:enabled?).and_return(true)
+    allow(ActivityLog).to receive(:post)
   end
 
   let(:user) { double("user", id: 42) }
@@ -30,8 +31,12 @@ RSpec.describe Roles::Select do
   end
 
   it "logs the gained role" do
-    expect(ActivityLog).to receive(:record).with(
-      server_config, :roles, :role_gained, bot:, actor: "<@42>", roles: ["News"]
+    expect(ActivityLog).to receive(:post).with(
+      server_config,
+      bot:,
+      title: "Roles updated",
+      body: "<@42> gained **News**.",
+      meta: "Self-assigned via the \"#{set.name}\" role menu"
     )
     handle
   end
@@ -39,14 +44,32 @@ RSpec.describe Roles::Select do
   context "when the user swaps one role for another" do
     let(:member) { double("member", roles: [double("role", id: 200)], modify_roles: nil, mention: "<@42>") }
 
-    it "logs the gained and lost roles as separate lines" do
-      expect(ActivityLog).to receive(:record).with(
-        server_config, :roles, :role_gained, bot:, actor: "<@42>", roles: ["News"]
-      )
-      expect(ActivityLog).to receive(:record).with(
-        server_config, :roles, :role_lost, bot:, actor: "<@42>", roles: ["Events"]
+    it "logs one combined entry for the gained and lost roles" do
+      expect(ActivityLog).to receive(:post).with(
+        server_config,
+        bot:,
+        title: "Roles updated",
+        body: "<@42> gained **News** and lost **Events**.",
+        meta: "Self-assigned via the \"#{set.name}\" role menu"
       )
       handle
+    end
+
+    context "when only the gained toggle is enabled" do
+      before do
+        allow(ActivityLog).to receive(:enabled?).with(server_config, "roles.role_lost").and_return(false)
+      end
+
+      it "logs only the gained side" do
+        expect(ActivityLog).to receive(:post).with(
+          server_config,
+          bot:,
+          title: "Roles updated",
+          body: "<@42> gained **News**.",
+          meta: "Self-assigned via the \"#{set.name}\" role menu"
+        )
+        handle
+      end
     end
   end
 
@@ -59,9 +82,12 @@ RSpec.describe Roles::Select do
     end
 
     it "logs only the lost roles" do
-      expect(ActivityLog).not_to receive(:record).with(server_config, :roles, :role_gained, any_args)
-      expect(ActivityLog).to receive(:record).with(
-        server_config, :roles, :role_lost, bot:, actor: "<@42>", roles: ["News", "Events"]
+      expect(ActivityLog).to receive(:post).with(
+        server_config,
+        bot:,
+        title: "Roles updated",
+        body: "<@42> lost **News** and **Events**.",
+        meta: "Self-assigned via the \"#{set.name}\" role menu"
       )
       handle
     end
@@ -71,7 +97,20 @@ RSpec.describe Roles::Select do
     let(:member) { double("member", roles: [double("role", id: 100)], modify_roles: nil, mention: "<@42>") }
 
     it "logs nothing" do
-      expect(ActivityLog).not_to receive(:record)
+      expect(ActivityLog).not_to receive(:post)
+      handle
+    end
+  end
+
+  context "when both log toggles are off" do
+    let(:member) { double("member", roles: [double("role", id: 200)], modify_roles: nil, mention: "<@42>") }
+
+    before do
+      allow(ActivityLog).to receive(:enabled?).and_return(false)
+    end
+
+    it "logs nothing" do
+      expect(ActivityLog).not_to receive(:post)
       handle
     end
   end

--- a/spec/plugins/roles/message_spec.rb
+++ b/spec/plugins/roles/message_spec.rb
@@ -167,10 +167,12 @@ RSpec.describe Roles::Message do
     end
   end
 
-  describe ".selection_summary" do
-    subject(:summary) { described_class.selection_summary(set, active) }
+  describe ".pick_confirmation" do
+    subject(:confirmation) { described_class.pick_confirmation(set, picked, had) }
 
     let(:set) { create(:role_set, role_setting: setting, name: "Color") }
+    let(:picked) { 200 }
+    let(:had) { [] }
 
     before do
       create(:assignable_role, role_set: set, role_id: 100, position: 0)
@@ -179,19 +181,33 @@ RSpec.describe Roles::Message do
       sync_role(200, "Blue")
     end
 
-    context "with roles selected" do
-      let(:active) { [200] }
-
-      it "lists the chosen synced role names" do
-        expect(summary).to eq("**Color**: Blue")
+    context "when the member had no role from the set" do
+      it "confirms the new role" do
+        expect(confirmation).to eq("You now have **Blue**.")
       end
     end
 
-    context "with nothing selected" do
-      let(:active) { [] }
+    context "when the pick replaces another role" do
+      let(:had) { [100] }
 
-      it "says none" do
-        expect(summary).to eq("**Color**: none")
+      it "names what was swapped out" do
+        expect(confirmation).to eq("You now have **Blue** - swapped out **Red**.")
+      end
+    end
+
+    context "when the member picks the role they already have" do
+      let(:had) { [200] }
+
+      it "says nothing changed" do
+        expect(confirmation).to eq("No change - you already have **Blue**.")
+      end
+    end
+
+    context "when a picked role is missing from the sync" do
+      let(:picked) { 300 }
+
+      it "falls back to the placeholder" do
+        expect(confirmation).to eq("You now have **Unknown role**.")
       end
     end
   end

--- a/spec/plugins/roles/message_spec.rb
+++ b/spec/plugins/roles/message_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Roles::Message do
       end
 
       it "explains the multi-select" do
-        expect(text_block(rendered)[:content]).to include("Select all roles that apply")
+        expect(text_block(rendered)[:content]).to include("Pick any of these roles")
       end
 
       it "separates the text from the controls" do

--- a/spec/presenters/notification_presenter_spec.rb
+++ b/spec/presenters/notification_presenter_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe NotificationPresenter do
 
   describe "#message" do
     it "returns the localised message" do
-      expect(presenter.message).to eq("Logging was affected — choose a new channel")
+      expect(presenter.message).to eq("Logging was affected - choose a new channel")
     end
   end
 

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Home", type: :request do
   it "shows the hero headline" do
     home
 
-    expect(response.body).to include("Turn features")
+    expect(response.body).to include("You pick the parts.")
   end
 
   it "uses the brand display type for the wordmark" do

--- a/spec/requests/roles_config_spec.rb
+++ b/spec/requests/roles_config_spec.rb
@@ -71,12 +71,12 @@ RSpec.describe "Roles config", type: :request do
         it "warns about roles shrkbot can't assign" do
           create(:server_role, server_configuration: config, name: "Integration", discord_id: 333, managed: true)
           get server_roles_path(guild.id)
-          expect(response.body).to include("Greyed-out roles")
+          expect(response.body).to include("Grayed-out roles")
         end
 
         it "omits the warning when every role is assignable" do
           get server_roles_path(guild.id)
-          expect(response.body).not_to include("Greyed-out roles")
+          expect(response.body).not_to include("Grayed-out roles")
         end
       end
 


### PR DESCRIPTION
Pre-deploy pass over all user-facing text, checked against the design system's content fundamentals.

## Activity log restyle
One interaction now writes **one** branded container entry instead of separate bare-text lines:

> **Roles updated**
> @Member gained **Gamer** and lost **Viewer**.
> \-# Self-assigned via the "Pronouns" role menu

- `ActivityLog` split into `enabled?` (toggle gating) + `post` (container delivery); `Roles::ActivityEntry` owns the message shape.
- Each side of a swap is still gated by its own web toggle - lost-toggle off logs only the gained half.
- Mention pings are suppressed in log entries, so logging a member's action no longer notifies them.

## Copy sweep
- American English throughout (canceled, grayed-out).
- Em dashes removed from all user-facing copy per the voice rules.
- Emoji trimmed to a minimal status set (⚠️ errors, 🚫 permission denied, 🦈 in /ping as the mascot moment); decorative ones removed.
- Presence advertised `/help`, which doesn't exist - now `/info`.
- Onboarding DM now renders as the branded accent container like every other bot surface.
- Role menu copy: friendlier multi-select wording, arrow-free manage hint.
- Website copy: spelling + dash fixes only; the rest read fine.

Docs: `architecture.md` activity-logging section rewritten for the composite-entry design.

Gates: rspec (895), standardrb, active_record_doctor, i18n-tasks missing/check-normalized, undercover - all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-up: remaining surface restyles
- `/donate` containerized: costs / pledge / links / muted footer as separated blocks, markdown links instead of bare URLs.
- `/reminders` containerized with a `### Your reminders` heading; empty state stays a plain one-liner.
- Reminder delivery containerized over REST. **Needs a live check that the `<@user>` mention still pings from inside the component** - Components V2 forbids a `content` field.
- Boyscout: `Discord::Components.send_to` extracts the positional `send_message` shape four call sites were each spelling out.