### PR TITLE
Add imprint page and auth-aware public header

### DIFF
--- a/app/components/legal_links.rb
+++ b/app/components/legal_links.rb
@@ -5,6 +5,7 @@ class Components::LegalLinks < Components::Base
     nav(class: "flex items-center justify-center gap-4 text-xs text-text-muted") do
       a(href: privacy_policy_path, class: link_classes) { t(".privacy") }
       a(href: terms_of_service_path, class: link_classes) { t(".terms") }
+      a(href: imprint_path, class: link_classes) { t(".imprint") }
     end
   end
 

--- a/app/components/legal_page.rb
+++ b/app/components/legal_page.rb
@@ -4,18 +4,20 @@ class Components::LegalPage < Components::Base
   CONTACT_EMAIL = "info@shrkbot.com"
   SUPPORT_URL = "https://discord.gg/3gwFMTY"
 
-  def initialize(title:, updated:)
+  def initialize(title:, updated: nil, user: nil, contact: true)
     @title = title
     @updated = updated
+    @user = user
+    @contact = contact
   end
 
   def view_template(&block)
-    render Components::PublicShell.new do
+    render Components::PublicShell.new(user: @user) do
       article(class: "mx-auto max-w-2xl px-6 py-16") do
         h1(class: "mb-2 font-display text-3xl font-bold tracking-tight") { @title }
-        p(class: "mb-10 text-sm text-text-muted") { @updated }
+        p(class: "mb-10 text-sm text-text-muted") { @updated } if @updated
         yield
-        contact_section
+        contact_section if @contact
       end
     end
   end

--- a/app/components/legal_page.rb
+++ b/app/components/legal_page.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Components::LegalPage < Components::Base
+  include Components::LegalProse
+
   CONTACT_EMAIL = "info@shrkbot.com"
   SUPPORT_URL = "https://discord.gg/3gwFMTY"
 
@@ -32,9 +34,5 @@ class Components::LegalPage < Components::Base
       plain " / "
       a(href: SUPPORT_URL, class: link_classes) { t(".contact_support") }
     end
-  end
-
-  def link_classes
-    "underline transition-colors hover:text-text-primary"
   end
 end

--- a/app/components/legal_prose.rb
+++ b/app/components/legal_prose.rb
@@ -3,6 +3,10 @@
 module Components::LegalProse
   private
 
+  def link_classes
+    "underline transition-colors hover:text-text-primary"
+  end
+
   def heading(text)
     h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { text }
   end

--- a/app/components/public_shell.rb
+++ b/app/components/public_shell.rb
@@ -6,6 +6,10 @@ class Components::PublicShell < Components::Base
 
   REPO_URL = "https://github.com/badBlackShark/shrkbot"
 
+  def initialize(user: nil)
+    @user = user
+  end
+
   def view_template(&block)
     div(class: "flex min-h-screen flex-col") do
       header_bar
@@ -24,15 +28,26 @@ class Components::PublicShell < Components::Base
       end
       div(class: "flex-1")
       render Components::ThemeToggle.new
-      button_to(
-        "/auth/discord",
-        method: :post,
-        data: {turbo: false},
-        class: Components::Button.css(variant: :primary, size: :lg)
-      ) do
-        render Components::Icon.new("sign-in", class: "size-4")
-        span { t(".sign_in") }
-      end
+      @user ? dashboard_link : sign_in_button
+    end
+  end
+
+  def dashboard_link
+    a(href: servers_path, class: Components::Button.css(variant: :primary, size: :lg)) do
+      render Components::Icon.new("squares-four", class: "size-4")
+      span { t(".dashboard") }
+    end
+  end
+
+  def sign_in_button
+    button_to(
+      "/auth/discord",
+      method: :post,
+      data: {turbo: false},
+      class: Components::Button.css(variant: :primary, size: :lg)
+    ) do
+      render Components::Icon.new("sign-in", class: "size-4")
+      span { t(".sign_in") }
     end
   end
 

