### PR TITLE
Server Shield: group scaffold + settings + config ops (PR 1)

### DIFF
--- a/.active_record_doctor.rb
+++ b/.active_record_doctor.rb
@@ -33,7 +33,8 @@ ActiveRecordDoctor.configure do
       "server_channels.discord_id",
       "server_channels.parent_id",
       "server_roles.discord_id",
-      "channel_overwrites.target_id"
+      "channel_overwrites.target_id",
+      "moderation_settings.staff_role_id"
     ]
 
   # These are NOT NULL with a DB default, so they're never nil — presence is wrong
@@ -42,6 +43,7 @@ ActiveRecordDoctor.configure do
     ignore_columns_with_default: true,
     ignore_attributes: [
       "PluginActivation.enabled",
+      "Moderation::SpamProtection::Settings.match_symbol_only_messages",
       "Reminders::Reminder.deliver_via_dm",
       "ServerConfiguration.force_dm_reminders",
       "ServerRole.managed"

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,10 @@
 # OS / editor cruft.
 .DS_Store
 
+# Python bytecode (OCR sidecar tooling).
+__pycache__/
+*.pyc
+
 # Local Claude Code / AI sandbox config (not part of the app).
 /.claude/
 

--- a/app/models/plugin_catalog.rb
+++ b/app/models/plugin_catalog.rb
@@ -1,22 +1,38 @@
 # frozen_string_literal: true
 
 class PluginCatalog
-  Definition = Data.define(:key, :name, :description, :channel_setting) do
+  Definition = Data.define(:key, :name, :description, :channel_setting, :requires_plugin, :parent) do
+    def initialize(key:, name:, description:, channel_setting: nil, requires_plugin: nil, parent: nil)
+      super
+    end
+
     def channel_backed?
       !channel_setting.nil?
     end
 
     def prerequisites_met?(server_configuration)
+      return false unless required_plugins_enabled?(server_configuration)
       return true unless channel_backed?
 
       server_configuration.public_send(channel_setting)&.channel_id.present?
+    end
+
+    private
+
+    def required_plugins_enabled?(server_configuration)
+      [requires_plugin, parent].compact.all? do |key|
+        server_configuration.plugins.enabled.exists?(key:)
+      end
     end
   end
 
   DEFINITIONS = [
     Definition.new(key: :logging, name: "Logging", description: "Writes moderation actions to a log channel.", channel_setting: :logging_setting),
     Definition.new(key: :roles, name: "Roles", description: "Self-assignable roles.", channel_setting: :role_setting),
-    Definition.new(key: :welcomes, name: "Welcomes", description: "Join and leave messages.", channel_setting: :welcome_settings)
+    Definition.new(key: :welcomes, name: "Welcomes", description: "Join and leave messages.", channel_setting: :welcome_settings),
+    Definition.new(key: :moderation, name: "Server Shield", description: "Your server's aegis: automated moderation beyond Discord's AutoMod.", requires_plugin: :logging),
+    Definition.new(key: :spam_protection, name: "Cross-Channel Spam Guard", description: "Detects the same message blasted across multiple channels within seconds and purges it before it spreads. Matching is fingerprint-based — message content is never stored.", parent: :moderation),
+    Definition.new(key: :image_scanning, name: "Scam Image Detection", description: "Reads the text inside posted images and checks it against known scam patterns and previously confirmed scam images. Staff confirm or dismiss every catch, and the bot remembers.", parent: :moderation)
   ].freeze
 
   def self.all

--- a/app/models/server_configuration.rb
+++ b/app/models/server_configuration.rb
@@ -7,6 +7,9 @@ class ServerConfiguration < ApplicationRecord
   has_one :logging_setting, dependent: :delete
   has_one :role_setting, class_name: "Roles::Settings", dependent: :destroy
   has_one :welcome_settings, class_name: "Welcomes::Settings", dependent: :delete
+  has_one :moderation_settings, class_name: "Moderation::Settings", dependent: :delete
+  has_one :spam_protection_settings, class_name: "Moderation::SpamProtection::Settings", dependent: :delete
+  has_one :image_scanning_settings, class_name: "Moderation::ImageScanning::Settings", dependent: :delete
 
   has_many :notifications, dependent: :delete_all
   has_many :server_channels, dependent: :destroy

--- a/app/operations/logging/configure.rb
+++ b/app/operations/logging/configure.rb
@@ -12,6 +12,7 @@ module Ops
         settings.assign_attributes(channel_id:, enabled_actions:)
         activation = staged_activation
 
+        return moderation_dependency_failure(activation) if moderation_enabled? && !logging_stays_available?
         return failure(messages(settings, activation), value: activation) unless settings.valid? && activation.valid?
 
         settings.save!
@@ -20,6 +21,19 @@ module Ops
       end
 
       private
+
+      def moderation_enabled?
+        server_configuration.plugins.enabled.exists?(key: :moderation)
+      end
+
+      def logging_stays_available?
+        enabling? && channel_id.present?
+      end
+
+      def moderation_dependency_failure(activation)
+        activation.errors.add(:enabled, "can't be turned off or lose its channel while Server Shield is enabled")
+        failure(activation.errors[:enabled], value: activation)
+      end
 
       def plugin_key
         :logging

--- a/app/operations/moderation/configure.rb
+++ b/app/operations/moderation/configure.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Ops
+  module Moderation
+    class Configure < ApplicationOperation
+      include Ops::PluginConfiguration
+
+      receives :server_configuration, :staff_role_id, :enabled
+
+      def call
+        settings = server_configuration.moderation_settings
+        settings.assign_attributes(staff_role_id: staff_role_id.presence)
+        activation = staged_activation
+
+        return logging_guard_failure(activation) if enabling? && !logging_ready?
+
+        settings.save!
+        activation.save!
+        ok(activation)
+      end
+
+      private
+
+      def logging_ready?
+        server_configuration.plugins.enabled.exists?(key: :logging) &&
+          server_configuration.logging_setting&.channel_id.present?
+      end
+
+      def logging_guard_failure(activation)
+        activation.errors.add(:enabled, "requires the Logging plugin enabled with a log channel set")
+        failure(activation.errors[:enabled], value: activation)
+      end
+
+      def plugin_key
+        :moderation
+      end
+    end
+  end
+end

--- a/app/operations/moderation/image_scanning/configure.rb
+++ b/app/operations/moderation/image_scanning/configure.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Ops
+  module Moderation
+    module ImageScanning
+      class Configure < ApplicationOperation
+        include Ops::PluginConfiguration
+        include Ops::Moderation::SubPluginConfiguration
+
+        receives :server_configuration,
+          :sensitivity,
+          :action,
+          :punishment,
+          :timeout_seconds,
+          :custom_keywords,
+          :custom_keyword_min_hits,
+          :enabled
+
+        def call
+          settings = server_configuration.image_scanning_settings
+          settings.assign_attributes(
+            sensitivity:,
+            action:,
+            punishment:,
+            timeout_seconds:,
+            custom_keyword_min_hits:,
+            custom_keywords: Array(custom_keywords)
+          )
+          activation = staged_activation
+
+          return staff_role_guard_failure(activation) if enabling? && staff_role_missing?
+          return failure(messages(settings, activation), value: activation) unless settings.valid? && activation.valid?
+
+          settings.save!
+          activation.save!
+          ok(activation)
+        end
+
+        private
+
+        def plugin_key
+          :image_scanning
+        end
+      end
+    end
+  end
+end

--- a/app/operations/moderation/spam_protection/configure.rb
+++ b/app/operations/moderation/spam_protection/configure.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Ops
+  module Moderation
+    module SpamProtection
+      class Configure < ApplicationOperation
+        include Ops::PluginConfiguration
+        include Ops::Moderation::SubPluginConfiguration
+
+        receives :server_configuration,
+          :channel_threshold,
+          :window_seconds,
+          :similarity,
+          :match_symbol_only_messages,
+          :action,
+          :punishment,
+          :timeout_seconds,
+          :enabled
+
+        def call
+          settings = server_configuration.spam_protection_settings
+          settings.assign_attributes(
+            channel_threshold:,
+            window_seconds:,
+            similarity:,
+            match_symbol_only_messages:,
+            action:,
+            punishment:,
+            timeout_seconds:
+          )
+          activation = staged_activation
+
+          return staff_role_guard_failure(activation) if enabling? && staff_role_missing?
+          return failure(messages(settings, activation), value: activation) unless settings.valid? && activation.valid?
+
+          settings.save!
+          activation.save!
+          ok(activation)
+        end
+
+        private
+
+        def plugin_key
+          :spam_protection
+        end
+      end
+    end
+  end
+end

--- a/app/operations/moderation/sub_plugin_configuration.rb
+++ b/app/operations/moderation/sub_plugin_configuration.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Ops
+  module Moderation
+    module SubPluginConfiguration
+      private
+
+      def staff_role_missing?
+        server_configuration.moderation_settings&.staff_role_id.blank?
+      end
+
+      def staff_role_guard_failure(activation)
+        activation.errors.add(:enabled, "requires a staff role set on the Server Shield overview")
+        failure(activation.errors[:enabled], value: activation)
+      end
+    end
+  end
+end

--- a/app/operations/plugin_configuration.rb
+++ b/app/operations/plugin_configuration.rb
@@ -4,6 +4,10 @@ module Ops
   module PluginConfiguration
     private
 
+    def enabling?
+      ActiveModel::Type::Boolean.new.cast(enabled)
+    end
+
     def staged_activation
       activation = server_configuration.plugin_activations.find_or_initialize_by(plugin: Plugin.find_by!(key: plugin_key))
       activation.enabled = enabled

--- a/app/operations/server_configuration/ensure.rb
+++ b/app/operations/server_configuration/ensure.rb
@@ -31,6 +31,9 @@ module Ops
         config.logging_setting || config.create_logging_setting!
         config.role_setting || config.create_role_setting!
         config.welcome_settings || config.create_welcome_settings!
+        config.moderation_settings || config.create_moderation_settings!
+        config.spam_protection_settings || config.create_spam_protection_settings!
+        config.image_scanning_settings || config.create_image_scanning_settings!
       end
     end
   end

--- a/app/plugins/moderation/image_scanning/settings.rb
+++ b/app/plugins/moderation/image_scanning/settings.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Moderation
+  module ImageScanning
+    class Settings < ApplicationRecord
+      include Moderation::Punishable
+      include Moderation::SubPluginSettings
+
+      self.table_name = "image_scanning_settings"
+
+      SENSITIVITIES = %w[relaxed standard strict].freeze
+      ACTIONS = %w[none delete].freeze
+      MAX_KEYWORDS = 200
+
+      belongs_to :server_configuration
+
+      validates :sensitivity, inclusion: {in: SENSITIVITIES}
+      validates :action, inclusion: {in: ACTIONS}
+      validates :custom_keyword_min_hits,
+        numericality: {only_integer: true, greater_than_or_equal_to: 1}
+      validate :custom_keywords_within_limit
+      validate :custom_keywords_not_blank
+      validate :min_hits_within_keyword_count
+
+      def self.active_for(discord_id)
+        active_group_settings(discord_id, :image_scanning) { |config| config.image_scanning_settings }
+      end
+
+      private
+
+      def custom_keywords_within_limit
+        return if custom_keywords.size <= MAX_KEYWORDS
+
+        errors.add(:custom_keywords, "can have at most #{MAX_KEYWORDS} entries")
+      end
+
+      def custom_keywords_not_blank
+        return if custom_keywords.all? { |keyword| keyword.to_s.strip.present? }
+
+        errors.add(:custom_keywords, "can't contain blank entries")
+      end
+
+      def min_hits_within_keyword_count
+        return if custom_keywords.empty?
+        return if custom_keyword_min_hits <= custom_keywords.size
+
+        errors.add(:custom_keyword_min_hits, "can't exceed the number of keywords")
+      end
+    end
+  end
+end

--- a/app/plugins/moderation/punishable.rb
+++ b/app/plugins/moderation/punishable.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Moderation
+  module Punishable
+    extend ActiveSupport::Concern
+
+    PUNISHMENTS = %w[none timeout kick ban].freeze
+
+    included do
+      validates :punishment, inclusion: {in: PUNISHMENTS}
+      validates :timeout_seconds,
+        numericality: {only_integer: true, greater_than_or_equal_to: 60, less_than_or_equal_to: 2_419_200}
+    end
+  end
+end

--- a/app/plugins/moderation/settings.rb
+++ b/app/plugins/moderation/settings.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Moderation
+  class Settings < ApplicationRecord
+    self.table_name = "moderation_settings"
+
+    belongs_to :server_configuration
+  end
+end

--- a/app/plugins/moderation/spam_protection/settings.rb
+++ b/app/plugins/moderation/spam_protection/settings.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Moderation
+  module SpamProtection
+    class Settings < ApplicationRecord
+      include Moderation::Punishable
+      include Moderation::SubPluginSettings
+
+      self.table_name = "spam_protection_settings"
+
+      ACTIONS = %w[purge notify_only].freeze
+
+      belongs_to :server_configuration
+
+      validates :channel_threshold,
+        numericality: {only_integer: true, greater_than_or_equal_to: 2, less_than_or_equal_to: 500}
+      validates :window_seconds,
+        numericality: {only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 60}
+      validates :similarity,
+        numericality: {greater_than_or_equal_to: 0.75, less_than_or_equal_to: 1.0}
+      validates :action, inclusion: {in: ACTIONS}
+
+      def self.active_for(discord_id)
+        active_group_settings(discord_id, :spam_protection) { |config| config.spam_protection_settings }
+      end
+    end
+  end
+end

--- a/app/plugins/moderation/sub_plugin_settings.rb
+++ b/app/plugins/moderation/sub_plugin_settings.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Moderation
+  module SubPluginSettings
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def active_group_settings(discord_id, plugin_key)
+        config = ServerConfiguration.find_by(discord_id:)
+        return unless config
+
+        enabled = config.plugins.enabled
+        return unless enabled.exists?(key: :moderation) && enabled.exists?(key: plugin_key)
+
+        yield config
+      end
+    end
+  end
+end

--- a/app/views/servers/show.rb
+++ b/app/views/servers/show.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Views::Servers::Show < Views::Base
+  include Components::PluginNav
+
   def initialize(guild:, server_configuration:, plugins:, user:, servers: [], plugin_counts: {})
     @guild = guild
     @server_configuration = server_configuration
@@ -56,7 +58,7 @@ class Views::Servers::Show < Views::Base
   def plugins_section
     p(class: "mb-3 text-[11px] font-semibold uppercase tracking-widest text-eyebrow") { t(".plugins") }
     div(class: "flex flex-col gap-3") do
-      @plugins.each do |row|
+      @plugins.select { |row| plugin_config_path(@guild.id, row.key) }.each do |row|
         render Components::PluginRow.new(server_id: @guild.id, key: row.key, enabled: row.enabled, configured: row.configured, locked: row.locked)
       end
     end

--- a/config/locales/legal.en.yml
+++ b/config/locales/legal.en.yml
@@ -54,7 +54,8 @@ en:
         (IDs, names, types, colours, positions) and their permission overwrites —
         which can reference member Discord IDs — mirrored from Discord so the dashboard
         can display and apply your setup. Also which plugins are enabled, and the
-        welcome, logging and role-menu settings admins configure.'
+        welcome, logging, role-menu and moderation settings admins configure — including
+        any custom scam-keyword list.'
       data_h: What we store and why
       data_lead: 'We store only what the enabled features need:'
       data_notifications: 'Dashboard notifications: short activity entries (an event

--- a/db/migrate/20260708135120_create_moderation_settings.rb
+++ b/db/migrate/20260708135120_create_moderation_settings.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateModerationSettings < ActiveRecord::Migration[8.1]
+  def change
+    create_table :moderation_settings, id: false do |t|
+      t.string :id, null: false, primary_key: true
+      t.references :server_configuration, null: false, foreign_key: true, type: :string, index: {unique: true}
+      t.bigint :staff_role_id
+      t.timestamps
+    end
+
+    reversible do |dir|
+      dir.up { execute "ALTER TABLE moderation_settings ALTER COLUMN id SET DEFAULT ('mds_' || gen_random_uuid())" }
+    end
+  end
+end

--- a/db/migrate/20260708135125_create_spam_protection_settings.rb
+++ b/db/migrate/20260708135125_create_spam_protection_settings.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class CreateSpamProtectionSettings < ActiveRecord::Migration[8.1]
+  def change
+    create_table :spam_protection_settings, id: false do |t|
+      t.string :id, null: false, primary_key: true
+      t.references :server_configuration, null: false, foreign_key: true, type: :string, index: {unique: true}
+      t.integer :channel_threshold, null: false, default: 4
+      t.integer :window_seconds, null: false, default: 15
+      t.float :similarity, null: false, default: 1.0
+      t.boolean :match_symbol_only_messages, null: false, default: false
+      t.string :action, null: false, default: "purge"
+      t.string :punishment, null: false, default: "none"
+      t.integer :timeout_seconds, null: false, default: 3600
+      t.timestamps
+    end
+
+    add_check_constraint :spam_protection_settings, "channel_threshold >= 2 AND channel_threshold <= 500", name: "spam_protection_settings_channel_threshold_check"
+    add_check_constraint :spam_protection_settings, "window_seconds >= 1 AND window_seconds <= 60", name: "spam_protection_settings_window_seconds_check"
+    add_check_constraint :spam_protection_settings, "similarity >= 0.75 AND similarity <= 1.0", name: "spam_protection_settings_similarity_check"
+    add_check_constraint :spam_protection_settings, "action IN ('purge', 'notify_only')", name: "spam_protection_settings_action_check"
+    add_check_constraint :spam_protection_settings, "punishment IN ('none', 'timeout', 'kick', 'ban')", name: "spam_protection_settings_punishment_check"
+    add_check_constraint :spam_protection_settings, "timeout_seconds >= 60 AND timeout_seconds <= 2419200", name: "spam_protection_settings_timeout_seconds_check"
+
+    reversible do |dir|
+      dir.up { execute "ALTER TABLE spam_protection_settings ALTER COLUMN id SET DEFAULT ('sps_' || gen_random_uuid())" }
+    end
+  end
+end

--- a/db/migrate/20260708135128_create_image_scanning_settings.rb
+++ b/db/migrate/20260708135128_create_image_scanning_settings.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class CreateImageScanningSettings < ActiveRecord::Migration[8.1]
+  def change
+    create_table :image_scanning_settings, id: false do |t|
+      t.string :id, null: false, primary_key: true
+      t.references :server_configuration, null: false, foreign_key: true, type: :string, index: {unique: true}
+      t.string :sensitivity, null: false, default: "standard"
+      t.string :action, null: false, default: "delete"
+      t.string :punishment, null: false, default: "none"
+      t.integer :timeout_seconds, null: false, default: 3600
+      t.text :custom_keywords, array: true, null: false, default: []
+      t.integer :custom_keyword_min_hits, null: false, default: 2
+      t.timestamps
+    end
+
+    add_check_constraint :image_scanning_settings, "sensitivity IN ('relaxed', 'standard', 'strict')", name: "image_scanning_settings_sensitivity_check"
+    add_check_constraint :image_scanning_settings, "action IN ('none', 'delete')", name: "image_scanning_settings_action_check"
+    add_check_constraint :image_scanning_settings, "punishment IN ('none', 'timeout', 'kick', 'ban')", name: "image_scanning_settings_punishment_check"
+    add_check_constraint :image_scanning_settings, "timeout_seconds >= 60 AND timeout_seconds <= 2419200", name: "image_scanning_settings_timeout_seconds_check"
+    add_check_constraint :image_scanning_settings, "cardinality(custom_keywords) <= 200", name: "image_scanning_settings_custom_keywords_count_check"
+    add_check_constraint :image_scanning_settings, "custom_keyword_min_hits >= 1 AND (cardinality(custom_keywords) = 0 OR custom_keyword_min_hits <= cardinality(custom_keywords))", name: "image_scanning_settings_min_hits_check"
+
+    reversible do |dir|
+      dir.up { execute "ALTER TABLE image_scanning_settings ALTER COLUMN id SET DEFAULT ('iss_' || gen_random_uuid())" }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_04_155534) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_08_135128) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -45,6 +45,25 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_04_155534) do
     t.check_constraint "target_type::text = ANY (ARRAY['role'::character varying::text, 'member'::character varying::text])", name: "channel_overwrites_target_type_check"
   end
 
