### PR TITLE
Trim OAuth scope and add retention caps

### DIFF
--- a/config/cache.yml
+++ b/config/cache.yml
@@ -1,7 +1,6 @@
 default: &default
   store_options:
-    # Cap age of oldest cache entry to fulfill retention policies
-    # max_age: <%= 60.days.to_i %>
+    max_age: <%= 60.days.to_i %>
     max_size: <%= 256.megabytes %>
     namespace: <%= Rails.env %>
 

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -4,7 +4,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   provider :discord,
     ENV["DISCORD_CLIENT_ID"],
     ENV["DISCORD_CLIENT_SECRET"],
-    scope: "identify email guilds"
+    scope: "identify guilds"
 end
 
 OmniAuth.config.on_failure = proc do |env|

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -13,3 +13,6 @@ production:
   clear_solid_queue_finished_jobs:
     command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
     schedule: every hour at minute 12
+  clear_stale_failed_jobs:
+    command: "SolidQueue::FailedExecution.where(created_at: ...30.days.ago).discard_all_in_batches"
+    schedule: every day at 4am


### PR DESCRIPTION
First chunk of the GDPR/privacy work (ahead of account deletion, guild-kick purge, and the policy pages).

- Drop the `email` OAuth scope — nothing in the app reads or stores it, so requesting it only widens consent surface (data minimization).
- Enable solid_cache `max_age` of 60 days so cache entries don't persist unbounded.
- Add a daily recurring task discarding failed Solid Queue jobs older than 30 days (finished jobs were already cleared hourly; failed ones lived forever).