--- a/app/controllers/imprints_controller.rb
+++ b/app/controllers/imprints_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ImprintsController < ApplicationController
+  skip_before_action :require_login
+
+  def show
+    render Views::Imprint.new(user: current_user)
+  end
+end

--- a/app/controllers/privacy_policies_controller.rb
+++ b/app/controllers/privacy_policies_controller.rb
@@ -4,6 +4,6 @@ class PrivacyPoliciesController < ApplicationController
   skip_before_action :require_login
 
   def show
-    render Views::PrivacyPolicy.new
+    render Views::PrivacyPolicy.new(user: current_user)
   end
 end

--- a/app/controllers/terms_of_services_controller.rb
+++ b/app/controllers/terms_of_services_controller.rb
@@ -4,6 +4,6 @@ class TermsOfServicesController < ApplicationController
   skip_before_action :require_login
 
   def show
-    render Views::TermsOfService.new
+    render Views::TermsOfService.new(user: current_user)
   end
 end

--- a/app/views/imprint.rb
+++ b/app/views/imprint.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class Views::Imprint < Views::Base
+  include Components::LegalProse
+
+  def initialize(user:)
+    @user = user
+  end
+
+  def view_template
+    render Components::LegalPage.new(title: t(".title"), user: @user, contact: false) do
+      paragraph(t(".legal_ref"))
+      provider_section
+      contact_section
+    end
+  end
+
+  private
+
+  def provider_section
+    heading(t(".provider_h"))
+    p(class: "mb-4 leading-relaxed text-text-secondary") do
+      plain t(".provider_name")
+      br
+      plain t(".provider_street")
+      br
+      plain t(".provider_city")
+      br
+      plain t(".provider_country")
+    end
+  end
+
+  def contact_section
+    heading(t(".contact_h"))
+    paragraph(t(".contact_phone"))
+    p(class: "mb-4 leading-relaxed text-text-secondary") do
+      plain t(".contact_email_pre")
+      a(href: "mailto:#{Components::LegalPage::CONTACT_EMAIL}", class: "underline transition-colors hover:text-text-primary") { Components::LegalPage::CONTACT_EMAIL }
+    end
+  end
+end

--- a/app/views/imprint.rb
+++ b/app/views/imprint.rb
@@ -35,7 +35,7 @@ class Views::Imprint < Views::Base
     paragraph(t(".contact_phone"))
     p(class: "mb-4 leading-relaxed text-text-secondary") do
       plain t(".contact_email_pre")
-      a(href: "mailto:#{Components::LegalPage::CONTACT_EMAIL}", class: "underline transition-colors hover:text-text-primary") { Components::LegalPage::CONTACT_EMAIL }
+      a(href: "mailto:#{Components::LegalPage::CONTACT_EMAIL}", class: link_classes) { Components::LegalPage::CONTACT_EMAIL }
     end
   end
 end

--- a/app/views/privacy_policy.rb
+++ b/app/views/privacy_policy.rb
@@ -3,8 +3,12 @@
 class Views::PrivacyPolicy < Views::Base
   include Components::LegalProse
 
+  def initialize(user:)
+    @user = user
+  end
+
   def view_template
-    render Components::LegalPage.new(title: t(".title"), updated: t(".updated")) do
+    render Components::LegalPage.new(title: t(".title"), updated: t(".updated"), user: @user) do
       intro_section
       audience_section
       data_section

--- a/app/views/terms_of_service.rb
+++ b/app/views/terms_of_service.rb
@@ -3,8 +3,12 @@
 class Views::TermsOfService < Views::Base
   include Components::LegalProse
 
+  def initialize(user:)
+    @user = user
+  end
+
   def view_template
