### PR TITLE
Let users delete their account and reminders

### DIFF
--- a/app/components/app_shell.rb
+++ b/app/components/app_shell.rb
@@ -4,7 +4,6 @@ class Components::AppShell < Components::Base
   include Phlex::Rails::Helpers::ImageTag
   include Phlex::Rails::Helpers::ButtonTo
   include Phlex::Rails::Helpers::TurboFrameTag
-  include Components::Initials
 
   def initialize(user:, current_server: nil, current_server_id: nil, servers: [], plugin_counts: {}, sidebar: nil)
     @user = user
@@ -120,7 +119,7 @@ class Components::AppShell < Components::Base
         data: {action: "click->dropdown#toggle"},
         class: "flex h-10 cursor-pointer list-none items-center gap-2 rounded-full pl-1 pr-2.5 transition-colors hover:bg-surface-sunken [&::-webkit-details-marker]:hidden"
       ) do
-        avatar
+        render Components::UserAvatar.new(user: @user, size: :sm)
         span(class: "hidden text-sm font-medium sm:block") { @user.display_name }
         render Components::Icon.new("caret-down", class: "dropdown-chevron size-4 text-text-muted")
       end
@@ -156,14 +155,6 @@ class Components::AppShell < Components::Base
           span { t(".log_out") }
         end
       end
-    end
-  end
-
-  def avatar
-    if @user.avatar_url
-      image_tag(@user.avatar_url, alt: "", loading: "lazy", class: "size-8 rounded-full object-cover")
-    else
-      span(class: "flex size-8 items-center justify-center rounded-full bg-accent-soft text-xs font-bold text-accent-soft-fg") { initials(@user.display_name) }
     end
   end
 end

--- a/app/components/app_shell.rb
+++ b/app/components/app_shell.rb
@@ -129,6 +129,14 @@ class Components::AppShell < Components::Base
         data: {dropdown_target: "menu"},
         class: "dropdown-menu absolute right-0 top-12 z-40 w-52 rounded-lg border border-border-default bg-surface-card p-1.5 shadow-lg"
       ) do
+        a(
+          href: account_path,
+          class: "flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-sm text-text-secondary transition-colors hover:bg-surface-sunken"
+        ) do
+          render Components::Icon.new("user", class: "size-4")
+          span { t(".account") }
+        end
+        div(class: "mx-1 my-1 h-px bg-surface-sunken")
         if @user.owner?
           a(
             href: admin_settings_path,

--- a/app/components/user_avatar.rb
+++ b/app/components/user_avatar.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class Components::UserAvatar < Components::Base
+  include Phlex::Rails::Helpers::ImageTag
+  include Components::Initials
+
+  SIZES = {
+    sm: {box: "size-8", text: "text-xs"},
+    lg: {box: "size-16", text: "text-lg"}
+  }.freeze
+
+  def initialize(user:, size:)
+    @user = user
+    @size = size
+  end
+
+  def view_template
+    if @user.avatar_url
+      image_tag(@user.avatar_url, alt: "", loading: "lazy", class: "#{dims[:box]} rounded-full object-cover")
+    else
+      span(class: "flex #{dims[:box]} items-center justify-center rounded-full bg-accent-soft #{dims[:text]} font-bold text-accent-soft-fg") do
+        initials(@user.display_name)
+      end
+    end
+  end
+
+  private
+
+  def dims
+    SIZES.fetch(@size)
+  end
+end

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AccountsController < ApplicationController
+  def show
+    render Views::Accounts::Show.new(
+      user: current_user,
+      reminder_count: ::Reminders::Reminder.for_user(current_user.discord_id).count
+    )
+  end
+
+  def destroy
+    Ops::Users::Destroy.call(user: current_user)
+    reset_session
+    redirect_to root_path, notice: t("accounts.deleted")
+  end
+end

--- a/app/operations/users/destroy.rb
+++ b/app/operations/users/destroy.rb
@@ -6,7 +6,7 @@ module Ops
       receives :user
 
       def call
-        ::Reminders::Reminder.where(user_id: user.discord_id).delete_all
+        ::Reminders::Reminder.for_user(user.discord_id).delete_all
         user.destroy!
         ok(user)
       end

--- a/app/operations/users/destroy.rb
+++ b/app/operations/users/destroy.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Ops
+  module Users
+    class Destroy < ApplicationOperation
+      receives :user
+
+      def call
+        ::Reminders::Reminder.where(user_id: user.discord_id).delete_all
+        user.destroy!
+        ok(user)
+      end
+    end
+  end
+end

--- a/app/views/accounts/show.rb
+++ b/app/views/accounts/show.rb
@@ -2,8 +2,6 @@
 
 class Views::Accounts::Show < Views::Base
   include Phlex::Rails::Helpers::ButtonTo
-  include Phlex::Rails::Helpers::ImageTag
-  include Components::Initials
 
   def initialize(user:, reminder_count:)
     @user = user
@@ -32,7 +30,7 @@ class Views::Accounts::Show < Views::Base
   def data_card
     render Components::Card.new(class: "mb-6 flex flex-col gap-4") do
       div(class: "flex items-center gap-4") do
-        avatar
+        render Components::UserAvatar.new(user: @user, size: :lg)
         div do
           p(class: "font-semibold") { @user.display_name }
           p(class: "text-sm text-text-secondary") { @user.username }
@@ -53,16 +51,6 @@ class Views::Accounts::Show < Views::Base
         data: {turbo_confirm: t(".confirm")},
         class: "rounded-md border border-danger px-4 py-2 text-sm font-semibold text-danger transition-colors hover:bg-danger-soft"
       ) { t(".button") }