+  create_table "image_scanning_settings", id: :string, default: -> { "('iss_'::text || gen_random_uuid())" }, force: :cascade do |t|
+    t.string "action", default: "delete", null: false
+    t.datetime "created_at", null: false
+    t.integer "custom_keyword_min_hits", default: 2, null: false
+    t.text "custom_keywords", default: [], null: false, array: true
+    t.string "punishment", default: "none", null: false
+    t.string "sensitivity", default: "standard", null: false
+    t.string "server_configuration_id", null: false
+    t.integer "timeout_seconds", default: 3600, null: false
+    t.datetime "updated_at", null: false
+    t.index ["server_configuration_id"], name: "index_image_scanning_settings_on_server_configuration_id", unique: true
+    t.check_constraint "action::text = ANY (ARRAY['none'::character varying, 'delete'::character varying]::text[])", name: "image_scanning_settings_action_check"
+    t.check_constraint "cardinality(custom_keywords) <= 200", name: "image_scanning_settings_custom_keywords_count_check"
+    t.check_constraint "custom_keyword_min_hits >= 1 AND (cardinality(custom_keywords) = 0 OR custom_keyword_min_hits <= cardinality(custom_keywords))", name: "image_scanning_settings_min_hits_check"
+    t.check_constraint "punishment::text = ANY (ARRAY['none'::character varying, 'timeout'::character varying, 'kick'::character varying, 'ban'::character varying]::text[])", name: "image_scanning_settings_punishment_check"
+    t.check_constraint "sensitivity::text = ANY (ARRAY['relaxed'::character varying, 'standard'::character varying, 'strict'::character varying]::text[])", name: "image_scanning_settings_sensitivity_check"
+    t.check_constraint "timeout_seconds >= 60 AND timeout_seconds <= 2419200", name: "image_scanning_settings_timeout_seconds_check"
+  end
+
   create_table "logging_settings", id: :string, default: -> { "('lgs_'::text || gen_random_uuid())" }, force: :cascade do |t|
     t.bigint "channel_id"
     t.datetime "created_at", null: false
