### PR TITLE
Give enabled buttons a pointer cursor globally

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "./base.css";
 @import "./fonts.css";
 @import "./tokens.css";
 @import "./theme.css";

--- a/app/assets/tailwind/base.css
+++ b/app/assets/tailwind/base.css
@@ -1,0 +1,6 @@
+@layer base {
+  button:not(:disabled),
+  [role="button"]:not(:disabled) {
+    cursor: pointer;
+  }
+}


### PR DESCRIPTION
The delete-account button (and in fact every `<button>` in the app, including everything styled via `Components::Button`) showed the default arrow cursor: Tailwind v4's preflight follows the browser default and nothing set `cursor: pointer`. The handful of sprinkled `cursor-pointer` utility classes only patched individual spots.

One `@layer base` rule covers `button:not(:disabled)` and `[role="button"]:not(:disabled)` app-wide. Disabled buttons keep their existing `cursor-not-allowed` treatment from `Components::Button`. Verified the rule lands in the compiled `builds/tailwind.css`.