### PR TITLE
Reconcile guild purges missed while the bot was offline

### DIFF
--- a/app/bot/discord/guild_membership.rb
+++ b/app/bot/discord/guild_membership.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Discord
+  module GuildMembership
+    module_function
+
+    def member?(guild_id)
+      Discordrb::API::Server.resolve(BotConfig.rest_token, guild_id)
+      true
+    rescue Discordrb::Errors::UnknownServer, Discordrb::Errors::NoPermission
+      false
+    end
+  end
+end

--- a/app/bot/server_reconciliation.rb
+++ b/app/bot/server_reconciliation.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class ServerReconciliation < BaseEvent
+  on :ready
+
+  def handle
+    stale_configurations.each do |config|
+      next if Discord::GuildMembership.member?(config.discord_id)
+
+      Ops::ServerConfiguration::Destroy.call(server_configuration: config)
+    end
+  end
+
+  private
+
+  def stale_configurations
+    ::ServerConfiguration.where.not(discord_id: event.bot.servers.keys).select do |config|
+      on_this_shard?(config.discord_id)
+    end
+  end
+
+  def on_this_shard?(discord_id)
+    shard_id, num_shards = event.bot.shard_key
+    return true unless num_shards
+
+    (discord_id >> 22) % num_shards == shard_id
+  end
+end

--- a/docs/adding-a-plugin.md
+++ b/docs/adding-a-plugin.md
@@ -87,3 +87,29 @@ runtime (a DB read), since handlers aren't hidden the way guild commands are.
 Every non-trivial unit ships with a spec (RSpec + FactoryBot). Test our logic, not
 discordrb. Factories never set `id`. Run `bundle exec rspec`, `bundle exec standardrb`,
 and `bundle exec rake active_record_doctor` before pushing.
+
+## 7. Privacy & data
+
+Any new stored data must be reflected **in the same chunk** in three places:
+
+1. **Privacy policy** (`config/locales/legal.en.yml`): describe what is stored, why,
+   and how long it is retained.
+2. **`Ops::Users::Destroy`**: if the data is per-user (keyed by a Discord user ID),
+   add deletion there so a user's data is purged on request.
+3. **Guild purge**: if the data is guild-scoped, it must cascade when the guild
+   configuration is destroyed.
+
+For guild-scoped data, hang the table off `ServerConfiguration` with a `dependent:`
+option on the association so `Ops::ServerConfiguration::Destroy` cascades automatically.
+Data keyed by raw Discord snowflakes without an Active Record association (like
+reminders, which use a bare `server_id` column) must be handled explicitly inside that
+operation.
+
+The privacy policy's promises are binding constraints on implementation, not aspirational
+copy. For example, the moderation section commits to in-memory scanning with no message
+retention — that constraint must hold in any implementation of that plugin.
+
+The guild purge runs in two places: the `server_delete` event (`ServerCleanup`) and a
+REST-confirmed reconciliation at startup (`ServerReconciliation`, which catches kicks
+that happened while the bot was offline). Purge logic must therefore live entirely in
+`Ops::ServerConfiguration::Destroy` — never duplicated in the event handlers themselves.

--- a/spec/bot/discord/guild_membership_spec.rb
+++ b/spec/bot/discord/guild_membership_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "discordrb"
+
+RSpec.describe Discord::GuildMembership do
+  let(:guild_id) { 123_456 }
+  let(:rest_token) { "Bot token" }
+
+  before do
+    allow(BotConfig).to receive(:rest_token).and_return(rest_token)
+  end
+
+  describe ".member?" do
+    subject(:member?) { described_class.member?(guild_id) }
+
+    context "when resolve succeeds" do
+      before do
+        allow(Discordrb::API::Server).to receive(:resolve)
+      end
+
+      it "returns true" do
+        expect(member?).to be(true)
+      end
+    end
+
+    context "when resolve raises UnknownServer" do
+      before do
+        allow(Discordrb::API::Server).to receive(:resolve).and_raise(
+          Discordrb::Errors::UnknownServer.new("Unknown Server")
+        )
+      end
+
+      it "returns false" do
+        expect(member?).to be(false)
+      end
+    end
+
+    context "when resolve raises NoPermission" do
+      before do
+        allow(Discordrb::API::Server).to receive(:resolve).and_raise(Discordrb::Errors::NoPermission)
+      end
+
+      it "returns false" do
+        expect(member?).to be(false)
+      end
+    end
+
+    context "when resolve raises a non-Discord error" do
+      before do
+        allow(Discordrb::API::Server).to receive(:resolve).and_raise(RuntimeError, "network failure")
+      end
+
+      it "lets the error propagate" do
+        expect { member? }.to raise_error(RuntimeError, "network failure")
+      end
+    end
+  end
+end