@@ -52,6 +71,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_04_155534) do
     t.string "server_configuration_id", null: false
     t.datetime "updated_at", null: false
     t.index ["server_configuration_id"], name: "index_logging_settings_on_server_configuration_id", unique: true
+  end
+
+  create_table "moderation_settings", id: :string, default: -> { "('mds_'::text || gen_random_uuid())" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "server_configuration_id", null: false
+    t.bigint "staff_role_id"
+    t.datetime "updated_at", null: false
+    t.index ["server_configuration_id"], name: "index_moderation_settings_on_server_configuration_id", unique: true
   end
 
   create_table "notifications", id: :string, default: -> { "('ntf_'::text || gen_random_uuid())" }, force: :cascade do |t|
@@ -276,6 +303,26 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_04_155534) do
     t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
   end
 
+  create_table "spam_protection_settings", id: :string, default: -> { "('sps_'::text || gen_random_uuid())" }, force: :cascade do |t|
+    t.string "action", default: "purge", null: false
+    t.integer "channel_threshold", default: 4, null: false
+    t.datetime "created_at", null: false
+    t.boolean "match_symbol_only_messages", default: false, null: false
+    t.string "punishment", default: "none", null: false
+    t.string "server_configuration_id", null: false
+    t.float "similarity", default: 1.0, null: false
+    t.integer "timeout_seconds", default: 3600, null: false
+    t.datetime "updated_at", null: false
+    t.integer "window_seconds", default: 15, null: false
+    t.index ["server_configuration_id"], name: "index_spam_protection_settings_on_server_configuration_id", unique: true
+    t.check_constraint "action::text = ANY (ARRAY['purge'::character varying, 'notify_only'::character varying]::text[])", name: "spam_protection_settings_action_check"
+    t.check_constraint "channel_threshold >= 2 AND channel_threshold <= 500", name: "spam_protection_settings_channel_threshold_check"
+    t.check_constraint "punishment::text = ANY (ARRAY['none'::character varying, 'timeout'::character varying, 'kick'::character varying, 'ban'::character varying]::text[])", name: "spam_protection_settings_punishment_check"
+    t.check_constraint "similarity >= 0.75::double precision AND similarity <= 1.0::double precision", name: "spam_protection_settings_similarity_check"
+    t.check_constraint "timeout_seconds >= 60 AND timeout_seconds <= 2419200", name: "spam_protection_settings_timeout_seconds_check"
+    t.check_constraint "window_seconds >= 1 AND window_seconds <= 60", name: "spam_protection_settings_window_seconds_check"
+  end
+
   create_table "users", id: :string, default: -> { "('usr_'::text || gen_random_uuid())" }, force: :cascade do |t|
     t.string "avatar"
     t.datetime "created_at", null: false