-    render Components::LegalPage.new(title: t(".title"), updated: t(".updated")) do
+    render Components::LegalPage.new(title: t(".title"), updated: t(".updated"), user: @user) do
       intro_section
       service_section
       eligibility_section

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -6,6 +6,7 @@ data:
     - config/locales/*.%{locale}.yml
   write:
     - ["activity_log.*", "config/locales/activity_log.%{locale}.yml"]
+    - ["views.imprint.*", "config/locales/legal.%{locale}.yml"]
     - ["views.privacy_policy.*", "config/locales/legal.%{locale}.yml"]
     - ["views.terms_of_service.*", "config/locales/legal.%{locale}.yml"]
     - ["components.legal_page.*", "config/locales/legal.%{locale}.yml"]

--- a/config/locales/legal.en.yml
+++ b/config/locales/legal.en.yml
@@ -6,6 +6,17 @@ en:
       contact_operator: Tim Engelhardt
       contact_support: support server
   views:
+    imprint:
+      contact_email_pre: 'Email: '
+      contact_h: Contact
+      contact_phone: 'Phone: [PHONE_NUMBER]'
+      legal_ref: Information in accordance with § 5 DDG (German Digital Services Act).
+      provider_city: "[POSTAL_CODE_AND_CITY]"
+      provider_country: Germany
+      provider_h: Service provider
+      provider_name: Tim Engelhardt
+      provider_street: "[STREET_ADDRESS]"
+      title: Imprint
     privacy_policy:
       audience_dashboard: 'Dashboard users: people (usually server admins) who sign
         in to this website with Discord to configure the bot.'

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -40,6 +40,7 @@ en:
       enabled: Enabled
       servers: Servers
     legal_links:
+      imprint: Imprint
       privacy: Privacy policy
       terms: Terms of service
     logging:
@@ -98,6 +99,7 @@ en:
       dashboard: Dashboard
       plugins: Plugins
     public_shell:
+      dashboard: Dashboard
       footer_link: free and open source
       footer_mid: ". Made with "
       footer_post: " by badBlackShark."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
 
   resource :privacy_policy, only: :show, path: "privacy"
   resource :terms_of_service, only: :show, path: "terms"
+  resource :imprint, only: :show
 
   resources :notifications, only: [:index, :show, :update]
   namespace :notifications do

--- a/spec/requests/legal_pages_spec.rb
+++ b/spec/requests/legal_pages_spec.rb
@@ -17,6 +17,28 @@ RSpec.describe "Legal pages", type: :request do
 
       expect(response.body).to include("Privacy policy")
     end
+
+    context "when signed out" do
+      it "shows the sign-in button and not the dashboard link" do
+        privacy
+
+        expect(response.body).to include("Sign in with Discord")
+        expect(response.body).not_to include('href="/servers"')
+      end
+    end
+
+    context "when signed in" do
+      include_context "discord auth"
+
+      before { post "/auth/discord/callback" }
+
+      it "shows the dashboard link and not the sign-in button" do
+        privacy
+
+        expect(response.body).to include('href="/servers"')
+        expect(response.body).not_to include("Sign in with Discord")
+      end
+    end
   end
 
   describe "GET /terms" do
@@ -32,6 +54,22 @@ RSpec.describe "Legal pages", type: :request do
       terms
 
       expect(response.body).to include("Terms of service")
+    end
+  end
+
+  describe "GET /imprint" do
+    subject(:imprint) { get imprint_path }
+
+    it "responds ok while signed out" do
+      imprint
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "includes the imprint title" do
+      imprint
+
+      expect(response.body).to include("Imprint")
     end
   end
 end


### PR DESCRIPTION
Two fixes from review of the live pages:

- **Auth-aware public header:** /privacy and /terms showed "Sign in with Discord" to signed-in users. `PublicShell` now takes an optional user and renders a Dashboard button instead; the legal controllers pass `current_user` through. Home is unaffected (signed-in users never reach it).
- **Imprint (§ 5 DDG):** new /imprint page with the service-provider block, linked site-wide via the shared footer links. `[STREET_ADDRESS]`, `[POSTAL_CODE_AND_CITY]` and `[PHONE_NUMBER]` are placeholders pending real data; email is info@shrkbot.com; deliberately no USt-IdNr line (Kleinunternehmer — none exists). Note: the ECJ has held the "direct contact" requirement can be met by a promptly-answered electronic channel instead of a phone number (C-298/07) — worth confirming in the legal pass, the placeholder may be deletable.