### PR TITLE
Add privacy policy and terms of service pages

### DIFF
--- a/app/components/app_shell.rb
+++ b/app/components/app_shell.rb
@@ -26,10 +26,17 @@ class Components::AppShell < Components::Base
       else
         main(class: "flex-1") { yield }
       end
+      footer_bar
     end
   end
 
   private
+
+  def footer_bar
+    footer(class: "border-t border-border-default px-6 py-4") do
+      render Components::LegalLinks.new
+    end
+  end
 
   def top_bar
     header(class: "app-bar z-30 flex h-16 flex-none items-center gap-3 px-5") do

--- a/app/components/legal_links.rb
+++ b/app/components/legal_links.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class Components::LegalLinks < Components::Base
+  def view_template
+    nav(class: "flex items-center justify-center gap-4 text-xs text-text-muted") do
+      a(href: privacy_policy_path, class: link_classes) { t(".privacy") }
+      a(href: terms_of_service_path, class: link_classes) { t(".terms") }
+    end
+  end
+
+  private
+
+  def link_classes
+    "underline transition-colors hover:text-text-secondary"
+  end
+end

--- a/app/components/legal_page.rb
+++ b/app/components/legal_page.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Components::LegalPage < Components::Base
+  CONTACT_EMAIL = "info@shrkbot.com"
+  SUPPORT_URL = "https://discord.gg/3gwFMTY"
+
   def initialize(title:, updated:)
     @title = title
     @updated = updated
@@ -12,7 +15,24 @@ class Components::LegalPage < Components::Base
         h1(class: "mb-2 font-display text-3xl font-bold tracking-tight") { @title }
         p(class: "mb-10 text-sm text-text-muted") { @updated }
         yield
+        contact_section
       end
     end
+  end
+
+  private
+
+  def contact_section
+    h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { t(".contact_h") }
+    p(class: "mb-4 leading-relaxed text-text-secondary") do
+      plain "#{t(".contact_operator")} — "
+      a(href: "mailto:#{CONTACT_EMAIL}", class: link_classes) { CONTACT_EMAIL }
+      plain " / "
+      a(href: SUPPORT_URL, class: link_classes) { t(".contact_support") }
+    end
+  end
+
+  def link_classes
+    "underline transition-colors hover:text-text-primary"
   end
 end

--- a/app/components/legal_page.rb
+++ b/app/components/legal_page.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Components::LegalPage < Components::Base
+  def initialize(title:, updated:)
+    @title = title
+    @updated = updated
+  end
+
+  def view_template(&block)
+    render Components::PublicShell.new do
+      article(class: "mx-auto max-w-2xl px-6 py-16") do
+        h1(class: "mb-2 font-display text-3xl font-bold tracking-tight") { @title }
+        p(class: "mb-10 text-sm text-text-muted") { @updated }
+        yield
+      end
+    end
+  end
+end

--- a/app/components/legal_prose.rb
+++ b/app/components/legal_prose.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Components::LegalProse
+  private
+
+  def heading(text)
+    h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { text }
+  end
+
+  def paragraph(text)
+    p(class: "mb-4 leading-relaxed text-text-secondary") { text }
+  end
+
+  def bullets(*items)
+    ul(class: "mb-4 list-disc space-y-2 pl-6 text-text-secondary") do
+      items.each { |item| li { item } }
+    end
+  end
+end

--- a/app/components/public_shell.rb
+++ b/app/components/public_shell.rb
@@ -43,9 +43,8 @@ class Components::PublicShell < Components::Base
       plain t(".footer_mid")
       span(class: "text-accent-2-text") { "♥" }
       plain t(".footer_post")
-      nav(class: "mt-3 flex items-center justify-center gap-4") do
-        a(href: privacy_policy_path, class: "underline transition-colors hover:text-text-secondary") { t(".privacy") }
-        a(href: terms_of_service_path, class: "underline transition-colors hover:text-text-secondary") { t(".terms") }
+      div(class: "mt-3") do
+        render Components::LegalLinks.new
       end
     end
   end

--- a/app/components/public_shell.rb
+++ b/app/components/public_shell.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class Components::PublicShell < Components::Base
+  include Phlex::Rails::Helpers::ButtonTo
+  include Phlex::Rails::Helpers::ImageTag
+
+  REPO_URL = "https://github.com/badBlackShark/shrkbot"
+
+  def view_template(&block)
+    div(class: "flex min-h-screen flex-col") do
+      header_bar
+      main(class: "flex-1") { yield }
+      footer_bar
+    end
+  end
+
+  private
+
+  def header_bar
+    header(class: "app-bar z-30 flex h-16 items-center gap-3 px-6") do
+      image_tag("shrkbot-mascot.png", alt: "shrkbot", class: "size-9 rounded-control")
+      span(class: "font-display text-lg font-bold tracking-tight") do
+        render Components::Wordmark.new
+      end
+      div(class: "flex-1")
+      render Components::ThemeToggle.new
+      button_to(
+        "/auth/discord",
+        method: :post,
+        data: {turbo: false},
+        class: Components::Button.css(variant: :primary, size: :lg)
+      ) do
+        render Components::Icon.new("sign-in", class: "size-4")
+        span { t(".sign_in") }
+      end
+    end
+  end
+
+  def footer_bar
+    footer(class: "border-t border-border-default px-6 py-8 text-center text-xs text-text-muted") do
+      plain t(".footer_pre")
+      a(href: REPO_URL, class: "underline transition-colors hover:text-text-secondary") { t(".footer_link") }
+      plain t(".footer_mid")
+      span(class: "text-accent-2-text") { "♥" }
+      plain t(".footer_post")
+      nav(class: "mt-3 flex items-center justify-center gap-4") do
+        a(href: privacy_policy_path, class: "underline transition-colors hover:text-text-secondary") { t(".privacy") }
+        a(href: terms_of_service_path, class: "underline transition-colors hover:text-text-secondary") { t(".terms") }
+      end
+    end
+  end
+end

--- a/app/controllers/privacy_policies_controller.rb
+++ b/app/controllers/privacy_policies_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class PrivacyPoliciesController < ApplicationController
+  skip_before_action :require_login
+
+  def show
+    render Views::PrivacyPolicy.new
+  end
+end

--- a/app/controllers/terms_of_services_controller.rb
+++ b/app/controllers/terms_of_services_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class TermsOfServicesController < ApplicationController
+  skip_before_action :require_login
+
+  def show
+    render Views::TermsOfService.new
+  end
+end

--- a/app/views/home.rb
+++ b/app/views/home.rb
@@ -5,40 +5,14 @@ class Views::Home < Views::Base
   include Phlex::Rails::Helpers::ImageTag
   include Components::PluginNav
 
-  REPO_URL = "https://github.com/badBlackShark/shrkbot"
-
   def view_template
-    div(class: "flex min-h-screen flex-col") do
-      header_bar
-      main(class: "flex-1") do
-        hero
-        plugin_showcase
-      end
-      footer_bar
+    render Components::PublicShell.new do
+      hero
+      plugin_showcase
     end
   end
 
   private
-
-  def header_bar
-    header(class: "app-bar z-30 flex h-16 items-center gap-3 px-6") do
-      image_tag("shrkbot-mascot.png", alt: "shrkbot", class: "size-9 rounded-control")
-      span(class: "font-display text-lg font-bold tracking-tight") do
-        render Components::Wordmark.new
-      end
-      div(class: "flex-1")
-      render Components::ThemeToggle.new
-      button_to(
-        "/auth/discord",
-        method: :post,
-        data: {turbo: false},
-        class: Components::Button.css(variant: :primary, size: :lg)
-      ) do
-        render Components::Icon.new("sign-in", class: "size-4")
-        span { t(".sign_in") }
-      end
-    end
-  end
 
   def hero
     section(class: "mx-auto flex max-w-4xl flex-col items-center gap-12 px-6 py-20 sm:flex-row") do