@@ -298,7 +345,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_04_155534) do
 
   add_foreign_key "assignable_roles", "role_sets"
   add_foreign_key "channel_overwrites", "server_channels"
+  add_foreign_key "image_scanning_settings", "server_configurations"
   add_foreign_key "logging_settings", "server_configurations"
+  add_foreign_key "moderation_settings", "server_configurations"
   add_foreign_key "notifications", "server_configurations"
   add_foreign_key "plugin_activations", "plugins"
   add_foreign_key "plugin_activations", "server_configurations"
@@ -312,5 +361,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_04_155534) do
   add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "spam_protection_settings", "server_configurations"
   add_foreign_key "welcome_settings", "server_configurations"
 end

--- a/docs/adding-a-plugin.md
+++ b/docs/adding-a-plugin.md
@@ -68,6 +68,12 @@ A `channel_setting` makes the plugin **channel-backed**: it can't be enabled unt
 channel is set. `TogglePlugin` enforces this and a `PluginActivation` validation
 backstops it. `key` is read back as a symbol; branch on `:welcomes` in code.
 
+`requires_plugin:` names another plugin that must be enabled first (a hard dependency).
+`parent:` marks the plugin as a member of a plugin group; the parent must be enabled
+before a child can enable. Both are folded into `prerequisites_met?` and backstopped by
+the `PluginActivation` validation. Example: the moderation group's sub-plugins set
+`parent: :moderation`, and `:moderation` sets `requires_plugin: :logging`.
+
 ## 4. Writes go through operations
 
 All settings writes and runtime mutations are operations under

--- a/spec/factories/image_scanning_settings.rb
+++ b/spec/factories/image_scanning_settings.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :image_scanning_settings, class: "Moderation::ImageScanning::Settings" do
+    association :server_configuration
+  end
+end

--- a/spec/factories/moderation_settings.rb
+++ b/spec/factories/moderation_settings.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :moderation_settings, class: "Moderation::Settings" do
+    association :server_configuration
+  end
+end

--- a/spec/factories/spam_protection_settings.rb
+++ b/spec/factories/spam_protection_settings.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :spam_protection_settings, class: "Moderation::SpamProtection::Settings" do
+    association :server_configuration
+  end
+end

--- a/spec/models/plugin_catalog_spec.rb
+++ b/spec/models/plugin_catalog_spec.rb
@@ -25,6 +25,20 @@ RSpec.describe PluginCatalog do
     end
   end
 
+  describe "moderation group wiring" do
+    it "spam_protection has parent :moderation" do
+      expect(described_class.find(:spam_protection).parent).to eq(:moderation)
+    end
+
+    it "image_scanning has parent :moderation" do
+      expect(described_class.find(:image_scanning).parent).to eq(:moderation)
+    end
+
+    it "moderation requires_plugin :logging" do
+      expect(described_class.find(:moderation).requires_plugin).to eq(:logging)
+    end
+  end
+
   describe PluginCatalog::Definition do
     def definition(channel_setting:)
       described_class.new(key: :x, name: "X", description: "", channel_setting:)
@@ -47,6 +61,56 @@ RSpec.describe PluginCatalog do
 
       context "with a channel" do
         let(:config) { double(logging_setting: double(channel_id: 5)) }
