### PR TITLE
Fix dropdown dark-theme leaks; build on the deploy host

### DIFF
--- a/app/assets/tailwind/tom-select.css
+++ b/app/assets/tailwind/tom-select.css
@@ -21,6 +21,7 @@
   align-items: center;
 }
 .ts-wrapper.single .ts-control { cursor: pointer; }
+.ts-wrapper.single.input-active .ts-control { background: var(--surface-card); }
 .ts-wrapper .ts-control::placeholder,
 .ts-wrapper .ts-control input::placeholder { color: var(--text-muted); }
 .ts-wrapper.focus .ts-control,
@@ -95,6 +96,7 @@
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--text-primary) 18%, transparent);
 }
 .ts-wrapper.multi .ts-control > .item .ts-dot { margin-right: 0.3125rem; }
+.ts-wrapper.plugin-remove_button:not(.rtl) .item .remove { border-left-color: var(--accent-soft-bd); }
 .ts-lock {
   display: inline-flex;
   margin-left: auto;

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -35,6 +35,7 @@ registry:
 builder:
   arch: amd64
   dockerfile: Dockerfile.prod
+  remote: ssh://root@<%= ENV["DEPLOY_HOST"] %>
 
 env:
   clear:


### PR DESCRIPTION
## What

Three small fixes bundled for deploy.

### Tom Select dark-theme leaks (two visual bugs)
The vendored `tom-select-base.css` bakes in light-theme colors that win on specificity over the token skin (`tom-select.css`). Overrode both in the skin with theme-aware tokens (matching specificity, skin loads last so it wins):

- **Channel picker field flips to white on open** (logging, welcomes, both role selects). On open Tom Select adds `.input-active`, and `.ts-wrapper.single.input-active .ts-control { background: #fff }` (0,4,0) beat the skin's `.ts-wrapper.single .ts-control` (0,3,0). Override -> `var(--surface-card)`.
- **Role remove-button divider too bright in dark mode.** The separator used a fixed `border-left: 1px solid #d0d0d0`. Override the color -> `var(--accent-soft-bd)` (matches the chip border).

### Remote builder
Build the amd64 production image on the deploy host instead of via QEMU emulation on arm64 dev machines (was OOMing during `bundle install`). Uses `ENV["DEPLOY_HOST"]`, consistent with every other host reference in the file.

Also folded a stray duplicate `builder:` block + a `redis-server --save ""` typo back into a single clean block (both had appeared in the working tree).

## Testing
CSS + YAML only, no Ruby touched. Validated via `rails tailwindcss:build` (overrides confirmed to win in the built cascade) and a YAML parse. standardrb clean. Rendering to be eyeballed in both themes on the config pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)