### PR TITLE
Purge all guild data when the bot is removed

### DIFF
--- a/app/bot/server_cleanup.rb
+++ b/app/bot/server_cleanup.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class ServerCleanup < BaseEvent
+  on :server_delete
+
+  def handle
+    config = ::ServerConfiguration.find_by(discord_id: event.server)
+    return unless config
+
+    Ops::ServerConfiguration::Destroy.call(server_configuration: config)
+  end
+end

--- a/app/operations/server_configuration/destroy.rb
+++ b/app/operations/server_configuration/destroy.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Ops
+  module ServerConfiguration
+    class Destroy < ApplicationOperation
+      receives :server_configuration
+
+      def call
+        purge_reminders
+        server_configuration.destroy!
+        ok(server_configuration)
+      end
+
+      private
+
+      def purge_reminders
+        reminders = ::Reminders::Reminder.where(server_id: server_configuration.discord_id)
+        channel_bound = reminders.where(deliver_via_dm: false)
+        if server_configuration.force_dm_reminders
+          channel_bound.update_all(deliver_via_dm: true)
+        else
+          channel_bound.delete_all
+        end
+        reminders.update_all(server_id: nil)
+      end
+    end
+  end
+end

--- a/spec/bot/server_cleanup_spec.rb
+++ b/spec/bot/server_cleanup_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ServerCleanup do
+  subject(:handle) { described_class.new(event).handle }
+
+  let(:event) { double("event", server: 1) }
+
+  let(:op) { Ops::ServerConfiguration::Destroy }
+
+  context "for a configured server" do
+    let!(:config) { create(:server_configuration, discord_id: 1) }
+
+    it "calls the destroy operation with the config" do
+      expect(op).to receive(:call).with(server_configuration: config)
+      handle
+    end
+  end
+
+  context "for an unconfigured server" do
+    it "does not call the destroy operation" do
+      expect(op).not_to receive(:call)
+      handle
+    end
+  end
+end

--- a/spec/operations/server_configuration/destroy_spec.rb
+++ b/spec/operations/server_configuration/destroy_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Ops::ServerConfiguration::Destroy do
+  subject(:result) { described_class.call(server_configuration: config) }
+
+  let!(:config) { create(:server_configuration) }
+
+  it "destroys the server configuration" do
+    result
+
+    expect(ServerConfiguration.find_by(id: config.id)).to be_nil
+  end
+
+  it "returns success" do
+    expect(result).to be_success
+  end
+
+  context "cascade to associated rows" do
+    let!(:plugin) { create(:plugin, key: "test", name: "Test") }
+    let!(:plugin_activation) { create(:plugin_activation, server_configuration: config, plugin:) }
+    let!(:welcome_settings) { create(:welcome_settings, server_configuration: config) }
+    let!(:server_channel) { create(:server_channel, server_configuration: config) }
+    let!(:channel_overwrite) { create(:channel_overwrite, server_channel:) }
+    let!(:server_role) { create(:server_role, server_configuration: config) }
+    let!(:notification) { create(:notification, server_configuration: config) }
+    let!(:role_setting) { create(:role_setting, server_configuration: config) }
+    let!(:role_set) { create(:role_set, role_setting:) }
+    let!(:assignable_role) { create(:assignable_role, role_set:) }
+
+    it "removes all associated rows" do
+      result
+
+      expect(PluginActivation.find_by(id: plugin_activation.id)).to be_nil
+      expect(Welcomes::Settings.find_by(id: welcome_settings.id)).to be_nil
+      expect(ServerChannel.find_by(id: server_channel.id)).to be_nil
+      expect(ChannelOverwrite.find_by(id: channel_overwrite.id)).to be_nil
+      expect(ServerRole.find_by(id: server_role.id)).to be_nil
+      expect(Notification.find_by(id: notification.id)).to be_nil
+      expect(Roles::Settings.find_by(id: role_setting.id)).to be_nil
+      expect(Roles::Set.find_by(id: role_set.id)).to be_nil
+      expect(Roles::AssignableRole.find_by(id: assignable_role.id)).to be_nil
+    end
+  end
+
+  context "reminder handling" do
+    let(:guild_id) { config.discord_id }
+    let!(:channel_reminder) { create(:reminder, server_id: guild_id, deliver_via_dm: false) }
+    let!(:dm_reminder) { create(:reminder, server_id: guild_id, deliver_via_dm: true) }
+    let!(:other_guild_reminder) { create(:reminder, server_id: guild_id + 1, deliver_via_dm: false) }
+
+    it "deletes channel-bound reminders for the guild" do
+      result
+
+      expect(Reminders::Reminder.find_by(id: channel_reminder.id)).to be_nil
+    end
+
+    it "keeps DM reminders for the guild but nulls their server_id" do
+      result
+
+      dm_reminder.reload
+      expect(dm_reminder).to be_present
+      expect(dm_reminder.server_id).to be_nil
+    end
+
+    it "leaves reminders for other guilds untouched" do
+      result
+
+      other_guild_reminder.reload
+      expect(other_guild_reminder.server_id).to eq(guild_id + 1)
+    end
+
+    context "when force_dm_reminders is true" do
+      let!(:config) { create(:server_configuration, force_dm_reminders: true) }
+
+      it "flips channel-bound reminders to deliver_via_dm instead of deleting them" do
+        result
+
+        channel_reminder.reload
+        expect(channel_reminder).to be_present
+        expect(channel_reminder.deliver_via_dm).to be(true)
+      end
+
+      it "nulls server_id on channel-bound reminders" do
+        result
+
+        channel_reminder.reload
+        expect(channel_reminder.server_id).to be_nil
+      end
+
+      it "also nulls server_id on DM reminders" do
+        result
+
+        dm_reminder.reload
+        expect(dm_reminder.server_id).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Third chunk of the GDPR/privacy work: when shrkbot is kicked from (or leaves) a guild, all data for that guild is purged.

- `ServerCleanup` handles `:server_delete` and hands the guild's `ServerConfiguration` to the new `Ops::ServerConfiguration::Destroy`. discordrb already swallows outage-flagged `GUILD_DELETE` payloads, so the handler only fires on real removal — no accidental purges during Discord outages.
- The existing `dependent:` cascade covers everything guild-scoped (channels + overwrites, roles, role sets + assignable roles, welcome/logging settings, plugin activations, notifications).
- Reminders aren't associated, so the op handles them by intent: channel-bound reminders are deleted (their target channel is gone), DM reminders survive with `server_id` cleared, and guilds with `force_dm_reminders` get channel reminders flipped to DM instead of deleted.