+
+        it { is_expected.to be(true) }
+      end
+    end
+
+    context "when requiring another plugin (requires_plugin: :logging)" do
+      def requiring_definition
+        described_class.new(key: :x, name: "X", description: "", requires_plugin: :logging)
+      end
+
+      subject(:check) { requiring_definition.prerequisites_met?(config) }
+
+      context "when required plugin is not enabled" do
+        let(:config) { double(plugins: double(enabled: double(exists?: false))) }
+
+        it { is_expected.to be(false) }
+      end
+
+      context "when required plugin is enabled" do
+        let(:enabled_scope) do
+          scope = double
+          allow(scope).to receive(:exists?).with(key: :logging).and_return(true)
+          scope
+        end
+        let(:config) { double(plugins: double(enabled: enabled_scope)) }
+
+        it { is_expected.to be(true) }
+      end
+    end
+
+    context "when a group member (parent: :moderation)" do
+      def child_definition
+        described_class.new(key: :x, name: "X", description: "", parent: :moderation)
+      end
+
+      subject(:check) { child_definition.prerequisites_met?(config) }
+
+      context "when parent plugin is not enabled" do
+        let(:config) { double(plugins: double(enabled: double(exists?: false))) }
+
+        it { is_expected.to be(false) }
+      end
+
+      context "when parent plugin is enabled" do
+        let(:enabled_scope) do
+          scope = double
+          allow(scope).to receive(:exists?).with(key: :moderation).and_return(true)
+          scope
+        end
+        let(:config) { double(plugins: double(enabled: enabled_scope)) }
 
         it { is_expected.to be(true) }
       end

--- a/spec/operations/logging/configure_spec.rb
+++ b/spec/operations/logging/configure_spec.rb
@@ -49,4 +49,39 @@ RSpec.describe Ops::Logging::Configure do
       expect(config.plugin_activations.find_by(plugin:)&.enabled).to be_falsey
     end
   end
+
+  context "when moderation is enabled and logging would become unavailable" do
+    let!(:moderation_plugin) { create(:plugin, key: "moderation", name: "Server Shield") }
+
+    before do
+      config.logging_setting.update!(channel_id: 200)
+      create(:plugin_activation, server_configuration: config, plugin:, enabled: true)
+      create(:plugin_activation, server_configuration: config, plugin: moderation_plugin, enabled: true)
+    end
+
+    context "when disabling logging" do
+      let(:enabled) { "0" }
+      let(:channel_id) { 200 }
+
+      it "fails with an error on enabled" do
+        expect(result).to be_failure
+        expect(result.value.errors[:enabled]).to be_present
+      end
+
+      it "leaves logging enabled" do
+        result
+        expect(config.plugin_activations.find_by(plugin:).enabled).to be(true)
+      end
+    end
+
+    context "when clearing the logging channel while keeping enabled" do
+      let(:enabled) { "1" }
+      let(:channel_id) { "" }
+
+      it "fails with an error on enabled" do
+        expect(result).to be_failure
+        expect(result.value.errors[:enabled]).to be_present
+      end
+    end
+  end
 end

--- a/spec/operations/moderation/configure_spec.rb
+++ b/spec/operations/moderation/configure_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Ops::Moderation::Configure do
+  subject(:result) do
+    described_class.call(
+      server_configuration: config,
+      staff_role_id:,
+      enabled:
+    )
+  end
+
+  let(:config) { create(:server_configuration) }
+  let!(:plugin) { create(:plugin, key: "moderation", name: "Server Shield") }
+  let!(:settings) { config.create_moderation_settings! }
+  let(:staff_role_id) { 111_222_333 }
+  let(:enabled) { "1" }
+
+  context "when enabling without logging ready (no logging plugin enabled)" do
+    it "fails with an error on the enabled field" do
+      expect(result).to be_failure
+      expect(result.value.errors[:enabled]).to be_present
+    end
+
+    it "persists no activation" do
+      result
+      expect(config.plugin_activations.reload).to be_empty
+    end
+  end
+
+  context "when enabling with logging plugin enabled but no channel set" do
+    let!(:logging_plugin) { create(:plugin, key: "logging", name: "Logging") }
+
+    before do
+      config.create_logging_setting!(channel_id: nil)
+      create(:plugin_activation, server_configuration: config, plugin: logging_plugin, enabled: false).update_column(:enabled, true)
+    end
+
+    it "fails with an error on the enabled field" do
+      expect(result).to be_failure
+      expect(result.value.errors[:enabled]).to be_present
+    end
+  end
+
+  context "when enabling with logging plugin enabled but no logging setting record" do
+    let!(:logging_plugin) { create(:plugin, key: "logging", name: "Logging") }
+
+    before do
+      create(:plugin_activation, server_configuration: config, plugin: logging_plugin, enabled: false).update_column(:enabled, true)
+    end
+
+    it "fails with an error on the enabled field" do
+      expect(result).to be_failure
+      expect(result.value.errors[:enabled]).to be_present
+    end
+  end
+
+  context "when enabling with logging ready" do
+    let!(:logging_plugin) { create(:plugin, key: "logging", name: "Logging") }
+
+    before do
+      config.create_logging_setting!(channel_id: 999)
+      create(:plugin_activation, server_configuration: config, plugin: logging_plugin, enabled: true)
+    end
+
+    it "succeeds" do
+      expect(result).to be_success
+    end
+
+    it "saves the staff_role_id" do
+      result
+      expect(config.moderation_settings.reload.staff_role_id).to eq(111_222_333)
+    end
+
+    it "enables the moderation activation" do
+      result
+      expect(config.plugin_activations.find_by(plugin:).enabled).to be(true)
+    end
+  end
+
+  context "when saving staff_role_id without enabling (enabled 0)" do
+    let(:enabled) { "0" }
+
+    it "succeeds" do
+      expect(result).to be_success
+    end
+
+    it "saves the staff_role_id" do
+      result
+      expect(config.moderation_settings.reload.staff_role_id).to eq(111_222_333)
+    end
+
+    it "does not enable the activation" do
+      result
+      expect(config.plugin_activations.find_by(plugin:)&.enabled).to be_falsey
+    end
+  end
+end