--- a/spec/bot/server_reconciliation_spec.rb
+++ b/spec/bot/server_reconciliation_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ServerReconciliation do
+  subject(:handle) { described_class.new(event).handle }
+
+  let(:present_id) { 111 }
+  let(:bot) { double("bot", servers: {present_id => double("server")}, shard_key: nil) }
+  let(:event) { double("event", bot:) }
+
+  let(:op) { Ops::ServerConfiguration::Destroy }
+
+  context "when a config's guild is present in bot.servers" do
+    let!(:config) { create(:server_configuration, discord_id: present_id) }
+
+    it "does not check membership" do
+      expect(Discord::GuildMembership).not_to receive(:member?)
+      handle
+    end
+
+    it "does not destroy the config" do
+      expect(op).not_to receive(:call)
+      handle
+    end
+  end
+
+  context "when a config's guild is absent from bot.servers" do
+    let(:absent_id) { 999 }
+    let!(:config) { create(:server_configuration, discord_id: absent_id) }
+
+    context "when member? returns false (bot was kicked)" do
+      before do
+        allow(Discord::GuildMembership).to receive(:member?).with(absent_id).and_return(false)
+      end
+
+      it "calls the destroy operation" do
+        expect(op).to receive(:call).with(server_configuration: config)
+        handle
+      end
+    end
+
+    context "when member? returns true (cache was incomplete)" do
+      before do
+        allow(Discord::GuildMembership).to receive(:member?).with(absent_id).and_return(true)
+      end
+
+      it "does not destroy the config" do
+        expect(op).not_to receive(:call)
+        handle
+      end
+    end
+  end
+
+  context "when sharded" do
+    let(:shard_0_id) { 2 << 22 }
+    let(:shard_1_id) { 1 << 22 }
+
+    let(:bot) { double("bot", servers: {}, shard_key: [0, 2]) }
+
+    let!(:own_config) { create(:server_configuration, discord_id: shard_0_id) }
+    let!(:other_config) { create(:server_configuration, discord_id: shard_1_id) }
+
+    before do
+      allow(Discord::GuildMembership).to receive(:member?).with(shard_0_id).and_return(false)
+    end
+
+    it "checks membership only for configs on this shard" do
+      expect(Discord::GuildMembership).not_to receive(:member?).with(shard_1_id)
+      handle
+    end
+
+    it "destroys only the config on this shard" do
+      expect(op).to receive(:call).with(server_configuration: own_config)
+      expect(op).not_to receive(:call).with(server_configuration: other_config)
+      handle
+    end
+  end
+end


### PR DESCRIPTION
Closes the offline-kick gap in the guild purge (follow-up to #102): a kick during downtime never delivers `server_delete`, so on `:ready` each shard sweeps for configurations whose guild is missing from its cache and purges the confirmed ones through the existing `Ops::ServerConfiguration::Destroy`.

Two safety properties worth knowing about:
- **Absence is never proof.** discordrb fires `:ready` after a 10-second timeout even while guilds are still streaming in during a Discord outage, so every candidate is REST-confirmed kicked (`Discord::GuildMembership`, 404/403 = gone, anything else propagates and skips the sweep) before anything is deleted. An outage can only delay a purge, never cause one.
- **Shard-scoped candidates.** Configs are filtered by `(discord_id >> 22) % num_shards` against `bot.shard_key`, so multi-shard setups never purge guilds belonging to another shard.

Also adds the standing "Privacy & data" rules to `docs/adding-a-plugin.md`: new stored data must update the privacy policy, `Ops::Users::Destroy` (per-user), and the guild purge (guild-scoped) in the same chunk, and purge logic lives only in the op since two callers now share it.