### PR TITLE
Fill imprint contact details

### DIFF
--- a/app/views/imprint.rb
+++ b/app/views/imprint.rb
@@ -22,6 +22,8 @@ class Views::Imprint < Views::Base
     p(class: "mb-4 leading-relaxed text-text-secondary") do
       plain t(".provider_name")
       br
+      plain t(".provider_care_of")
+      br
       plain t(".provider_street")
       br
       plain t(".provider_city")

--- a/app/views/imprint.rb
+++ b/app/views/imprint.rb
@@ -32,10 +32,11 @@ class Views::Imprint < Views::Base
 
   def contact_section
     heading(t(".contact_h"))
-    paragraph(t(".contact_phone"))
     p(class: "mb-4 leading-relaxed text-text-secondary") do
       plain t(".contact_email_pre")
       a(href: "mailto:#{Components::LegalPage::CONTACT_EMAIL}", class: link_classes) { Components::LegalPage::CONTACT_EMAIL }
     end
+    p(class: "leading-relaxed text-text-secondary") { t(".contact_phone") }
+    p(class: "mb-4 text-sm text-text-muted") { t(".contact_phone_note") }
   end
 end

--- a/config/locales/legal.en.yml
+++ b/config/locales/legal.en.yml
@@ -13,11 +13,12 @@ en:
       contact_phone_note: Voice calls only; for written contact, please use the email
         above.
       legal_ref: Information in accordance with § 5 DDG (German Digital Services Act).
+      provider_care_of: 'c/o flexdienst – #21478'
       provider_city: 67663 Kaiserslautern
       provider_country: Germany
       provider_h: Service provider
       provider_name: Tim Engelhardt
-      provider_street: 'c/o flexdienst – #21478, Kurt-Schumacher-Straße 76'
+      provider_street: Kurt-Schumacher-Straße 76
       title: Imprint
     privacy_policy:
       audience_dashboard: 'Dashboard users: people (usually server admins) who sign

--- a/config/locales/legal.en.yml
+++ b/config/locales/legal.en.yml
@@ -9,13 +9,15 @@ en:
     imprint:
       contact_email_pre: 'Email: '
       contact_h: Contact
-      contact_phone: 'Phone: [PHONE_NUMBER]'
+      contact_phone: 'Phone: +49 15679 814054'
+      contact_phone_note: Voice calls only; for written contact, please use the email
+        above.
       legal_ref: Information in accordance with § 5 DDG (German Digital Services Act).
-      provider_city: "[POSTAL_CODE_AND_CITY]"
+      provider_city: 67663 Kaiserslautern
       provider_country: Germany
       provider_h: Service provider
       provider_name: Tim Engelhardt
-      provider_street: "[STREET_ADDRESS]"
+      provider_street: 'c/o flexdienst – #21478, Kurt-Schumacher-Straße 76'
       title: Imprint
     privacy_policy:
       audience_dashboard: 'Dashboard users: people (usually server admins) who sign


### PR DESCRIPTION
Completes the imprint (§ 5 DDG) with real contact details.

- **Address:** service-provider block filled with the operator's c/o mail-forwarding address.
- **Phone:** voice-only number added, with a muted sub-line noting it's calls only and steering written contact to email.
- **Order:** email now listed first as the primary written channel, phone below it.

The phone value is quoted in YAML — a bare `#` in the address line was otherwise read as a comment and dropped the house number.

Gates green locally: rspec (942), standardrb, active_record_doctor, undercover, i18n-tasks (normalized + no missing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)