--- a/spec/operations/moderation/image_scanning/configure_spec.rb
+++ b/spec/operations/moderation/image_scanning/configure_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Ops::Moderation::ImageScanning::Configure do
+  subject(:result) do
+    described_class.call(
+      server_configuration: config,
+      sensitivity:,
+      action:,
+      punishment:,
+      timeout_seconds:,
+      custom_keywords:,
+      custom_keyword_min_hits:,
+      enabled:
+    )
+  end
+
+  let(:config) { create(:server_configuration) }
+  let!(:plugin) { create(:plugin, key: "image_scanning", name: "Scam Image Detection") }
+  let!(:settings) { config.create_image_scanning_settings! }
+  let(:sensitivity) { "standard" }
+  let(:action) { "delete" }
+  let(:punishment) { "none" }
+  let(:timeout_seconds) { 3600 }
+  let(:custom_keywords) { [] }
+  let(:custom_keyword_min_hits) { 2 }
+  let(:enabled) { "1" }
+
+  def setup_moderation_group_enabled
+    logging_plugin = create(:plugin, key: "logging", name: "Logging")
+    moderation_plugin = create(:plugin, key: "moderation", name: "Server Shield")
+    config.create_logging_setting!(channel_id: 999)
+    config.create_moderation_settings!.tap { |s| s.update!(staff_role_id: 777_888_999) }
+    create(:plugin_activation, server_configuration: config, plugin: logging_plugin, enabled: true)
+    create(:plugin_activation, server_configuration: config, plugin: moderation_plugin, enabled: true)
+  end
+
+  context "when moderation group is enabled and staff_role_id is set (happy path)" do
+    let(:custom_keywords) { %w[free nitro click here] }
+    let(:custom_keyword_min_hits) { 2 }
+
+    before { setup_moderation_group_enabled }
+
+    it "succeeds" do
+      expect(result).to be_success
+    end
+
+    it "saves the settings including custom_keywords" do
+      result
+      reloaded = config.image_scanning_settings.reload
+      expect(reloaded.sensitivity).to eq("standard")
+      expect(reloaded.custom_keywords).to eq(%w[free nitro click here])
+    end
+
+    it "enables the image_scanning activation" do
+      result
+      expect(config.plugin_activations.find_by(plugin:).enabled).to be(true)
+    end
+  end
+
+  context "when enabling while staff_role_id is blank" do
+    before do
+      logging_plugin = create(:plugin, key: "logging", name: "Logging")
+      moderation_plugin = create(:plugin, key: "moderation", name: "Server Shield")
+      config.create_logging_setting!(channel_id: 999)
+      config.create_moderation_settings!
+      create(:plugin_activation, server_configuration: config, plugin: logging_plugin, enabled: true)
+      create(:plugin_activation, server_configuration: config, plugin: moderation_plugin, enabled: true)
+    end
+
+    it "fails" do
+      expect(result).to be_failure
+    end
+
+    it "reports an error on enabled" do
+      expect(result.value.errors[:enabled]).to be_present
+    end
+
+    it "persists nothing for image_scanning" do
+      result
+      expect(config.plugin_activations.find_by(plugin:)).to be_nil
+    end
+  end
+
+  context "when sensitivity is invalid with enabled 0" do
+    let(:sensitivity) { "medium" }
+    let(:enabled) { "0" }
+
+    it "fails via settings validation" do
+      expect(result).to be_failure
+    end
+  end
+
+  context "when custom_keyword_min_hits exceeds keyword count" do
+    let(:custom_keywords) { %w[scam] }
+    let(:custom_keyword_min_hits) { 3 }
+    let(:enabled) { "0" }
+
+    it "fails via settings validation" do
+      expect(result).to be_failure
+    end
+  end
+
+  context "when saving settings without enabling" do
+    let(:enabled) { "0" }
+    let(:custom_keywords) { %w[scam free] }
+
+    before { setup_moderation_group_enabled }
+
+    it "succeeds" do
+      expect(result).to be_success
+    end
+
+    it "saves the custom_keywords round-trip" do
+      result
+      expect(config.image_scanning_settings.reload.custom_keywords).to eq(%w[scam free])
+    end
+
+    it "does not enable the activation" do
+      result
+      expect(config.plugin_activations.find_by(plugin:)&.enabled).to be_falsey
+    end
+  end
+end

--- a/spec/operations/moderation/spam_protection/configure_spec.rb
+++ b/spec/operations/moderation/spam_protection/configure_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Ops::Moderation::SpamProtection::Configure do
+  subject(:result) do
+    described_class.call(
+      server_configuration: config,
+      channel_threshold:,
+      window_seconds:,
+      similarity:,
+      match_symbol_only_messages:,
+      action:,
+      punishment:,
+      timeout_seconds:,
+      enabled:
+    )
+  end
+
+  let(:config) { create(:server_configuration) }
+  let!(:plugin) { create(:plugin, key: "spam_protection", name: "Cross-Channel Spam Guard") }
+  let!(:settings) { config.create_spam_protection_settings! }
+  let(:channel_threshold) { 4 }
+  let(:window_seconds) { 15 }
+  let(:similarity) { 1.0 }
+  let(:match_symbol_only_messages) { false }
+  let(:action) { "purge" }
+  let(:punishment) { "none" }
+  let(:timeout_seconds) { 3600 }
+  let(:enabled) { "1" }
+
+  def setup_moderation_group_enabled
+    logging_plugin = create(:plugin, key: "logging", name: "Logging")
+    moderation_plugin = create(:plugin, key: "moderation", name: "Server Shield")
+    config.create_logging_setting!(channel_id: 999)
+    config.create_moderation_settings!.tap { |s| s.update!(staff_role_id: 777_888_999) }
+    create(:plugin_activation, server_configuration: config, plugin: logging_plugin, enabled: true)
+    create(:plugin_activation, server_configuration: config, plugin: moderation_plugin, enabled: true)
+  end
+
+  context "when moderation group is enabled and staff_role_id is set (happy path)" do
+    before { setup_moderation_group_enabled }
+
+    it "succeeds" do
+      expect(result).to be_success
+    end
+
+    it "saves the settings" do
+      result
+      expect(config.spam_protection_settings.reload.channel_threshold).to eq(4)
+    end
+
+    it "enables the spam_protection activation" do
+      result
+      expect(config.plugin_activations.find_by(plugin:).enabled).to be(true)
+    end
+  end
+
+  context "when enabling while staff_role_id is blank" do
+    before do
+      logging_plugin = create(:plugin, key: "logging", name: "Logging")
+      moderation_plugin = create(:plugin, key: "moderation", name: "Server Shield")
+      config.create_logging_setting!(channel_id: 999)
+      config.create_moderation_settings!
+      create(:plugin_activation, server_configuration: config, plugin: logging_plugin, enabled: true)
+      create(:plugin_activation, server_configuration: config, plugin: moderation_plugin, enabled: true)
+    end
+
+    it "fails" do
+      expect(result).to be_failure
+    end
+
+    it "reports an error on enabled" do
+      expect(result.value.errors[:enabled]).to be_present
+    end
+
+    it "persists nothing for spam_protection" do
+      result
+      expect(config.plugin_activations.find_by(plugin:)).to be_nil
+    end
+  end
+
+  context "when channel_threshold is invalid (1) with enabled 0" do
+    let(:channel_threshold) { 1 }
+    let(:enabled) { "0" }
+
+    it "fails via settings validation" do
+      expect(result).to be_failure
+    end
+  end
+
+  context "when saving settings without enabling" do
+    let(:enabled) { "0" }
+
+    before { setup_moderation_group_enabled }
+
+    it "succeeds" do
+      expect(result).to be_success
+    end
+
+    it "does not enable the activation" do
+      result
+      expect(config.plugin_activations.find_by(plugin:)&.enabled).to be_falsey
+    end
+  end
+
+  context "when enabling with no moderation settings record at all" do
+    it "fails the staff-role guard" do
+      expect(result).to be_failure
+      expect(result.value.errors[:enabled]).to be_present
+    end
+  end
+end

--- a/spec/operations/server_configuration/ensure_spec.rb
+++ b/spec/operations/server_configuration/ensure_spec.rb
@@ -26,6 +26,9 @@ RSpec.describe Ops::ServerConfiguration::Ensure do
     expect(config.logging_setting).to be_present
     expect(config.role_setting).to be_present
     expect(config.welcome_settings).to be_present
+    expect(config.moderation_settings).to be_present
+    expect(config.spam_protection_settings).to be_present
+    expect(config.image_scanning_settings).to be_present
   end
 
   context "when a concurrent insert wins the race" do