@@ -62,7 +36,7 @@ class Views::Home < Views::Base
             span { t(".add_to_server") }
           end
           a(
-            href: REPO_URL,
+            href: Components::PublicShell::REPO_URL,
             target: "_blank",
             rel: "noopener",
             class: Components::Button.css(variant: :secondary, size: :xl, extra: "text-sm")
@@ -104,16 +78,6 @@ class Views::Home < Views::Base
       end
       p(class: "font-display text-sm font-semibold") { t("components.plugin_row.plugin.#{key}.name") }
       p(class: "mt-1 text-sm leading-relaxed text-text-secondary") { t(".plugins.#{key}") }
-    end
-  end
-
-  def footer_bar
-    footer(class: "border-t border-border-default px-6 py-8 text-center text-xs text-text-muted") do
-      plain t(".footer_pre")
-      a(href: REPO_URL, class: "underline transition-colors hover:text-text-secondary") { t(".footer_link") }
-      plain t(".footer_mid")
-      span(class: "text-accent-2-text") { "♥" }
-      plain t(".footer_post")
     end
   end
 end

--- a/app/views/privacy_policy.rb
+++ b/app/views/privacy_policy.rb
@@ -1,16 +1,23 @@
 # frozen_string_literal: true
 
 class Views::PrivacyPolicy < Views::Base
+  include Components::LegalProse
+
   def view_template
     render Components::LegalPage.new(title: t(".title"), updated: t(".updated")) do
       intro_section
-      controller_section
+      audience_section
       data_section
-      purpose_section
+      messages_section
+      not_section
+      basis_section
       sharing_section
       retention_section
+      deletion_section
       rights_section
+      security_section
       cookies_section
+      children_section
       changes_section
     end
   end
@@ -18,60 +25,90 @@ class Views::PrivacyPolicy < Views::Base
   private
 
   def intro_section
-    p(class: "mb-4 leading-relaxed text-text-secondary") { t(".intro") }
+    paragraph(t(".intro_1"))
+    paragraph(t(".intro_2"))
   end
 
-  def controller_section
-    h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { t(".controller_h") }
-    p(class: "mb-4 leading-relaxed text-text-secondary") { t(".controller_p") }
+  def audience_section
+    heading(t(".audience_h"))
+    bullets(t(".audience_members"), t(".audience_dashboard"))
   end
 
   def data_section
-    h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { t(".data_h") }
-    p(class: "mb-4 leading-relaxed text-text-secondary") { t(".data_lead") }
-    ul(class: "mb-4 list-disc space-y-2 pl-6 text-text-secondary") do
-      li { t(".data_account") }
-      li { t(".data_guild") }
-      li { t(".data_reminders") }
-      li { t(".data_overwrites") }
-      li { t(".data_session") }
-    end
+    heading(t(".data_h"))
+    paragraph(t(".data_lead"))
+    bullets(
+      t(".data_guild"),
+      t(".data_account"),
+      t(".data_reminders"),
+      t(".data_notifications"),
+      t(".data_operational")
+    )
   end
 
-  def purpose_section
-    h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { t(".purpose_h") }
-    p(class: "mb-4 leading-relaxed text-text-secondary") { t(".purpose_p") }
+  def messages_section
+    heading(t(".messages_h"))
+    paragraph(t(".messages_p"))
+  end
+
+  def not_section
+    heading(t(".not_h"))
+    paragraph(t(".not_p"))
+  end
+
+  def basis_section
+    heading(t(".basis_h"))
+    paragraph(t(".basis_p"))
   end
 
   def sharing_section
-    h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { t(".sharing_h") }
-    p(class: "mb-4 leading-relaxed text-text-secondary") { t(".sharing_p") }
+    heading(t(".sharing_h"))
+    paragraph(t(".sharing_p"))
   end
 
   def retention_section
-    h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { t(".retention_h") }
-    ul(class: "mb-4 list-disc space-y-2 pl-6 text-text-secondary") do
-      li { t(".retention_delivery") }
-      li { t(".retention_guild") }
-      li { t(".retention_account") }
-      li { t(".retention_infra") }
-    end
+    heading(t(".retention_h"))
+    bullets(
+      t(".retention_guild"),
+      t(".retention_reminders"),
+      t(".retention_account"),
+      t(".retention_infra")
+    )
+  end
+
+  def deletion_section
+    heading(t(".deletion_h"))
+    paragraph(t(".deletion_lead"))
+    bullets(
+      t(".deletion_guild"),
+      t(".deletion_reminders"),
+      t(".deletion_account"),
+      t(".deletion_contact")
+    )
   end
 
   def rights_section
-    h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { t(".rights_h") }
-    p(class: "mb-4 leading-relaxed text-text-secondary") { t(".rights_p") }
-    p(class: "mb-4 leading-relaxed text-text-secondary") { t(".rights_delete") }
-    p(class: "mb-4 leading-relaxed text-text-secondary") { t(".rights_contact") }
+    heading(t(".rights_h"))
+    paragraph(t(".rights_p"))
+  end
+
+  def security_section
+    heading(t(".security_h"))
+    paragraph(t(".security_p"))
   end
 
   def cookies_section
-    h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { t(".cookies_h") }
-    p(class: "mb-4 leading-relaxed text-text-secondary") { t(".cookies_p") }
+    heading(t(".cookies_h"))
+    paragraph(t(".cookies_p"))
+  end
+
+  def children_section
+    heading(t(".children_h"))
+    paragraph(t(".children_p"))
   end
 
   def changes_section
-    h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { t(".changes_h") }
-    p(class: "mb-4 leading-relaxed text-text-secondary") { t(".changes_p") }
+    heading(t(".changes_h"))
+    paragraph(t(".changes_p"))
   end
 end

--- a/app/views/privacy_policy.rb
+++ b/app/views/privacy_policy.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+class Views::PrivacyPolicy < Views::Base
+  def view_template
+    render Components::PublicShell.new do
+      article(class: "mx-auto max-w-2xl px-6 py-16") do
+        h1(class: "mb-2 font-display text-3xl font-bold tracking-tight") { t(".title") }
+        p(class: "mb-10 text-sm text-text-muted") { t(".updated") }
+        sections
+      end
+    end
+  end
+
+  private
+
+  def sections
+    intro_section
+    controller_section
+    data_section
+    purpose_section
+    sharing_section
+    retention_section
+    rights_section
+    cookies_section
+    changes_section
+  end
+
+  def intro_section
+    p(class: "mb-4 leading-relaxed text-text-secondary") { t(".intro") }
+  end
+
+  def controller_section
+    h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { t(".controller_h") }
+    p(class: "mb-4 leading-relaxed text-text-secondary") { t(".controller_p") }
+  end
+
+  def data_section
+    h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { t(".data_h") }
+    p(class: "mb-4 leading-relaxed text-text-secondary") { t(".data_lead") }
+    ul(class: "mb-4 list-disc space-y-2 pl-6 text-text-secondary") do
+      li { t(".data_account") }
+      li { t(".data_guild") }
+      li { t(".data_reminders") }
+      li { t(".data_overwrites") }
+      li { t(".data_session") }
+    end
+  end
+
+  def purpose_section
+    h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { t(".purpose_h") }
+    p(class: "mb-4 leading-relaxed text-text-secondary") { t(".purpose_p") }
+  end
+
+  def sharing_section
+    h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { t(".sharing_h") }
+    p(class: "mb-4 leading-relaxed text-text-secondary") { t(".sharing_p") }
+  end
+
+  def retention_section
+    h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { t(".retention_h") }
+    ul(class: "mb-4 list-disc space-y-2 pl-6 text-text-secondary") do
+      li { t(".retention_delivery") }
+      li { t(".retention_guild") }
+      li { t(".retention_account") }
+      li { t(".retention_infra") }
+    end
+  end
+
+  def rights_section
+    h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { t(".rights_h") }
+    p(class: "mb-4 leading-relaxed text-text-secondary") { t(".rights_p") }
+    p(class: "mb-4 leading-relaxed text-text-secondary") { t(".rights_delete") }
+    p(class: "mb-4 leading-relaxed text-text-secondary") { t(".rights_contact") }
+  end
+
+  def cookies_section
+    h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { t(".cookies_h") }
+    p(class: "mb-4 leading-relaxed text-text-secondary") { t(".cookies_p") }
+  end
+
+  def changes_section
+    h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { t(".changes_h") }
+    p(class: "mb-4 leading-relaxed text-text-secondary") { t(".changes_p") }
+  end
+end

--- a/app/views/privacy_policy.rb
+++ b/app/views/privacy_policy.rb
@@ -48,7 +48,10 @@ class Views::PrivacyPolicy < Views::Base
 
   def messages_section
     heading(t(".messages_h"))
-    paragraph(t(".messages_p"))
+    paragraph(t(".messages_p_1"))
+    paragraph(t(".messages_p_2"))
+    paragraph(t(".messages_p_3"))
+    paragraph(t(".messages_p_4"))
   end
 
   def not_section

--- a/app/views/privacy_policy.rb
+++ b/app/views/privacy_policy.rb
@@ -2,28 +2,20 @@
 
 class Views::PrivacyPolicy < Views::Base
   def view_template
-    render Components::PublicShell.new do
-      article(class: "mx-auto max-w-2xl px-6 py-16") do
-        h1(class: "mb-2 font-display text-3xl font-bold tracking-tight") { t(".title") }
-        p(class: "mb-10 text-sm text-text-muted") { t(".updated") }
-        sections
-      end
+    render Components::LegalPage.new(title: t(".title"), updated: t(".updated")) do
+      intro_section
+      controller_section
+      data_section
+      purpose_section
+      sharing_section
+      retention_section
+      rights_section
+      cookies_section
+      changes_section
     end
   end
 
   private
-
-  def sections
-    intro_section
-    controller_section
-    data_section
-    purpose_section
-    sharing_section
-    retention_section
-    rights_section
-    cookies_section
-    changes_section
-  end
 
   def intro_section
     p(class: "mb-4 leading-relaxed text-text-secondary") { t(".intro") }

--- a/app/views/terms_of_service.rb
+++ b/app/views/terms_of_service.rb
@@ -1,61 +1,93 @@
 # frozen_string_literal: true
 
 class Views::TermsOfService < Views::Base
+  include Components::LegalProse
+
   def view_template
     render Components::LegalPage.new(title: t(".title"), updated: t(".updated")) do
       intro_section
       service_section
+      eligibility_section
       use_section
+      admin_section
       availability_section
-      termination_section
       liability_section
+      privacy_section
+      source_section
+      termination_section
+      changes_section
       law_section
-      contact_section
     end
   end
 
   private
 
   def intro_section
-    p(class: "mb-4 leading-relaxed text-text-secondary") { t(".intro") }
+    paragraph(t(".intro"))
   end
 
   def service_section
-    h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { t(".service_h") }
-    p(class: "mb-4 leading-relaxed text-text-secondary") { t(".service_p") }
+    heading(t(".service_h"))
+    paragraph(t(".service_p"))
+  end
+
+  def eligibility_section
+    heading(t(".eligibility_h"))
+    paragraph(t(".eligibility_p"))
   end
 
   def use_section
-    h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { t(".use_h") }
-    ul(class: "mb-4 list-disc space-y-2 pl-6 text-text-secondary") do
-      li { t(".use_items_1") }
-      li { t(".use_items_2") }
-      li { t(".use_items_3") }
-    end
+    heading(t(".use_h"))
+    paragraph(t(".use_lead"))
+    bullets(
+      t(".use_items_1"),
+      t(".use_items_2"),
+      t(".use_items_3"),
+      t(".use_items_4")
+    )
+  end
+
+  def admin_section
+    heading(t(".admin_h"))
+    paragraph(t(".admin_p"))
   end
 
   def availability_section
-    h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { t(".availability_h") }
-    p(class: "mb-4 leading-relaxed text-text-secondary") { t(".availability_p") }
-  end
-
-  def termination_section
-    h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { t(".termination_h") }
-    p(class: "mb-4 leading-relaxed text-text-secondary") { t(".termination_p") }
+    heading(t(".availability_h"))
+    paragraph(t(".availability_p"))
   end
 
   def liability_section
-    h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { t(".liability_h") }
-    p(class: "mb-4 leading-relaxed text-text-secondary") { t(".liability_p") }
+    heading(t(".liability_h"))
+    paragraph(t(".liability_p"))
+  end
+
+  def privacy_section
+    heading(t(".privacy_h"))
+    p(class: "mb-4 leading-relaxed text-text-secondary") do
+      plain t(".privacy_pre")
+      a(href: privacy_policy_path, class: "underline transition-colors hover:text-text-primary") { t(".privacy_link") }
+      plain t(".privacy_post")
+    end
+  end
+
+  def source_section
+    heading(t(".source_h"))
+    paragraph(t(".source_p"))
+  end
+
+  def termination_section
+    heading(t(".termination_h"))
+    paragraph(t(".termination_p"))
+  end
+
+  def changes_section
+    heading(t(".changes_h"))
+    paragraph(t(".changes_p"))
   end
 
   def law_section
-    h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { t(".law_h") }
-    p(class: "mb-4 leading-relaxed text-text-secondary") { t(".law_p") }
-  end
-
-  def contact_section
-    h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { t(".contact_h") }
-    p(class: "mb-4 leading-relaxed text-text-secondary") { t(".contact_p") }
+    heading(t(".law_h"))
+    paragraph(t(".law_p"))
   end
 end

--- a/app/views/terms_of_service.rb
+++ b/app/views/terms_of_service.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+class Views::TermsOfService < Views::Base
+  def view_template
+    render Components::PublicShell.new do
+      article(class: "mx-auto max-w-2xl px-6 py-16") do
+        h1(class: "mb-2 font-display text-3xl font-bold tracking-tight") { t(".title") }
+        p(class: "mb-10 text-sm text-text-muted") { t(".updated") }
+        sections
+      end
+    end
+  end
+
+  private
+
+  def sections
+    intro_section
+    service_section
+    use_section
+    availability_section
+    termination_section
+    liability_section
+    law_section
+    contact_section
+  end
+
+  def intro_section
+    p(class: "mb-4 leading-relaxed text-text-secondary") { t(".intro") }
+  end
+
+  def service_section
+    h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { t(".service_h") }
+    p(class: "mb-4 leading-relaxed text-text-secondary") { t(".service_p") }
+  end
+
+  def use_section
+    h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { t(".use_h") }
+    ul(class: "mb-4 list-disc space-y-2 pl-6 text-text-secondary") do
+      li { t(".use_items_1") }
+      li { t(".use_items_2") }
+      li { t(".use_items_3") }
+    end
+  end
+
+  def availability_section
+    h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { t(".availability_h") }
+    p(class: "mb-4 leading-relaxed text-text-secondary") { t(".availability_p") }
+  end
+
+  def termination_section
+    h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { t(".termination_h") }
+    p(class: "mb-4 leading-relaxed text-text-secondary") { t(".termination_p") }
+  end
+
+  def liability_section
+    h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { t(".liability_h") }
+    p(class: "mb-4 leading-relaxed text-text-secondary") { t(".liability_p") }
+  end
+
+  def law_section
+    h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { t(".law_h") }
+    p(class: "mb-4 leading-relaxed text-text-secondary") { t(".law_p") }
+  end
+
+  def contact_section
+    h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { t(".contact_h") }
+    p(class: "mb-4 leading-relaxed text-text-secondary") { t(".contact_p") }
+  end
+end

--- a/app/views/terms_of_service.rb
+++ b/app/views/terms_of_service.rb
@@ -2,27 +2,19 @@
 
 class Views::TermsOfService < Views::Base
   def view_template
-    render Components::PublicShell.new do
-      article(class: "mx-auto max-w-2xl px-6 py-16") do
-        h1(class: "mb-2 font-display text-3xl font-bold tracking-tight") { t(".title") }
-        p(class: "mb-10 text-sm text-text-muted") { t(".updated") }
-        sections
-      end
+    render Components::LegalPage.new(title: t(".title"), updated: t(".updated")) do
+      intro_section
+      service_section
+      use_section
+      availability_section
+      termination_section
+      liability_section
+      law_section
+      contact_section
     end
   end
 
   private
-
-  def sections
-    intro_section
-    service_section
-    use_section
-    availability_section
-    termination_section
-    liability_section
-    law_section
-    contact_section
-  end
 
   def intro_section
     p(class: "mb-4 leading-relaxed text-text-secondary") { t(".intro") }

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -6,6 +6,9 @@ data:
     - config/locales/*.%{locale}.yml
   write:
     - ["activity_log.*", "config/locales/activity_log.%{locale}.yml"]
+    - ["views.privacy_policy.*", "config/locales/legal.%{locale}.yml"]
+    - ["views.terms_of_service.*", "config/locales/legal.%{locale}.yml"]
+    - ["components.legal_page.*", "config/locales/legal.%{locale}.yml"]
     - "config/locales/web.%{locale}.yml"
 
 search:

--- a/config/locales/legal.en.yml
+++ b/config/locales/legal.en.yml
@@ -1,0 +1,183 @@
+---
+en:
+  components:
+    legal_page:
+      contact_h: Contact
+      contact_operator: Tim Engelhardt
+      contact_support: support server
+  views:
+    privacy_policy:
+      audience_dashboard: 'Dashboard users: people (usually server admins) who sign
+        in to this website with Discord to configure the bot.'
+      audience_h: Who this applies to
+      audience_members: 'Server members: people in a Discord server that shrkbot has
+        been added to. shrkbot may process limited data about you because of features
+        an admin has enabled.'
+      basis_h: Legal bases
+      basis_p: Where the GDPR applies we rely on performance of the service (Art.
+        6(1)(b) — providing the features you or your admins enable) and legitimate
+        interests (Art. 6(1)(f) — operating, securing and debugging the Service).
+        You can object to processing based on legitimate interests — see "Your rights".
+      changes_h: Changes
+      changes_p: If this policy changes, the new version is published here with an
+        updated date; for significant changes we'll try to give notice through the
+        Service.
+      children_h: Children
+      children_p: shrkbot isn't directed at children. You must meet Discord's minimum
+        age requirement (at least 13, or older where your country requires) to use
+        Discord and the Service.
+      cookies_h: Cookies
+      cookies_p: 'We set exactly one cookie: the essential encrypted session cookie
+        described above. No tracking, no third-party cookies.'
+      data_account: 'Dashboard account: when you sign in with Discord we store your
+        Discord ID, username, display name and avatar reference. We request only the
+        identify and guilds OAuth scopes — we never receive your email, password or
+        messages. Your Discord access token is held only in an encrypted session cookie
+        in your browser (valid two weeks), never in our database, and is used solely
+        to read which servers you manage.'
+      data_guild: 'Server configuration: the server''s Discord ID, name, icon reference
+        and approximate member count, plus a cached copy of its channels and roles
+        (IDs, names, types, colours, positions) and their permission overwrites —
+        which can reference member Discord IDs — mirrored from Discord so the dashboard
+        can display and apply your setup. Also which plugins are enabled, and the
+        welcome, logging and role-menu settings admins configure.'
+      data_h: What we store and why
+      data_lead: 'We store only what the enabled features need:'
+      data_notifications: 'Dashboard notifications: short activity entries (an event
+        type plus details such as a plugin or channel name) so admins can see recent
+        changes.'
+      data_operational: 'Operational data: background jobs briefly process the data
+        above while running; a failed job may keep a short error record for up to
+        30 days. The web server keeps standard technical logs (IP address, timestamp,
+        browser type) for security and troubleshooting.'
+      data_reminders: 'Reminders: the reminder text you write, your Discord ID, the
+        target channel and server, whether to deliver by DM, and the due time — kept
+        until delivered or deleted by you with /unremind.'
+      deletion_account: Delete your dashboard account and your reminders with the
+        "Delete my account" button on your account page.
+      deletion_contact: Or contact us (see below) and we'll take care of it.
+      deletion_guild: Remove the bot from a server to delete that server's configuration.
+      deletion_h: Deleting your data
+      deletion_lead: 'Erasure is self-service:'
+      deletion_reminders: Delete individual reminders with /unremind.
+      intro_1: This policy explains what the shrkbot Discord bot and its web dashboard
+        (together, the "Service") store, why, and the choices you have. It's written
+        to be readable rather than dense — if anything is unclear, contact us.
+      intro_2: The Service is operated by Tim Engelhardt, the data controller under
+        the EU General Data Protection Regulation (GDPR).
+      messages_h: Message content
+      messages_p_1: shrkbot uses Discord's message-content intent so that servers
+        can enable automated moderation. When an admin turns that feature on, shrkbot
+        reads new messages — including, using optical character recognition (OCR),
+        text contained in posted images — to check them against the server's rules.
+        On servers that don't enable moderation, messages aren't processed at all.
+      messages_p_2: 'This scanning happens in real time and in memory only: we do
+        not store or retain message content, images, or text extracted from images.
+        Once a message has been checked, its content is discarded. We keep no message
+        history, no message logs, and no copies of your server''s conversations.'
+      messages_p_3: If automated moderation acts on a message, shrkbot can post a
+        moderation log entry to a channel your admins designate. That entry may include
+        the offending message or the text extracted from an image so moderators can
+        review it — it is delivered as an ordinary Discord message and is therefore
+        stored by Discord in that channel, not retained by shrkbot. A short record
+        that an action occurred (without the message content) may also appear in the
+        dashboard.
+      messages_p_4: The bot also receives member join and leave events to deliver
+        welcome messages; the username shown there is rendered into the message and
+        not stored.
+      not_h: What we don't do
+      not_p: We don't sell data, we don't advertise, we don't profile you, we don't
+        run analytics, and we don't store your servers' member lists or conversations.
+      retention_account: 'Dashboard account: kept until you delete it on your account
+        page.'
+      retention_guild: 'Server configuration: deleted automatically, in full, the
+        moment the bot is removed from the server.'
+      retention_h: How long we keep it
+      retention_infra: Caches, background-job records and logs are cleared automatically
+        (at most 60 days, 30 days and briefly, respectively). Deleted data also drops
+        out of database backups as they rotate.
+      retention_reminders: 'Reminders: deleted once delivered, or earlier if you delete
+        them.'
+      rights_h: Your rights
+      rights_p: Under the GDPR you have the right to access, correct, delete, restrict
+        or object to our use of your personal data, and the right to data portability.
+        You also have the right to complain to a supervisory authority — in Germany,
+        your regional data protection authority. To exercise any of these, contact
+        us (see below).
+      security_h: Security
+      security_p: Data travels over encrypted (HTTPS/TLS) connections and database
+        access is restricted to the operator. No system is perfectly secure, so we
+        can't guarantee absolute security, but we take reasonable measures and will
+        notify affected users of a serious breach where the law requires it.
+      sharing_h: Who we share data with
+      sharing_p: 'Only the infrastructure that runs the Service: Discord itself, through
+        its API (your use of Discord is governed by Discord''s own privacy policy),
+        and our hosting provider Hetzner (Helsinki, Finland — within the EEA), where
+        the Service and its database run. We may disclose data where required by law.'
+      title: Privacy policy
+      updated: 'Last updated: July 5th, 2026'
+    terms_of_service:
+      admin_h: Your responsibilities as a server admin
+      admin_p: If you add shrkbot to a server or configure it, you're responsible
+        for how it's used there — including any messages you configure it to send
+        (such as welcome messages) and any logging you enable. Where you enable features
+        that process other members' data, you're responsible for having a proper basis
+        to do so and for informing your members as applicable law requires.
+      availability_h: Availability and changes
+      availability_p: The Service is provided "as is" and "as available", without
+        warranties of any kind. We may change, suspend, add or remove features, or
+        take the Service offline, at any time and without notice. We don't guarantee
+        that the Service will be uninterrupted or error-free, or that data will never
+        be lost.
+      changes_h: Changes to these terms
+      changes_p: We may update these terms. We'll update the "last updated" date and,
+        for significant changes, try to give notice through the Service. Continued
+        use after changes means you accept them.
+      eligibility_h: Eligibility
+      eligibility_p: You must meet Discord's minimum age requirement and comply with
+        Discord's Terms of Service and Community Guidelines when using the Service.
+      intro: These terms govern your use of the shrkbot Discord bot and its web dashboard
+        (the "Service"), operated by Tim Engelhardt. By adding shrkbot to a server,
+        using its features or signing in to the dashboard, you agree to them. If you
+        don't agree, please don't use the Service.
+      law_h: Governing law
+      law_p: These terms are governed by the laws of Germany, without regard to conflict-of-laws
+        rules and subject to any mandatory consumer protections that apply where you
+        live.
+      liability_h: Limitation of liability
+      liability_p: We are liable without limit for damages caused by intent or gross
+        negligence and for culpable injury to life, body or health. Beyond that, and
+        to the extent legally permissible, we are not liable for indirect, incidental
+        or consequential damages or for loss of data arising from your use of, or
+        inability to use, the free Service. Nothing in these terms limits liability
+        that cannot be limited by law.
+      privacy_h: Privacy
+      privacy_link: privacy policy
+      privacy_post: ", which forms part of these terms."
+      privacy_pre: 'Our handling of data is described in our '
+      service_h: The service
+      service_p: shrkbot is a general-purpose Discord bot whose features — self-assignable
+        roles, reminders, welcome and leave messages, activity logging and automated
+        moderation — are enabled per server and configured through commands and this
+        website. The Service is provided free of charge.
+      source_h: Open source
+      source_p: shrkbot's source code is published under the MIT licence. That licence
+        covers the code; your use of the instance we operate is governed by these
+        terms.
+      termination_h: Termination
+      termination_p: You can stop using the Service at any time by removing shrkbot
+        from your server — which permanently deletes that server's data — or by deleting
+        your dashboard account. We may restrict or terminate access for any server
+        or user that breaches these terms or that we reasonably believe is misusing
+        the Service.
+      title: Terms of service
+      updated: 'Last updated: July 5th, 2026'
+      use_h: Acceptable use
+      use_items_1: use the Service to violate Discord's Terms of Service, Community
+        Guidelines or any applicable law;
+      use_items_2: abuse, disrupt, overload or attempt to gain unauthorised access
+        to the Service or its infrastructure;
+      use_items_3: use the Service to harass others or to store or distribute unlawful
+        content;
+      use_items_4: attempt to circumvent limits, security or access controls.
+      use_lead: 'You agree not to:'

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -91,6 +91,14 @@ en:
     plugin_sidebar:
       dashboard: Dashboard
       plugins: Plugins
+    public_shell:
+      footer_link: free and open source
+      footer_mid: ". Made with "
+      footer_post: " by badBlackShark."
+      footer_pre: 'shrkbot is '
+      privacy: Privacy policy
+      sign_in: Sign in with Discord
+      terms: Terms of service
     reminders:
       config_form:
         callout:
@@ -199,10 +207,6 @@ en:
     home:
       add_to_server: Sign in to add shrkbot to your servers
       eyebrow: Free & open source
-      footer_link: free and open source
-      footer_mid: ". Made with "
-      footer_post: " by badBlackShark."
-      footer_pre: 'shrkbot is '
       headline: You pick the parts.
       headline_end: shrkbot
       headline_muted: does the rest.
@@ -219,8 +223,67 @@ en:
         welcomes: Greet new members with a custom message, and say goodbye when they
           leave.
       plugins_eyebrow: Example plugins
-      sign_in: Sign in with Discord
       view_source: View on GitHub
+    privacy_policy:
+      changes_h: Changes
+      changes_p: If this policy changes, the new version is published here with an
+        updated date.
+      controller_h: Who is responsible
+      controller_p: The data controller is [CONTROLLER_NAME]. You can reach us at
+        [CONTACT_EMAIL] for any privacy request.
+      cookies_h: Cookies
+      cookies_p: 'We set exactly one cookie: the essential session cookie described
+        above. No tracking, no third-party cookies.'
+      data_account: 'Dashboard account: when you sign in with Discord we store your
+        Discord ID, username, display name and avatar reference. We request only the
+        identify and guilds OAuth scopes — we never see your email, messages or friends.'
+      data_guild: 'Server configuration: for each server the bot is in we store the
+        server''s Discord ID, name, icon reference and member count, its channel and
+        role structure, and the settings admins configure (welcome messages, logging,
+        role menus, reminder options).'
+      data_h: What we store
+      data_lead: 'We store the minimum needed to run the bot and the dashboard:'
+      data_overwrites: 'Permission mirrors: server channel permission overwrites,
+        which can reference member Discord IDs, are mirrored from Discord so the dashboard
+        can display channel access. They are a copy of state that lives in Discord
+        and are refreshed from there.'
+      data_reminders: 'Reminders: when you set a reminder we store your Discord ID,
+        the target channel, the reminder text you wrote and the due time. A reminder
+        is deleted the moment it is delivered, and you can delete pending ones yourself
+        at any time with /unremind.'
+      data_session: 'Session: signing in sets a single encrypted session cookie (valid
+        two weeks) holding a reference to your account and your Discord access token.
+        We use the token only to read which servers you manage.'
+      intro: shrkbot is a Discord bot with a web dashboard. This policy explains what
+        data shrkbot stores, why, and what your rights are. It applies to the bot
+        and to this website.
+      purpose_h: Why we store it
+      purpose_p: We process this data solely to provide the bot's features and the
+        dashboard you configure them with (Art. 6(1)(b) GDPR) and to keep the service
+        secure and operational (Art. 6(1)(f) GDPR). We run no analytics, no advertising,
+        and we never sell or share data.
+      retention_account: 'Dashboard account: until you delete it on your account page,
+        which also removes all your reminders.'
+      retention_delivery: 'Reminders: until delivered or deleted by you.'
+      retention_guild: 'Server data: deleted automatically, in full, the moment the
+        bot is removed from a server.'
+      retention_h: How long we keep it
+      retention_infra: Caches and background-job records are cleared automatically
+        (at most 60 and 30 days respectively). Server logs contain no message content.
+      rights_contact: For anything else, contact [CONTACT_EMAIL].
+      rights_delete: 'Erasure is self-service: delete your account on the account
+        page, or use /unremind for individual reminders. Removing the bot from a server
+        erases that server''s data.'
+      rights_h: Your rights
+      rights_p: Under the GDPR you have the right to access, rectify, export and erase
+        your data, to restrict or object to processing, and to complain to a supervisory
+        authority.
+      sharing_h: Where it lives
+      sharing_p: Data is stored on servers operated by [HOSTING_PROVIDER]. The only
+        third party we exchange data with is Discord itself, through its API, to operate
+        the bot. Database backups are kept for [BACKUP_RETENTION_DAYS] days.
+      title: Privacy policy
+      updated: Last updated 5 July 2026
     reauth:
       body: Your Discord sign-in expired. Please stand by - we're refreshing it for
         you.
@@ -280,3 +343,33 @@ en:
           description: Greet new members and say goodbye when they leave.
           gate_message: Enable the plugin to configure messages.
           title: Welcomes
+    terms_of_service:
+      availability_h: Availability
+      availability_p: The service is provided as is, without warranty of any kind.
+        Features may change or be discontinued at any time.
+      contact_h: Contact
+      contact_p: 'Questions about these terms: [CONTACT_EMAIL].'
+      intro: By adding shrkbot to a server or using this website you agree to these
+        terms.
+      law_h: Governing law
+      law_p: These terms are governed by the law of [JURISDICTION].
+      liability_h: Liability
+      liability_p: We are liable only for damages caused by intent or gross negligence,
+        and for culpable injury to life, body or health. Any further liability is
+        excluded to the extent legally permissible.
+      service_h: The service
+      service_p: shrkbot provides Discord server utilities — role menus, welcome messages,
+        activity logging and reminders — configured through this website. The service
+        is provided free of charge.
+      termination_h: Termination
+      termination_p: You can stop using the service at any time by removing the bot
+        from your server, which permanently deletes that server's data, or by deleting
+        your dashboard account. We may remove the bot from servers that violate these
+        terms.
+      title: Terms of service
+      updated: Last updated 5 July 2026
+      use_h: Acceptable use
+      use_items_1: You must comply with Discord's Terms of Service and Community Guidelines.
+      use_items_2: Server admins are responsible for content they configure, such
+        as welcome and leave messages.
+      use_items_3: You may not abuse, overload or attempt to disrupt the service.

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -36,10 +36,9 @@ en:
       enable: Enable %{plugin}
       enabled: Enabled
       servers: Servers
-    legal_page:
-      contact_h: Contact
-      contact_operator: Tim Engelhardt
-      contact_support: support server
+    legal_links:
+      privacy: Privacy policy
+      terms: Terms of service
     logging:
       config_form:
         channel:
@@ -100,9 +99,7 @@ en:
       footer_mid: ". Made with "
       footer_post: " by badBlackShark."
       footer_pre: 'shrkbot is '
-      privacy: Privacy policy
       sign_in: Sign in with Discord
-      terms: Terms of service
     reminders:
       config_form:
         callout:
@@ -228,116 +225,6 @@ en:
           leave.
       plugins_eyebrow: Example plugins
       view_source: View on GitHub
-    privacy_policy:
-      audience_dashboard: 'Dashboard users: people (usually server admins) who sign
-        in to this website with Discord to configure the bot.'
-      audience_h: Who this applies to
-      audience_members: 'Server members: people in a Discord server that shrkbot has
-        been added to. shrkbot may process limited data about you because of features
-        an admin has enabled.'
-      basis_h: Legal bases
-      basis_p: Where the GDPR applies we rely on performance of the service (Art.
-        6(1)(b) — providing the features you or your admins enable) and legitimate
-        interests (Art. 6(1)(f) — operating, securing and debugging the Service).
-        You can object to processing based on legitimate interests — see "Your rights".
-      changes_h: Changes
-      changes_p: If this policy changes, the new version is published here with an
-        updated date; for significant changes we'll try to give notice through the
-        Service.
-      children_h: Children
-      children_p: shrkbot isn't directed at children. You must meet Discord's minimum
-        age requirement (at least 13, or older where your country requires) to use
-        Discord and the Service.
-      cookies_h: Cookies
-      cookies_p: 'We set exactly one cookie: the essential encrypted session cookie
-        described above. No tracking, no third-party cookies.'
-      data_account: 'Dashboard account: when you sign in with Discord we store your
-        Discord ID, username, display name and avatar reference. We request only the
-        identify and guilds OAuth scopes — we never receive your email, password or
-        messages. Your Discord access token is held only in an encrypted session cookie
-        in your browser (valid two weeks), never in our database, and is used solely
-        to read which servers you manage.'
-      data_guild: 'Server configuration: the server''s Discord ID, name, icon reference
-        and approximate member count, plus a cached copy of its channels and roles
-        (IDs, names, types, colours, positions) and their permission overwrites —
-        which can reference member Discord IDs — mirrored from Discord so the dashboard
-        can display and apply your setup. Also which plugins are enabled, and the
-        welcome, logging and role-menu settings admins configure.'
-      data_h: What we store and why
-      data_lead: 'We store only what the enabled features need:'
-      data_notifications: 'Dashboard notifications: short activity entries (an event
-        type plus details such as a plugin or channel name) so admins can see recent
-        changes.'
-      data_operational: 'Operational data: background jobs briefly process the data
-        above while running; a failed job may keep a short error record for up to
-        30 days. The web server keeps standard technical logs (IP address, timestamp,
-        browser type) for security and troubleshooting.'
-      data_reminders: 'Reminders: the reminder text you write, your Discord ID, the
-        target channel and server, whether to deliver by DM, and the due time — kept
-        until delivered or deleted by you with /unremind.'
-      deletion_account: Delete your dashboard account and your reminders with the
-        "Delete my account" button on your account page.
-      deletion_contact: Or contact us (see below) and we'll take care of it.
-      deletion_guild: Remove the bot from a server to delete that server's configuration.
-      deletion_h: Deleting your data
-      deletion_lead: 'Erasure is self-service:'
-      deletion_reminders: Delete individual reminders with /unremind.
-      intro_1: This policy explains what the shrkbot Discord bot and its web dashboard
-        (together, the "Service") store, why, and the choices you have. It's written
-        to be readable rather than dense — if anything is unclear, contact us.
-      intro_2: The Service is operated by Tim Engelhardt, the data controller under
-        the EU General Data Protection Regulation (GDPR).
-      messages_h: Message content
-      messages_p_1: shrkbot uses Discord's message-content intent so that servers
-        can enable automated moderation. When an admin turns that feature on, shrkbot
-        reads new messages — including, using optical character recognition (OCR),
-        text contained in posted images — to check them against the server's rules.
-        On servers that don't enable moderation, messages aren't processed at all.
-      messages_p_2: 'This scanning happens in real time and in memory only: we do
-        not store or retain message content, images, or text extracted from images.
-        Once a message has been checked, its content is discarded. We keep no message
-        history, no message logs, and no copies of your server''s conversations.'
-      messages_p_3: If automated moderation acts on a message, shrkbot can post a
-        moderation log entry to a channel your admins designate. That entry may include
-        the offending message or the text extracted from an image so moderators can
-        review it — it is delivered as an ordinary Discord message and is therefore
-        stored by Discord in that channel, not retained by shrkbot. A short record
-        that an action occurred (without the message content) may also appear in the
-        dashboard.
-      messages_p_4: The bot also receives member join and leave events to deliver
-        welcome messages; the username shown there is rendered into the message and
-        not stored.
-      not_h: What we don't do
-      not_p: We don't sell data, we don't advertise, we don't profile you, we don't
-        run analytics, and we don't store your servers' member lists or conversations.
-      retention_account: 'Dashboard account: kept until you delete it on your account
-        page.'
-      retention_guild: 'Server configuration: deleted automatically, in full, the
-        moment the bot is removed from the server.'
-      retention_h: How long we keep it
-      retention_infra: Caches, background-job records and logs are cleared automatically
-        (at most 60 days, 30 days and briefly, respectively). Deleted data also drops
-        out of database backups as they rotate.
-      retention_reminders: 'Reminders: deleted once delivered, or earlier if you delete
-        them.'
-      rights_h: Your rights
-      rights_p: Under the GDPR you have the right to access, correct, delete, restrict
-        or object to our use of your personal data, and the right to data portability.
-        You also have the right to complain to a supervisory authority — in Germany,
-        your regional data protection authority. To exercise any of these, contact
-        us (see below).
-      security_h: Security
-      security_p: Data travels over encrypted (HTTPS/TLS) connections and database
-        access is restricted to the operator. No system is perfectly secure, so we
-        can't guarantee absolute security, but we take reasonable measures and will
-        notify affected users of a serious breach where the law requires it.
-      sharing_h: Who we share data with
-      sharing_p: 'Only the infrastructure that runs the Service: Discord itself, through
-        its API (your use of Discord is governed by Discord''s own privacy policy),
-        and our hosting provider Hetzner (Helsinki, Finland — within the EEA), where
-        the Service and its database run. We may disclose data where required by law.'
-      title: Privacy policy
-      updated: 'Last updated: July 5th, 2026'
     reauth:
       body: Your Discord sign-in expired. Please stand by - we're refreshing it for
         you.
@@ -397,68 +284,3 @@ en:
           description: Greet new members and say goodbye when they leave.
           gate_message: Enable the plugin to configure messages.
           title: Welcomes
-    terms_of_service:
-      admin_h: Your responsibilities as a server admin
-      admin_p: If you add shrkbot to a server or configure it, you're responsible
-        for how it's used there — including any messages you configure it to send
-        (such as welcome messages) and any logging you enable. Where you enable features
-        that process other members' data, you're responsible for having a proper basis
-        to do so and for informing your members as applicable law requires.
-      availability_h: Availability and changes
-      availability_p: The Service is provided "as is" and "as available", without
-        warranties of any kind. We may change, suspend, add or remove features, or
-        take the Service offline, at any time and without notice. We don't guarantee
-        that the Service will be uninterrupted or error-free, or that data will never
-        be lost.
-      changes_h: Changes to these terms
-      changes_p: We may update these terms. We'll update the "last updated" date and,
-        for significant changes, try to give notice through the Service. Continued
-        use after changes means you accept them.
-      eligibility_h: Eligibility
-      eligibility_p: You must meet Discord's minimum age requirement and comply with
-        Discord's Terms of Service and Community Guidelines when using the Service.
-      intro: These terms govern your use of the shrkbot Discord bot and its web dashboard
-        (the "Service"), operated by Tim Engelhardt. By adding shrkbot to a server,
-        using its features or signing in to the dashboard, you agree to them. If you
-        don't agree, please don't use the Service.
-      law_h: Governing law
-      law_p: These terms are governed by the laws of Germany, without regard to conflict-of-laws
-        rules and subject to any mandatory consumer protections that apply where you
-        live.
-      liability_h: Limitation of liability
-      liability_p: We are liable without limit for damages caused by intent or gross
-        negligence and for culpable injury to life, body or health. Beyond that, and
-        to the extent legally permissible, we are not liable for indirect, incidental
-        or consequential damages or for loss of data arising from your use of, or
-        inability to use, the free Service. Nothing in these terms limits liability
-        that cannot be limited by law.
-      privacy_h: Privacy
-      privacy_link: privacy policy
-      privacy_post: ", which forms part of these terms."
-      privacy_pre: 'Our handling of data is described in our '
-      service_h: The service
-      service_p: shrkbot is a general-purpose Discord bot whose features — self-assignable
-        roles, reminders, welcome and leave messages, activity logging and automated
-        moderation — are enabled per server and configured through commands and this
-        website. The Service is provided free of charge.
-      source_h: Open source
-      source_p: shrkbot's source code is published under the MIT licence. That licence
-        covers the code; your use of the instance we operate is governed by these
-        terms.
-      termination_h: Termination
-      termination_p: You can stop using the Service at any time by removing shrkbot
-        from your server — which permanently deletes that server's data — or by deleting
-        your dashboard account. We may restrict or terminate access for any server
-        or user that breaches these terms or that we reasonably believe is misusing
-        the Service.
-      title: Terms of service
-      updated: 'Last updated: July 5th, 2026'
-      use_h: Acceptable use
-      use_items_1: use the Service to violate Discord's Terms of Service, Community
-        Guidelines or any applicable law;
-      use_items_2: abuse, disrupt, overload or attempt to gain unauthorised access
-        to the Service or its infrastructure;
-      use_items_3: use the Service to harass others or to store or distribute unlawful
-        content;
-      use_items_4: attempt to circumvent limits, security or access controls.
-      use_lead: 'You agree not to:'

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -288,10 +288,25 @@ en:
       intro_2: The Service is operated by Tim Engelhardt, the data controller under
         the EU General Data Protection Regulation (GDPR).
       messages_h: Message content
-      messages_p: shrkbot does not read your messages. It does not request Discord's
-        message-content intent, and no feature stores, scans or logs what anyone writes.
-        The bot does receive member join and leave events to deliver welcome messages;
-        the username shown there is rendered into the message and not stored.
+      messages_p_1: shrkbot uses Discord's message-content intent so that servers
+        can enable automated moderation. When an admin turns that feature on, shrkbot
+        reads new messages — including, using optical character recognition (OCR),
+        text contained in posted images — to check them against the server's rules.
+        On servers that don't enable moderation, messages aren't processed at all.
+      messages_p_2: 'This scanning happens in real time and in memory only: we do
+        not store or retain message content, images, or text extracted from images.
+        Once a message has been checked, its content is discarded. We keep no message
+        history, no message logs, and no copies of your server''s conversations.'
+      messages_p_3: If automated moderation acts on a message, shrkbot can post a
+        moderation log entry to a channel your admins designate. That entry may include
+        the offending message or the text extracted from an image so moderators can
+        review it — it is delivered as an ordinary Discord message and is therefore
+        stored by Discord in that channel, not retained by shrkbot. A short record
+        that an action occurred (without the message content) may also appear in the
+        dashboard.
+      messages_p_4: The bot also receives member join and leave events to deliver
+        welcome messages; the username shown there is rendered into the message and
+        not stored.
       not_h: What we don't do
       not_p: We don't sell data, we don't advertise, we don't profile you, we don't
         run analytics, and we don't store your servers' member lists or conversations.
@@ -423,9 +438,9 @@ en:
       privacy_pre: 'Our handling of data is described in our '
       service_h: The service
       service_p: shrkbot is a general-purpose Discord bot whose features — self-assignable
-        roles, reminders, welcome and leave messages, activity logging — are enabled
-        per server and configured through commands and this website. The Service is
-        provided free of charge.
+        roles, reminders, welcome and leave messages, activity logging and automated
+        moderation — are enabled per server and configured through commands and this
+        website. The Service is provided free of charge.
       source_h: Open source
       source_p: shrkbot's source code is published under the MIT licence. That licence
         covers the code; your use of the instance we operate is governed by these

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -36,6 +36,10 @@ en:
       enable: Enable %{plugin}
       enabled: Enabled
       servers: Servers
+    legal_page:
+      contact_h: Contact
+      contact_operator: Tim Engelhardt
+      contact_support: support server
     logging:
       config_form:
         channel:
@@ -225,65 +229,100 @@ en:
       plugins_eyebrow: Example plugins
       view_source: View on GitHub
     privacy_policy:
+      audience_dashboard: 'Dashboard users: people (usually server admins) who sign
+        in to this website with Discord to configure the bot.'
+      audience_h: Who this applies to
+      audience_members: 'Server members: people in a Discord server that shrkbot has
+        been added to. shrkbot may process limited data about you because of features
+        an admin has enabled.'
+      basis_h: Legal bases
+      basis_p: Where the GDPR applies we rely on performance of the service (Art.
+        6(1)(b) — providing the features you or your admins enable) and legitimate
+        interests (Art. 6(1)(f) — operating, securing and debugging the Service).
+        You can object to processing based on legitimate interests — see "Your rights".
       changes_h: Changes
       changes_p: If this policy changes, the new version is published here with an
-        updated date.
-      controller_h: Who is responsible
-      controller_p: The data controller is [CONTROLLER_NAME]. You can reach us at
-        [CONTACT_EMAIL] for any privacy request.
+        updated date; for significant changes we'll try to give notice through the
+        Service.
+      children_h: Children
+      children_p: shrkbot isn't directed at children. You must meet Discord's minimum
+        age requirement (at least 13, or older where your country requires) to use
+        Discord and the Service.
       cookies_h: Cookies
-      cookies_p: 'We set exactly one cookie: the essential session cookie described
-        above. No tracking, no third-party cookies.'
+      cookies_p: 'We set exactly one cookie: the essential encrypted session cookie
+        described above. No tracking, no third-party cookies.'
       data_account: 'Dashboard account: when you sign in with Discord we store your
         Discord ID, username, display name and avatar reference. We request only the
-        identify and guilds OAuth scopes — we never see your email, messages or friends.'
-      data_guild: 'Server configuration: for each server the bot is in we store the
-        server''s Discord ID, name, icon reference and member count, its channel and
-        role structure, and the settings admins configure (welcome messages, logging,
-        role menus, reminder options).'
-      data_h: What we store
-      data_lead: 'We store the minimum needed to run the bot and the dashboard:'
-      data_overwrites: 'Permission mirrors: server channel permission overwrites,
-        which can reference member Discord IDs, are mirrored from Discord so the dashboard
-        can display channel access. They are a copy of state that lives in Discord
-        and are refreshed from there.'
-      data_reminders: 'Reminders: when you set a reminder we store your Discord ID,
-        the target channel, the reminder text you wrote and the due time. A reminder
-        is deleted the moment it is delivered, and you can delete pending ones yourself
-        at any time with /unremind.'
-      data_session: 'Session: signing in sets a single encrypted session cookie (valid
-        two weeks) holding a reference to your account and your Discord access token.
-        We use the token only to read which servers you manage.'
-      intro: shrkbot is a Discord bot with a web dashboard. This policy explains what
-        data shrkbot stores, why, and what your rights are. It applies to the bot
-        and to this website.
-      purpose_h: Why we store it
-      purpose_p: We process this data solely to provide the bot's features and the
-        dashboard you configure them with (Art. 6(1)(b) GDPR) and to keep the service
-        secure and operational (Art. 6(1)(f) GDPR). We run no analytics, no advertising,
-        and we never sell or share data.
-      retention_account: 'Dashboard account: until you delete it on your account page,
-        which also removes all your reminders.'
-      retention_delivery: 'Reminders: until delivered or deleted by you.'
-      retention_guild: 'Server data: deleted automatically, in full, the moment the
-        bot is removed from a server.'
+        identify and guilds OAuth scopes — we never receive your email, password or
+        messages. Your Discord access token is held only in an encrypted session cookie
+        in your browser (valid two weeks), never in our database, and is used solely
+        to read which servers you manage.'
+      data_guild: 'Server configuration: the server''s Discord ID, name, icon reference
+        and approximate member count, plus a cached copy of its channels and roles
+        (IDs, names, types, colours, positions) and their permission overwrites —
+        which can reference member Discord IDs — mirrored from Discord so the dashboard
+        can display and apply your setup. Also which plugins are enabled, and the
+        welcome, logging and role-menu settings admins configure.'
+      data_h: What we store and why
+      data_lead: 'We store only what the enabled features need:'
+      data_notifications: 'Dashboard notifications: short activity entries (an event
+        type plus details such as a plugin or channel name) so admins can see recent
+        changes.'
+      data_operational: 'Operational data: background jobs briefly process the data
+        above while running; a failed job may keep a short error record for up to
+        30 days. The web server keeps standard technical logs (IP address, timestamp,
+        browser type) for security and troubleshooting.'
+      data_reminders: 'Reminders: the reminder text you write, your Discord ID, the
+        target channel and server, whether to deliver by DM, and the due time — kept
+        until delivered or deleted by you with /unremind.'
+      deletion_account: Delete your dashboard account and your reminders with the
+        "Delete my account" button on your account page.
+      deletion_contact: Or contact us (see below) and we'll take care of it.
+      deletion_guild: Remove the bot from a server to delete that server's configuration.
+      deletion_h: Deleting your data
+      deletion_lead: 'Erasure is self-service:'
+      deletion_reminders: Delete individual reminders with /unremind.
+      intro_1: This policy explains what the shrkbot Discord bot and its web dashboard
+        (together, the "Service") store, why, and the choices you have. It's written
+        to be readable rather than dense — if anything is unclear, contact us.
+      intro_2: The Service is operated by Tim Engelhardt, the data controller under
+        the EU General Data Protection Regulation (GDPR).
+      messages_h: Message content
+      messages_p: shrkbot does not read your messages. It does not request Discord's
+        message-content intent, and no feature stores, scans or logs what anyone writes.
+        The bot does receive member join and leave events to deliver welcome messages;
+        the username shown there is rendered into the message and not stored.
+      not_h: What we don't do
+      not_p: We don't sell data, we don't advertise, we don't profile you, we don't
+        run analytics, and we don't store your servers' member lists or conversations.
+      retention_account: 'Dashboard account: kept until you delete it on your account
+        page.'
+      retention_guild: 'Server configuration: deleted automatically, in full, the
+        moment the bot is removed from the server.'
       retention_h: How long we keep it
-      retention_infra: Caches and background-job records are cleared automatically
-        (at most 60 and 30 days respectively). Server logs contain no message content.
-      rights_contact: For anything else, contact [CONTACT_EMAIL].
-      rights_delete: 'Erasure is self-service: delete your account on the account
-        page, or use /unremind for individual reminders. Removing the bot from a server
-        erases that server''s data.'
+      retention_infra: Caches, background-job records and logs are cleared automatically
+        (at most 60 days, 30 days and briefly, respectively). Deleted data also drops
+        out of database backups as they rotate.
+      retention_reminders: 'Reminders: deleted once delivered, or earlier if you delete
+        them.'
       rights_h: Your rights
-      rights_p: Under the GDPR you have the right to access, rectify, export and erase
-        your data, to restrict or object to processing, and to complain to a supervisory
-        authority.
-      sharing_h: Where it lives
-      sharing_p: Data is stored on servers operated by [HOSTING_PROVIDER]. The only
-        third party we exchange data with is Discord itself, through its API, to operate
-        the bot. Database backups are kept for [BACKUP_RETENTION_DAYS] days.
+      rights_p: Under the GDPR you have the right to access, correct, delete, restrict
+        or object to our use of your personal data, and the right to data portability.
+        You also have the right to complain to a supervisory authority — in Germany,
+        your regional data protection authority. To exercise any of these, contact
+        us (see below).
+      security_h: Security
+      security_p: Data travels over encrypted (HTTPS/TLS) connections and database
+        access is restricted to the operator. No system is perfectly secure, so we
+        can't guarantee absolute security, but we take reasonable measures and will
+        notify affected users of a serious breach where the law requires it.
+      sharing_h: Who we share data with
+      sharing_p: 'Only the infrastructure that runs the Service: Discord itself, through
+        its API (your use of Discord is governed by Discord''s own privacy policy),
+        and our hosting provider Hetzner (Helsinki, Finland — within the EEA), where
+        the Service and its database run. We may disclose data where required by law.'
       title: Privacy policy
-      updated: Last updated 5 July 2026
+      updated: 'Last updated: July 5th, 2026'
     reauth:
       body: Your Discord sign-in expired. Please stand by - we're refreshing it for
         you.
@@ -344,32 +383,67 @@ en:
           gate_message: Enable the plugin to configure messages.
           title: Welcomes
     terms_of_service:
-      availability_h: Availability
-      availability_p: The service is provided as is, without warranty of any kind.
-        Features may change or be discontinued at any time.
-      contact_h: Contact
-      contact_p: 'Questions about these terms: [CONTACT_EMAIL].'
-      intro: By adding shrkbot to a server or using this website you agree to these
-        terms.
+      admin_h: Your responsibilities as a server admin
+      admin_p: If you add shrkbot to a server or configure it, you're responsible
+        for how it's used there — including any messages you configure it to send
+        (such as welcome messages) and any logging you enable. Where you enable features
+        that process other members' data, you're responsible for having a proper basis
+        to do so and for informing your members as applicable law requires.
+      availability_h: Availability and changes
+      availability_p: The Service is provided "as is" and "as available", without
+        warranties of any kind. We may change, suspend, add or remove features, or
+        take the Service offline, at any time and without notice. We don't guarantee
+        that the Service will be uninterrupted or error-free, or that data will never
+        be lost.
+      changes_h: Changes to these terms
+      changes_p: We may update these terms. We'll update the "last updated" date and,
+        for significant changes, try to give notice through the Service. Continued
+        use after changes means you accept them.
+      eligibility_h: Eligibility
+      eligibility_p: You must meet Discord's minimum age requirement and comply with
+        Discord's Terms of Service and Community Guidelines when using the Service.
+      intro: These terms govern your use of the shrkbot Discord bot and its web dashboard
+        (the "Service"), operated by Tim Engelhardt. By adding shrkbot to a server,
+        using its features or signing in to the dashboard, you agree to them. If you
+        don't agree, please don't use the Service.
       law_h: Governing law
-      law_p: These terms are governed by the law of [JURISDICTION].
-      liability_h: Liability
-      liability_p: We are liable only for damages caused by intent or gross negligence,
-        and for culpable injury to life, body or health. Any further liability is
-        excluded to the extent legally permissible.
+      law_p: These terms are governed by the laws of Germany, without regard to conflict-of-laws
+        rules and subject to any mandatory consumer protections that apply where you
+        live.
+      liability_h: Limitation of liability
+      liability_p: We are liable without limit for damages caused by intent or gross
+        negligence and for culpable injury to life, body or health. Beyond that, and
+        to the extent legally permissible, we are not liable for indirect, incidental
+        or consequential damages or for loss of data arising from your use of, or
+        inability to use, the free Service. Nothing in these terms limits liability
+        that cannot be limited by law.
+      privacy_h: Privacy
+      privacy_link: privacy policy
+      privacy_post: ", which forms part of these terms."
+      privacy_pre: 'Our handling of data is described in our '
       service_h: The service
-      service_p: shrkbot provides Discord server utilities — role menus, welcome messages,
-        activity logging and reminders — configured through this website. The service
-        is provided free of charge.
-      termination_h: Termination
-      termination_p: You can stop using the service at any time by removing the bot
-        from your server, which permanently deletes that server's data, or by deleting
-        your dashboard account. We may remove the bot from servers that violate these
+      service_p: shrkbot is a general-purpose Discord bot whose features — self-assignable
+        roles, reminders, welcome and leave messages, activity logging — are enabled
+        per server and configured through commands and this website. The Service is
+        provided free of charge.
+      source_h: Open source
+      source_p: shrkbot's source code is published under the MIT licence. That licence
+        covers the code; your use of the instance we operate is governed by these
         terms.
+      termination_h: Termination
+      termination_p: You can stop using the Service at any time by removing shrkbot
+        from your server — which permanently deletes that server's data — or by deleting
+        your dashboard account. We may restrict or terminate access for any server
+        or user that breaches these terms or that we reasonably believe is misusing
+        the Service.
       title: Terms of service
-      updated: Last updated 5 July 2026
+      updated: 'Last updated: July 5th, 2026'
       use_h: Acceptable use
-      use_items_1: You must comply with Discord's Terms of Service and Community Guidelines.
-      use_items_2: Server admins are responsible for content they configure, such
-        as welcome and leave messages.
-      use_items_3: You may not abuse, overload or attempt to disrupt the service.
+      use_items_1: use the Service to violate Discord's Terms of Service, Community
+        Guidelines or any applicable law;
+      use_items_2: abuse, disrupt, overload or attempt to gain unauthorised access
+        to the Service or its infrastructure;
+      use_items_3: use the Service to harass others or to store or distribute unlawful
+        content;
+      use_items_4: attempt to circumvent limits, security or access controls.
+      use_lead: 'You agree not to:'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,9 @@ Rails.application.routes.draw do
   get "/auth/failure", to: "sessions#failure"
   delete "/logout", to: "sessions#destroy", as: :logout
 
+  resource :privacy_policy, only: :show, path: "privacy"
+  resource :terms_of_service, only: :show, path: "terms"
+
   resources :notifications, only: [:index, :show, :update]
   namespace :notifications do
     resource :read, only: :create

--- a/spec/requests/legal_pages_spec.rb
+++ b/spec/requests/legal_pages_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Legal pages", type: :request do
+  describe "GET /privacy" do
+    subject(:privacy) { get privacy_policy_path }
+
+    it "responds ok while signed out" do
+      privacy
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "includes the privacy policy title" do
+      privacy
+
+      expect(response.body).to include("Privacy policy")
+    end
+  end
+
+  describe "GET /terms" do
+    subject(:terms) { get terms_of_service_path }
+
+    it "responds ok while signed out" do
+      terms
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "includes the terms of service title" do
+      terms
+
+      expect(response.body).to include("Terms of service")
+    end
+  end
+end


### PR DESCRIPTION
Final chunk of the GDPR/privacy work — required for Discord bot verification (privacy policy link) and GDPR Art. 13 disclosure.

- Public `/privacy` and `/terms` pages (singular resources, no login required) documenting exactly what shrkbot stores, legal bases, retention (including the automatic purges from #100/#102), self-service erasure (#101, `/unremind`), and the single-cookie situation.
- `Components::PublicShell` extracted from `Views::Home` (header/footer chrome, now needed by three pages); footer links both documents. `Components::LegalPage` wraps the shared document frame.

**Before merging, replace the bracketed placeholders in `config/locales/web.en.yml`:** `[CONTROLLER_NAME]`, `[CONTACT_EMAIL]` (×3), `[HOSTING_PROVIDER]`, `[BACKUP_RETENTION_DAYS]`, `[JURISDICTION]`.

⚠️ Drafted from general GDPR knowledge (Art. 6(1)(b)/(f), Art. 13) — not legal advice; please review before submitting for verification. Note `routes.rb` will conflict trivially with #101 (both touch the route block); whichever merges second needs a 10-second resolution.