-    end
-  end
-
-  def avatar
-    if @user.avatar_url
-      image_tag(@user.avatar_url, alt: "", loading: "lazy", class: "size-16 rounded-full object-cover")
-    else
-      span(class: "flex size-16 items-center justify-center rounded-full bg-accent-soft text-lg font-bold text-accent-soft-fg") do
-        initials(@user.display_name)
-      end
     end
   end
 end

--- a/app/views/accounts/show.rb
+++ b/app/views/accounts/show.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+class Views::Accounts::Show < Views::Base
+  include Phlex::Rails::Helpers::ButtonTo
+  include Phlex::Rails::Helpers::ImageTag
+  include Components::Initials
+
+  def initialize(user:, reminder_count:)
+    @user = user
+    @reminder_count = reminder_count
+  end
+
+  def view_template
+    render Components::AppShell.new(user: @user) do
+      div(class: "mx-auto max-w-2xl px-6 py-10") do
+        heading
+        data_card
+        danger_card
+      end
+    end
+  end
+
+  private
+
+  def heading
+    div(class: "mb-6") do
+      h1(class: "mb-1 font-display text-2xl font-bold tracking-tight") { t(".title") }
+      p(class: "text-text-secondary") { t(".subtitle") }
+    end
+  end
+
+  def data_card
+    render Components::Card.new(class: "mb-6 flex flex-col gap-4") do
+      div(class: "flex items-center gap-4") do
+        avatar
+        div do
+          p(class: "font-semibold") { @user.display_name }
+          p(class: "text-sm text-text-secondary") { @user.username }
+          p(class: "text-sm text-text-secondary") { @user.discord_id.to_s }
+        end
+      end
+      p(class: "text-sm text-text-secondary") { t(".reminders", count: @reminder_count) }
+    end
+  end
+
+  def danger_card
+    render Components::Card.new do
+      h2(class: "mb-2 font-semibold") { t(".danger_title") }
+      p(class: "mb-4 text-sm text-text-secondary") { t(".danger_body") }
+      button_to(
+        account_path,
+        method: :delete,
+        data: {turbo_confirm: t(".confirm")},
+        class: "rounded-md border border-danger px-4 py-2 text-sm font-semibold text-danger transition-colors hover:bg-danger-soft"
+      ) { t(".button") }
+    end
+  end
+
+  def avatar
+    if @user.avatar_url
+      image_tag(@user.avatar_url, alt: "", loading: "lazy", class: "size-16 rounded-full object-cover")
+    else
+      span(class: "flex size-16 items-center justify-center rounded-full bg-accent-soft text-lg font-bold text-accent-soft-fg") do
+        initials(@user.display_name)
+      end
+    end
+  end
+end

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -1,7 +1,7 @@
 ---
 en:
   accounts:
-    deleted: Your account and reminders have been deleted.
+    deleted: Your account and all associated data have been deleted.
   admin:
     owner_only: Only the bot owner can open that page.
     settings:
@@ -197,10 +197,10 @@ en:
     accounts:
       show:
         button: Delete my account
-        confirm: Delete your account and all your reminders? This cannot be undone.
-        danger_body: Permanently deletes your account and all your pending reminders.
-          Role assignments and server settings belong to their servers and are not
-          affected. This cannot be undone.
+        confirm: Delete your account and all associated data? This cannot be undone.
+        danger_body: Permanently deletes your account and all data associated with
+          it. Role assignments and server settings belong to their servers and are
+          not affected. This cannot be undone.
         danger_title: Delete account
         reminders:
           one: 1 pending reminder

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -1,5 +1,7 @@
 ---
 en:
+  accounts:
+    deleted: Your account and reminders have been deleted.
   admin:
     owner_only: Only the bot owner can open that page.
     settings:
@@ -16,6 +18,7 @@ en:
         description: Sends you a Discord DM when shrkbot hits an unexpected error.
         label: DM me on errors
     app_shell:
+      account: Account
       add_server: Add another server
       admin_settings: Admin settings
       log_out: Log out
@@ -191,6 +194,20 @@ en:
     signed_in: Signed in as %{name}.
     signed_out: Signed out.
   views:
+    accounts:
+      show:
+        button: Delete my account
+        confirm: Delete your account and all your reminders? This cannot be undone.
+        danger_body: Permanently deletes your account and all your pending reminders.
+          Role assignments and server settings belong to their servers and are not
+          affected. This cannot be undone.
+        danger_title: Delete account
+        reminders:
+          one: 1 pending reminder
+          other: "%{count} pending reminders"
+          zero: No pending reminders
+        subtitle: What shrkbot stores about you.
+        title: Account
     admin:
       settings:
         show:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   match "/auth/discord/callback", to: "sessions#create", via: [:get, :post]
   get "/auth/failure", to: "sessions#failure"
   delete "/logout", to: "sessions#destroy", as: :logout
+  resource :account, only: [:show, :destroy]
 
   resources :notifications, only: [:index, :show, :update]
   namespace :notifications do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", :as => :rails_health_check
 
   root "pages#home"
@@ -35,11 +31,4 @@ Rails.application.routes.draw do
       end
     end
   end
-
-  # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
-  # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
-  # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
-
-  # Defines the root path route ("/")
-  # root "posts#index"
 end

--- a/spec/components/user_avatar_spec.rb
+++ b/spec/components/user_avatar_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::UserAvatar do
+  include_context "component view context"
+
+  subject(:html) { described_class.new(user:, size:).render_in(view_context) }
+
+  let(:user) { build(:user, avatar: "abc123", display_name: "Shark Bot") }
+  let(:size) { :sm }
+
+  it "renders the Discord avatar image" do
+    expect(html).to include(user.avatar_url).and include("size-8")
+  end
+
+  context "without an avatar" do
+    let(:user) { build(:user, avatar: nil, display_name: "Shark Bot") }
+
+    it "falls back to initials" do
+      expect(html).to include("SB").and include("bg-accent-soft")
+    end
+  end
+
+  context "with the large size" do
+    let(:size) { :lg }
+
+    it "renders the larger frame" do
+      expect(html).to include("size-16")
+    end
+  end
+end

--- a/spec/operations/users/destroy_spec.rb
+++ b/spec/operations/users/destroy_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Ops::Users::Destroy do
+  subject(:result) { described_class.call(user:) }
+
+  let(:user) { create(:user) }
+  let!(:reminder) { create(:reminder, user_id: user.discord_id) }
+  let!(:other_reminder) { create(:reminder) }
+
+  it "destroys the user" do
+    result
+    expect(User.exists?(user.id)).to be(false)
+  end
+
+  it "deletes reminders whose user_id equals the user's discord_id" do
+    result
+    expect(Reminders::Reminder.exists?(reminder.id)).to be(false)
+  end
+
+  it "leaves other users' reminders untouched" do
+    result
+    expect(Reminders::Reminder.exists?(other_reminder.id)).to be(true)
+  end
+
+  it "returns success" do
+    expect(result.success?).to be(true)
+  end
+end

--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Accounts", type: :request do
+  include_context "discord auth"
+
+  context "when signed out" do
+    it "GET /account redirects to root" do
+      get account_path
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  context "when signed in" do
+    before { post "/auth/discord/callback" }
+
+    describe "GET /account" do
+      it "responds ok" do
+        get account_path
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe "DELETE /account" do
+      let(:user) { User.find_by(discord_id: 12345) }
+      let!(:reminder) { create(:reminder, user_id: user.discord_id) }
+
+      it "destroys the user" do
+        expect { delete account_path }.to change(User, :count).by(-1)
+      end
+
+      it "deletes the user's reminders" do
+        expect { delete account_path }.to change(Reminders::Reminder, :count).by(-1)
+      end
+
+      it "redirects to root" do
+        delete account_path
+        expect(response).to redirect_to(root_path)
+      end
+
+      it "clears the session so a subsequent authenticated request redirects" do
+        delete account_path
+        get account_path
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end

--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Accounts", type: :request do
     end
 
     describe "DELETE /account" do
-      let(:user) { User.find_by(discord_id: 12345) }
+      let(:user) { User.find_by(discord_id: auth.uid) }
       let!(:reminder) { create(:reminder, user_id: user.discord_id) }
 
       it "destroys the user" do


### PR DESCRIPTION
Second chunk of the GDPR/privacy work (Art. 17 right to erasure), ahead of the guild-removal purge and the policy pages.

- New account page (`/account`) shows what shrkbot stores about the signed-in user: profile mirror (avatar, names, Discord ID) and pending reminder count.
- Danger zone with a confirmed delete button: `Ops::Users::Destroy` removes the user row and all their reminders, then the session is reset.
- `Account` entry added to the user menu.
- Boyscout: extracted `Components::UserAvatar` (avatar-with-initials fallback was duplicated between AppShell and the new page), removed `rails new` scaffolding comments from `routes.rb`.

Server-side rows that reference member snowflakes (channel permission overwrites) are mirrors of live Discord state and are deliberately untouched — they fall to the guild-removal purge coming next.