--- a/spec/plugins/moderation/image_scanning/settings_spec.rb
+++ b/spec/plugins/moderation/image_scanning/settings_spec.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Moderation::ImageScanning::Settings do
+  subject(:settings) { build(:image_scanning_settings) }
+
+  it "is valid from the factory" do
+    expect(settings).to be_valid
+  end
+
+  describe "sensitivity" do
+    it "is invalid for an unrecognised value" do
+      settings.sensitivity = "medium"
+      expect(settings).not_to be_valid
+    end
+
+    %w[relaxed standard strict].each do |value|
+      it "is valid for #{value}" do
+        settings.sensitivity = value
+        expect(settings).to be_valid
+      end
+    end
+  end
+
+  describe "action" do
+    it "is invalid for an unrecognised value" do
+      settings.action = "purge"
+      expect(settings).not_to be_valid
+    end
+
+    %w[none delete].each do |value|
+      it "is valid for #{value}" do
+        settings.action = value
+        expect(settings).to be_valid
+      end
+    end
+  end
+
+  describe "punishment (via Punishable)" do
+    it "is invalid for an unrecognised value" do
+      settings.punishment = "mute"
+      expect(settings).not_to be_valid
+    end
+
+    %w[none timeout kick ban].each do |punishment|
+      it "is valid for #{punishment}" do
+        settings.punishment = punishment
+        expect(settings).to be_valid
+      end
+    end
+  end
+
+  describe "timeout_seconds" do
+    it "is invalid at 59" do
+      settings.timeout_seconds = 59
+      expect(settings).not_to be_valid
+    end
+
+    it "is invalid at 2_419_201" do
+      settings.timeout_seconds = 2_419_201
+      expect(settings).not_to be_valid
+    end
+  end
+
+  describe "custom_keywords" do
+    it "is valid when empty" do
+      settings.custom_keywords = []
+      expect(settings).to be_valid
+    end
+
+    it "is valid with entries" do
+      settings.custom_keywords = %w[scam giveaway]
+      expect(settings).to be_valid
+    end
+
+    it "is invalid with a blank entry" do
+      settings.custom_keywords = ["scam", "  ", "giveaway"]
+      expect(settings).not_to be_valid
+      expect(settings.errors[:custom_keywords]).to be_present
+    end
+
+    it "is invalid with a whitespace-only entry" do
+      settings.custom_keywords = [""]
+      expect(settings).not_to be_valid
+    end
+
+    it "is invalid with 201 entries" do
+      settings.custom_keywords = Array.new(201) { |i| "k#{i}" }
+      expect(settings).not_to be_valid
+      expect(settings.errors[:custom_keywords]).to be_present
+    end
+  end
+
+  describe "custom_keyword_min_hits" do
+    it "is invalid at 0" do
+      settings.custom_keywords = %w[a b]
+      settings.custom_keyword_min_hits = 0
+      expect(settings).not_to be_valid
+    end
+
+    it "is invalid when greater than keyword count" do
+      settings.custom_keywords = %w[a b]
+      settings.custom_keyword_min_hits = 3
+      expect(settings).not_to be_valid
+      expect(settings.errors[:custom_keyword_min_hits]).to be_present
+    end
+
+    it "is valid when equal to keyword count" do
+      settings.custom_keywords = %w[a b]
+      settings.custom_keyword_min_hits = 2
+      expect(settings).to be_valid
+    end
+
+    it "is valid at any value >= 1 when keywords are empty" do
+      settings.custom_keywords = []
+      settings.custom_keyword_min_hits = 5
+      expect(settings).to be_valid
+    end
+  end
+
+  describe ".active_for" do
+    subject(:active_setting) { described_class.active_for(discord_id) }
+
+    let(:server) { create(:server_configuration, discord_id: 456) }
+    let!(:scan_settings) { create(:image_scanning_settings, server_configuration: server) }
+    let(:discord_id) { 456 }
+
+    context "when no server configuration exists" do
+      let(:discord_id) { 999 }
+
+      it "returns nil" do
+        expect(active_setting).to be_nil
+      end
+    end
+
+    context "when only moderation is enabled" do
+      let!(:logging_plugin) { create(:plugin, key: "logging", name: "Logging") }
+      let!(:moderation_plugin) { create(:plugin, key: "moderation", name: "Server Shield") }
+
+      before do
+        server.create_logging_setting!(channel_id: 999)
+        create(:plugin_activation, server_configuration: server, plugin: logging_plugin, enabled: true)
+        create(:plugin_activation, server_configuration: server, plugin: moderation_plugin, enabled: true)
+      end
+
+      it "returns nil" do
+        expect(active_setting).to be_nil
+      end
+    end
+
+    context "when only image_scanning is enabled (moderation not enabled)" do
+      let!(:moderation_plugin) { create(:plugin, key: "moderation", name: "Server Shield") }
+      let!(:scan_plugin) { create(:plugin, key: "image_scanning", name: "Scam Image Detection") }
+
+      before do
+        create(:plugin_activation, server_configuration: server, plugin: moderation_plugin, enabled: false)
+        create(:plugin_activation, server_configuration: server, plugin: scan_plugin, enabled: false).update_column(:enabled, true)
+      end
+
+      it "returns nil" do
+        expect(active_setting).to be_nil
+      end
+    end
+
+    context "when both moderation and image_scanning are enabled" do
+      let!(:logging_plugin) { create(:plugin, key: "logging", name: "Logging") }
+      let!(:moderation_plugin) { create(:plugin, key: "moderation", name: "Server Shield") }
+      let!(:scan_plugin) { create(:plugin, key: "image_scanning", name: "Scam Image Detection") }
+
+      before do
+        server.create_logging_setting!(channel_id: 999)
+        create(:plugin_activation, server_configuration: server, plugin: logging_plugin, enabled: true)
+        create(:plugin_activation, server_configuration: server, plugin: moderation_plugin, enabled: true)
+        create(:plugin_activation, server_configuration: server, plugin: scan_plugin, enabled: true)
+      end
+
+      it "returns the image scanning settings" do
+        expect(active_setting).to eq(scan_settings)
+      end
+    end
+  end
+end

--- a/spec/plugins/moderation/settings_spec.rb
+++ b/spec/plugins/moderation/settings_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Moderation::Settings do
+  subject(:settings) { build(:moderation_settings) }
+
+  it "belongs to a server configuration" do
+    expect(settings.server_configuration).to be_present
+  end
+
+  it "uses the correct table name" do
+    expect(described_class.table_name).to eq("moderation_settings")
+  end
+
+  it "persists via the factory" do
+    expect { create(:moderation_settings) }.to change(described_class, :count).by(1)
+  end
+end

--- a/spec/plugins/moderation/spam_protection/settings_spec.rb
+++ b/spec/plugins/moderation/spam_protection/settings_spec.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Moderation::SpamProtection::Settings do
+  subject(:settings) { build(:spam_protection_settings) }
+
+  it "is valid from the factory" do
+    expect(settings).to be_valid
+  end
+
+  describe "channel_threshold" do
+    it "is invalid at 1" do
+      settings.channel_threshold = 1
+      expect(settings).not_to be_valid
+    end
+
+    it "is invalid at 501" do
+      settings.channel_threshold = 501
+      expect(settings).not_to be_valid
+    end
+
+    it "is valid at 2" do
+      settings.channel_threshold = 2
+      expect(settings).to be_valid
+    end
+
+    it "is valid at 500" do
+      settings.channel_threshold = 500
+      expect(settings).to be_valid
+    end
+  end
+
+  describe "window_seconds" do
+    it "is invalid at 0" do
+      settings.window_seconds = 0
+      expect(settings).not_to be_valid
+    end
+
+    it "is invalid at 61" do
+      settings.window_seconds = 61
+      expect(settings).not_to be_valid
+    end
+
+    it "is valid at 60" do
+      settings.window_seconds = 60
+      expect(settings).to be_valid
+    end
+  end
+
+  describe "similarity" do
+    it "is invalid at 0.74" do
+      settings.similarity = 0.74
+      expect(settings).not_to be_valid
+    end
+
+    it "is invalid at 1.01" do
+      settings.similarity = 1.01
+      expect(settings).not_to be_valid
+    end
+
+    it "is valid at 0.75" do
+      settings.similarity = 0.75
+      expect(settings).to be_valid
+    end
+
+    it "is valid at 1.0" do
+      settings.similarity = 1.0
+      expect(settings).to be_valid
+    end
+  end
+
+  describe "action" do
+    it "is invalid for an unrecognised value" do
+      settings.action = "delete"
+      expect(settings).not_to be_valid
+    end
+
+    it "is valid for purge" do
+      settings.action = "purge"
+      expect(settings).to be_valid
+    end
+
+    it "is valid for notify_only" do
+      settings.action = "notify_only"
+      expect(settings).to be_valid
+    end
+  end
+
+  describe "punishment (via Punishable)" do
+    it "is invalid for an unrecognised value" do
+      settings.punishment = "mute"
+      expect(settings).not_to be_valid
+    end
+
+    %w[none timeout kick ban].each do |punishment|
+      it "is valid for #{punishment}" do
+        settings.punishment = punishment
+        expect(settings).to be_valid
+      end
+    end
+  end
+
+  describe "timeout_seconds" do
+    it "is invalid at 59" do
+      settings.timeout_seconds = 59
+      expect(settings).not_to be_valid
+    end
+
+    it "is invalid at 2_419_201" do
+      settings.timeout_seconds = 2_419_201
+      expect(settings).not_to be_valid
+    end
+  end
+
+  describe ".active_for" do
+    subject(:active_setting) { described_class.active_for(discord_id) }
+
+    let(:server) { create(:server_configuration, discord_id: 123) }
+    let!(:spam_settings) { create(:spam_protection_settings, server_configuration: server) }
+    let(:discord_id) { 123 }
+
+    context "when no server configuration exists" do
+      let(:discord_id) { 999 }
+
+      it "returns nil" do
+        expect(active_setting).to be_nil
+      end
+    end
+
+    context "when only moderation is enabled" do
+      let!(:logging_plugin) { create(:plugin, key: "logging", name: "Logging") }
+      let!(:moderation_plugin) { create(:plugin, key: "moderation", name: "Server Shield") }
+
+      before do
+        server.create_logging_setting!(channel_id: 999)
+        create(:plugin_activation, server_configuration: server, plugin: logging_plugin, enabled: true)
+        create(:plugin_activation, server_configuration: server, plugin: moderation_plugin, enabled: true)
+      end
+
+      it "returns nil" do
+        expect(active_setting).to be_nil
+      end
+    end
+
+    context "when only spam_protection is enabled (moderation not enabled)" do
+      let!(:moderation_plugin) { create(:plugin, key: "moderation", name: "Server Shield") }
+      let!(:spam_plugin) { create(:plugin, key: "spam_protection", name: "Cross-Channel Spam Guard") }
+
+      before do
+        create(:plugin_activation, server_configuration: server, plugin: moderation_plugin, enabled: false)
+        create(:plugin_activation, server_configuration: server, plugin: spam_plugin, enabled: false).update_column(:enabled, true)
+      end
+
+      it "returns nil" do
+        expect(active_setting).to be_nil
+      end
+    end
+
+    context "when both moderation and spam_protection are enabled" do
+      let!(:logging_plugin) { create(:plugin, key: "logging", name: "Logging") }
+      let!(:moderation_plugin) { create(:plugin, key: "moderation", name: "Server Shield") }
+      let!(:spam_plugin) { create(:plugin, key: "spam_protection", name: "Cross-Channel Spam Guard") }
+
+      before do
+        server.create_logging_setting!(channel_id: 999)
+        create(:plugin_activation, server_configuration: server, plugin: logging_plugin, enabled: true)
+        create(:plugin_activation, server_configuration: server, plugin: moderation_plugin, enabled: true)
+        create(:plugin_activation, server_configuration: server, plugin: spam_plugin, enabled: true)
+      end
+
+      it "returns the spam protection settings" do
+        expect(active_setting).to eq(spam_settings)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Server Shield — PR 1: group scaffold + settings + config ops

First chunk of the moderation suite. **Config/data layer only** — no bot behaviour, no web pages (those land in later chunks). Everything here is what the rest of the suite reads.

### What's in it
- **Three settings tables + models** (`rails g` migrations, string PKs, unique FK indexes, DB check constraints mirrored by AR validations):
  - `moderation_settings` (`Moderation::Settings`) — group-shared staff role.
  - `spam_protection_settings` (`Moderation::SpamProtection::Settings`).
  - `image_scanning_settings` (`Moderation::ImageScanning::Settings`) — incl. `custom_keywords` (≤200) + min-hits gate.
  - Shared `Moderation::Punishable` (punishment/timeout validations) and `Moderation::SubPluginSettings` (`active_for` group-enabled invariant) concerns — extracted at the second occurrence.
- **PluginCatalog** gains `requires_plugin` (hard dependency) and `parent` (group membership) members, both folded into `prerequisites_met?` and backstopped by the existing `PluginActivation` validation. Three new definitions with the final locked copy: **Server Shield**, **Cross-Channel Spam Guard**, **Scam Image Detection**.
- **Configure operations** mirroring `Ops::Welcomes::Configure`: `Ops::Moderation::Configure` (+ logging-dependency guard), `Ops::Moderation::SpamProtection::Configure`, `Ops::Moderation::ImageScanning::Configure` (both share the staff-role guard via `Ops::Moderation::SubPluginConfiguration`).
- **Logging becomes a hard dependency both ways**: `Ops::Logging::Configure` now refuses to disable logging / clear its channel while the group is enabled.
- `Ensure` creates the three new settings rows per server; the guild-purge cascade covers them via `has_one … dependent: :delete`.
- Privacy policy (`legal.en.yml` `data_guild`) extended to name moderation settings incl. the custom-keyword list; `docs/adding-a-plugin.md` documents the two new catalog members.

### Deliberate calls (flagged for review)
- **Guard/error copy is hardcoded English**, mirroring the existing `PluginActivation` guard — there is no i18n-in-ops precedent. A repo-wide lift of op error strings into locale keys is tracked as a separate follow-up.
- **Sub-plugin ops guard the staff-role prerequisite only**; group-enabled is enforced by the catalog `parent` prerequisite (defense-in-depth), not a duplicate op guard.
- **`custom_keywords` non-blank check uses plain `.strip`**, not canonicalization — the `Canonicalizer` doesn't exist until a later chunk; the canonicalization-aware check lands with it.
- **New plugins are filtered off the dashboard/sidebar** (both key off config-route availability) until their config pages exist. Without this the dashboard would `KeyError` on the missing plugin icon.

### Boyscout
- `app/views/servers/show.rb` now filters the plugin list to config-route-backed plugins, mirroring `Components::PluginSidebar`'s existing filter.

### Gates
`rspec` (1039 examples, 0 failures), `standardrb`, `active_record_doctor`, `undercover --compare origin/main`, `i18n-tasks missing` + `check-normalized` — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
