### PR TITLE
Cross-channel spam protection

### DIFF
--- a/app/bot/activity_log.rb
+++ b/app/bot/activity_log.rb
@@ -5,11 +5,11 @@ module ActivityLog
 
   module_function
 
-  def post(server_configuration, bot:, title:, body:, meta:)
+  def post(server_configuration, bot:, title:, body:, meta:, allowed_mentions: SUPPRESS_MENTIONS)
     channel_id = server_configuration.logging_setting.channel_id
     return unless channel_id
 
-    deliver(bot, channel_id, entry(title, body, meta))
+    deliver(bot, channel_id, entry(title, body, meta), allowed_mentions:)
   end
 
   def enabled?(server_configuration, action)
@@ -24,11 +24,11 @@ module ActivityLog
     )
   end
 
-  def deliver(bot, channel_id, entry)
+  def deliver(bot, channel_id, entry, allowed_mentions: SUPPRESS_MENTIONS)
     channel = bot.channel(channel_id)
     return unless channel
 
-    Discord::Components.send_to(channel, entry, allowed_mentions: SUPPRESS_MENTIONS)
+    Discord::Components.send_to(channel, entry, allowed_mentions:)
   rescue => e
     Rails.logger.warn("[ActivityLog] could not write to ##{channel_id}: #{e.class}: #{e.message}")
   end

--- a/app/plugins/moderation/canonicalizer.rb
+++ b/app/plugins/moderation/canonicalizer.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Moderation
+  module Canonicalizer
+    PUNCT_PATTERN = /[[:punct:]]/
+    DIGIT_PUNCT_PATTERN = /[[:digit:][:punct:]]/
+
+    module_function
+
+    def call(text, strip_digits: false)
+      pattern = strip_digits ? DIGIT_PUNCT_PATTERN : PUNCT_PATTERN
+
+      text.to_s
+        .unicode_normalize(:nfkc)
+        .gsub(/[​-‏⁠﻿]/, "")
+        .downcase
+        .gsub(pattern, " ")
+        .gsub(/\s+/, " ")
+        .strip
+    end
+  end
+end

--- a/app/plugins/moderation/events/spam_guard.rb
+++ b/app/plugins/moderation/events/spam_guard.rb
@@ -50,7 +50,7 @@ module Moderation
           fingerprint:,
           message_id: event.message.id,
           channel_id: event.channel.id,
-          at: Time.now,
+          at: Time.current,
           window: settings.window_seconds,
           threshold: settings.channel_threshold,
           similarity: settings.similarity
@@ -87,29 +87,22 @@ module Moderation
     end
 
     def notify(config, settings, staff_role_id, hit)
-      channel_id = config.logging_setting.channel_id
-      return unless channel_id
-
-      channel = event.bot.channel(channel_id)
-      return unless channel
-
       channels = hit.map(&:channel_id).uniq
-      title = I18n.t("moderation.spam_protection.notification.title.#{settings.action}")
-      body = I18n.t(
-        "moderation.spam_protection.notification.body",
-        author: "<@#{event.author.id}>",
-        count: channels.size,
-        channels: channels.map { |id| "<##{id}>" }.join(", ")
-      )
-      meta = I18n.t("moderation.spam_protection.notification.meta.#{settings.action}")
+      ping = staff_role_id ? "<@&#{staff_role_id}> " : ""
 
-      prefix = staff_role_id ? "<@&#{staff_role_id}>\n" : ""
-      entry = Discord::Components.container(
-        [Discord::Components.text("#{prefix}**#{title}**\n#{body}\n-# #{meta}")]
+      ActivityLog.post(
+        config,
+        bot: event.bot,
+        title: I18n.t("moderation.spam_protection.notification.title.#{settings.action}"),
+        body: ping + I18n.t(
+          "moderation.spam_protection.notification.body",
+          author: "<@#{event.author.id}>",
+          count: channels.size,
+          channels: channels.map { |id| "<##{id}>" }.join(", ")
+        ),
+        meta: I18n.t("moderation.spam_protection.notification.meta.#{settings.action}"),
+        allowed_mentions: {parse: [], roles: [staff_role_id].compact}
       )
-      Discord::Components.send_to(channel, entry, allowed_mentions: {parse: [], roles: [staff_role_id].compact})
-    rescue => e
-      Rails.logger.warn("[Moderation::SpamGuard] notify failed: #{e.class}: #{e.message}")
     end
   end
 end

--- a/app/plugins/moderation/events/spam_guard.rb
+++ b/app/plugins/moderation/events/spam_guard.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+module Moderation
+  class SpamGuard < BaseEvent
+    on :message
+
+    def handle
+      return if event.from_bot? || event.message.webhook? || event.channel.pm?
+
+      settings = SpamProtection::Settings.active_for(event.server.id)
+      return unless settings
+
+      config = settings.server_configuration
+      staff_role_id = config.moderation_settings.staff_role_id
+
+      return if staff_member?(staff_role_id)
+
+      hit = detect(settings)
+      return unless hit
+
+      purge(hit) if settings.action == "purge"
+      punish(settings)
+      notify(config, settings, staff_role_id, hit)
+    end
+
+    private
+
+    def fingerprints(settings)
+      result = []
+      content = Canonicalizer.call(event.message.content, strip_digits: true)
+
+      if content.present?
+        result << SimHash.fingerprint(content)
+      elsif settings.match_symbol_only_messages
+        result << "blank"
+      end
+
+      event.message.attachments.each do |attachment|
+        result << "a:#{attachment.filename}:#{attachment.size}"
+      end
+
+      result
+    end
+
+    def detect(settings)
+      fingerprints(settings).each do |fingerprint|
+        hit = SpamTracker.instance.record(
+          guild_id: event.server.id,
+          author_id: event.author.id,
+          fingerprint:,
+          message_id: event.message.id,
+          channel_id: event.channel.id,
+          at: Time.now,
+          window: settings.window_seconds,
+          threshold: settings.channel_threshold,
+          similarity: settings.similarity
+        )
+        return hit if hit
+      end
+      nil
+    end
+
+    def staff_member?(staff_role_id)
+      return false unless staff_role_id
+
+      event.author.roles.any? { |role| role.id == staff_role_id }
+    end
+
+    def purge(hit)
+      hit.each do |entry|
+        event.bot.channel(entry.channel_id)&.delete_message(entry.message_id)
+      rescue => e
+        Rails.logger.warn("[Moderation::SpamGuard] delete failed in ##{entry.channel_id}: #{e.class}: #{e.message}")
+      end
+    end
+
+    def punish(settings)
+      return if settings.punishment == "none"
+
+      Punisher.call(
+        member: event.author,
+        server: event.server,
+        punishment: settings.punishment,
+        timeout_seconds: settings.timeout_seconds,
+        reason: I18n.t("moderation.spam_protection.punishment.reason")
+      )
+    end
+
+    def notify(config, settings, staff_role_id, hit)
+      channel_id = config.logging_setting.channel_id
+      return unless channel_id
+
+      channel = event.bot.channel(channel_id)
+      return unless channel
+
+      channels = hit.map(&:channel_id).uniq
+      title = I18n.t("moderation.spam_protection.notification.title.#{settings.action}")
+      body = I18n.t(
+        "moderation.spam_protection.notification.body",
+        author: "<@#{event.author.id}>",
+        count: channels.size,
+        channels: channels.map { |id| "<##{id}>" }.join(", ")
+      )
+      meta = I18n.t("moderation.spam_protection.notification.meta.#{settings.action}")
+
+      prefix = staff_role_id ? "<@&#{staff_role_id}>\n" : ""
+      entry = Discord::Components.container(
+        [Discord::Components.text("#{prefix}**#{title}**\n#{body}\n-# #{meta}")]
+      )
+      Discord::Components.send_to(channel, entry, allowed_mentions: {parse: [], roles: [staff_role_id].compact})
+    rescue => e
+      Rails.logger.warn("[Moderation::SpamGuard] notify failed: #{e.class}: #{e.message}")
+    end
+  end
+end

--- a/app/plugins/moderation/punisher.rb
+++ b/app/plugins/moderation/punisher.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Moderation
+  module Punisher
+    module_function
+
+    def call(member:, server:, punishment:, timeout_seconds:, reason:)
+      case punishment
+      when "timeout"
+        member.communication_disabled_until = Time.now + timeout_seconds
+      when "kick"
+        server.kick(member, reason)
+      when "ban"
+        server.ban(member, message_seconds: 0, reason:)
+      end
+    rescue => e
+      Rails.logger.warn("[Moderation::Punisher] #{punishment} failed: #{e.class}: #{e.message}")
+    end
+  end
+end

--- a/app/plugins/moderation/punisher.rb
+++ b/app/plugins/moderation/punisher.rb
@@ -7,7 +7,7 @@ module Moderation
     def call(member:, server:, punishment:, timeout_seconds:, reason:)
       case punishment
       when "timeout"
-        member.communication_disabled_until = Time.now + timeout_seconds
+        member.communication_disabled_until = Time.current + timeout_seconds
       when "kick"
         server.kick(member, reason)
       when "ban"

--- a/app/plugins/moderation/sim_hash.rb
+++ b/app/plugins/moderation/sim_hash.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "digest"
+
+module Moderation
+  module SimHash
+    BITS = 64
+
+    module_function
+
+    def fingerprint(text)
+      tallied = shingles(text).tally
+
+      return 0 if tallied.empty?
+
+      votes = Array.new(BITS, 0)
+
+      tallied.each do |shingle, weight|
+        bits = hash64(shingle)
+        BITS.times do |i|
+          votes[i] += (bits[i] == 1) ? weight : -weight
+        end
+      end
+
+      result = 0
+      BITS.times do |i|
+        result |= (1 << i) if votes[i] > 0
+      end
+      result
+    end
+
+    def similar?(a, b, similarity: 1.0)
+      hamming_distance(a, b) <= ((1.0 - similarity) * BITS).floor
+    end
+
+    def hamming_distance(a, b)
+      (a ^ b).to_s(2).count("1")
+    end
+
+    def shingles(text)
+      tokens = text.to_s.split
+      tokens + tokens.each_cons(2).map { |a, b| "#{a} #{b}" }
+    end
+
+    def hash64(shingle)
+      Digest::SHA1.digest(shingle).unpack1("Q>")
+    end
+
+    private_class_method :shingles, :hash64
+  end
+end

--- a/app/plugins/moderation/spam_tracker.rb
+++ b/app/plugins/moderation/spam_tracker.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Moderation
+  class SpamTracker
+    Entry = Data.define(:message_id, :channel_id, :at)
+
+    INSTANCE_MUTEX = Mutex.new
+
+    def self.instance
+      INSTANCE_MUTEX.synchronize { @instance ||= new }
+    end
+
+    def initialize
+      @mutex = Mutex.new
+      @buckets = Hash.new { |h, k| h[k] = [] }
+    end
+
+    def record(guild_id:, author_id:, fingerprint:, message_id:, channel_id:, at:, window:, threshold:, similarity:)
+      @mutex.synchronize do
+        key = bucket_key(guild_id, author_id, fingerprint, similarity)
+        entries = @buckets[key]
+        entries << Entry.new(message_id:, channel_id:, at:)
+        entries.reject! { |e| e.at < at - window }
+
+        distinct = entries.map(&:channel_id).uniq
+        return nil if distinct.size < threshold
+
+        hit = entries.dup
+        @buckets.delete(key)
+        hit
+      end
+    end
+
+    private
+
+    def bucket_key(guild_id, author_id, fingerprint, similarity)
+      exact = [guild_id, author_id, fingerprint]
+      return exact if similarity >= 1.0 || fingerprint.is_a?(String)
+
+      match = @buckets.keys.find do |g, a, fp|
+        g == guild_id && a == author_id && fp.is_a?(Integer) && SimHash.similar?(fp, fingerprint, similarity:)
+      end
+
+      match || exact
+    end
+  end
+end

--- a/bin/bot
+++ b/bin/bot
@@ -10,7 +10,8 @@ shard_count = BotConfig.shard_count
 bots = Array.new(shard_count) do |shard_id|
   Discordrb::Bot.new(
     token: BotConfig.token,
-    intents: %i[servers server_members],
+    # discordrb has no :message_content symbol; MESSAGE CONTENT is raw gateway bit 15
+    intents: [:servers, :server_members, :server_messages, 1 << 15],
     shard_id: shard_id,
     num_shards: shard_count
   )

--- a/config/locales/moderation.en.yml
+++ b/config/locales/moderation.en.yml
@@ -1,0 +1,14 @@
+---
+en:
+  moderation:
+    spam_protection:
+      notification:
+        body: "%{author} posted the same message in %{count} channels: %{channels}."
+        meta:
+          notify_only: Notify-only — no messages were deleted.
+          purge: Messages were deleted.
+        title:
+          notify_only: Cross-channel spam detected
+          purge: Cross-channel spam purged
+      punishment:
+        reason: Cross-channel spam

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -22,6 +22,14 @@ One Docker image, three processes (web/bot/jobs) plus managed accessories
 Add the OAuth2 redirect URI `https://shrkbot.com/auth/discord/callback` under your
 application's OAuth2 settings.
 
+#### Privileged Gateway Intents
+
+The **Server Shield / spam protection** feature requires the **MESSAGE CONTENT**
+privileged intent. Enable it under your application's **Bot → Privileged Gateway
+Intents** section in the Discord Developer Portal. Without it Discord sends
+`event.message.content` as an empty string, so content-based spam detection will
+not fire.
+
 ## Secrets
 
 Create a gitignored `.deploy.env` on your laptop and source it before deploying:

--- a/spec/plugins/moderation/canonicalizer_spec.rb
+++ b/spec/plugins/moderation/canonicalizer_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Moderation::Canonicalizer do
+  subject(:result) { described_class.call(text, **options) }
+
+  let(:options) { {} }
+
+  context "NFKC folding" do
+    let(:text) { "Ｈello" }
+
+    it "folds fullwidth characters to ASCII equivalents and downcases" do
+      expect(result).to eq("hello")
+    end
+  end
+
+  context "zero-width character removal" do
+    let(:text) { "he​llo" }
+
+    it "strips zero-width spaces" do
+      expect(result).to eq("hello")
+    end
+  end
+
+  context "downcasing" do
+    let(:text) { "HELLO World" }
+
+    it "lowercases all characters" do
+      expect(result).to eq("hello world")
+    end
+  end
+
+  context "punctuation replacement" do
+    let(:text) { "hello, world! foo.bar" }
+
+    it "replaces punctuation with spaces and collapses runs" do
+      expect(result).to eq("hello world foo bar")
+    end
+  end
+
+  context "with strip_digits: true" do
+    let(:text) { "abc123def" }
+    let(:options) { {strip_digits: true} }
+
+    it "removes digits" do
+      expect(result).to eq("abc def")
+    end
+  end
+
+  context "with default strip_digits (false)" do
+    let(:text) { "abc123def" }
+
+    it "keeps digits" do
+      expect(result).to eq("abc123def")
+    end
+  end
+
+  context "leading and trailing whitespace" do
+    let(:text) { "  hello world  " }
+
+    it "strips surrounding whitespace" do
+      expect(result).to eq("hello world")
+    end
+  end
+end

--- a/spec/plugins/moderation/events/spam_guard_spec.rb
+++ b/spec/plugins/moderation/events/spam_guard_spec.rb
@@ -1,0 +1,313 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Moderation::SpamGuard do
+  subject(:handle) { described_class.new(event).handle }
+
+  let(:guild_id) { 111 }
+  let(:author_id) { 222 }
+  let(:staff_role_id) { 333 }
+  let(:log_channel_id) { 444 }
+
+  let(:server) { double("server", id: guild_id) }
+  let(:author) { double("author", id: author_id, roles: []) }
+  let(:message) { double("message", id: 1, webhook?: false, content: "hello world foo bar", attachments: []) }
+  let(:channel) { double("channel", id: 1, pm?: false) }
+  let(:log_channel) { double("log_channel") }
+  let(:bot) { double("bot") }
+  let(:event) { double("event", from_bot?: false, server:, author:, message:, channel:, bot:) }
+
+  let(:logging_setting) { double("logging_setting", channel_id: log_channel_id) }
+  let(:moderation_settings) { double("moderation_settings", staff_role_id:) }
+  let(:config) do
+    double(
+      "server_configuration",
+      logging_setting:,
+      moderation_settings:
+    )
+  end
+  let(:action) { "purge" }
+  let(:punishment) { "none" }
+  let(:match_symbol_only_messages) { false }
+  let(:settings) do
+    double(
+      "spam_protection_settings",
+      server_configuration: config,
+      channel_threshold: 3,
+      window_seconds: 60,
+      similarity: 1.0,
+      action:,
+      punishment:,
+      timeout_seconds: 300,
+      match_symbol_only_messages:
+    )
+  end
+
+  let(:tracker) { Moderation::SpamTracker.new }
+
+  before do
+    allow(Moderation::SpamProtection::Settings).to receive(:active_for).with(guild_id).and_return(settings)
+    allow(Moderation::SpamTracker).to receive(:instance).and_return(tracker)
+    allow(bot).to receive(:channel).with(log_channel_id).and_return(log_channel)
+  end
+
+  def simulate_message(channel_id:, message_id:, content: "hello world foo bar", attachments: [])
+    msg = double("message_#{message_id}", id: message_id, webhook?: false, content:, attachments:)
+    ch = double("channel_#{channel_id}", id: channel_id, pm?: false)
+    evt = double("event_#{message_id}", from_bot?: false, server:, author:, message: msg, channel: ch, bot:)
+    described_class.new(evt).handle
+  end
+
+  context "when spam protection is inactive" do
+    before { allow(Moderation::SpamProtection::Settings).to receive(:active_for).and_return(nil) }
+
+    it "does nothing" do
+      expect(bot).not_to receive(:channel)
+      handle
+    end
+  end
+
+  context "when message is from bot" do
+    before { allow(event).to receive(:from_bot?).and_return(true) }
+
+    it "skips processing" do
+      expect(Moderation::SpamProtection::Settings).not_to receive(:active_for)
+      handle
+    end
+  end
+
+  context "when message is a webhook" do
+    before { allow(message).to receive(:webhook?).and_return(true) }
+
+    it "skips processing" do
+      expect(Moderation::SpamProtection::Settings).not_to receive(:active_for)
+      handle
+    end
+  end
+
+  context "when channel is a DM" do
+    before { allow(channel).to receive(:pm?).and_return(true) }
+
+    it "skips processing" do
+      expect(Moderation::SpamProtection::Settings).not_to receive(:active_for)
+      handle
+    end
+  end
+
+  context "when author has staff role" do
+    let(:staff_role) { double("role", id: staff_role_id) }
+    let(:author) { double("author", id: author_id, roles: [staff_role]) }
+
+    it "does not purge or notify" do
+      expect(bot).not_to receive(:channel)
+      handle
+    end
+  end
+
+  context "when below threshold" do
+    it "does not purge or notify" do
+      simulate_message(channel_id: 1, message_id: 1)
+      expect(bot).not_to receive(:channel).with(log_channel_id)
+      simulate_message(channel_id: 1, message_id: 2)
+    end
+  end
+
+  context "when threshold reached across channels with action 'purge'" do
+    before do
+      allow(bot).to receive(:channel).with(1).and_return(double("ch1", delete_message: nil))
+      allow(bot).to receive(:channel).with(2).and_return(double("ch2", delete_message: nil))
+      allow(bot).to receive(:channel).with(3).and_return(double("ch3", delete_message: nil))
+      allow(Discord::Components).to receive(:send_to)
+    end
+
+    it "deletes each hit message and sends a notification" do
+      expect(bot.channel(1)).to receive(:delete_message).with(10)
+      expect(bot.channel(2)).to receive(:delete_message).with(20)
+      expect(bot.channel(3)).to receive(:delete_message).with(30)
+      expect(Discord::Components).to receive(:send_to).with(
+        log_channel,
+        anything,
+        allowed_mentions: hash_including(roles: array_including(staff_role_id))
+      )
+
+      simulate_message(channel_id: 1, message_id: 10)
+      simulate_message(channel_id: 2, message_id: 20)
+      simulate_message(channel_id: 3, message_id: 30)
+    end
+  end
+
+  context "when action is 'notify_only'" do
+    let(:action) { "notify_only" }
+    let(:ch1) { double("ch1") }
+    let(:ch2) { double("ch2") }
+    let(:ch3) { double("ch3") }
+
+    before do
+      allow(bot).to receive(:channel).with(1).and_return(ch1)
+      allow(bot).to receive(:channel).with(2).and_return(ch2)
+      allow(bot).to receive(:channel).with(3).and_return(ch3)
+      allow(Discord::Components).to receive(:send_to)
+    end
+
+    it "sends notification but does not delete messages" do
+      expect(ch1).not_to receive(:delete_message)
+      expect(ch2).not_to receive(:delete_message)
+      expect(ch3).not_to receive(:delete_message)
+      expect(Discord::Components).to receive(:send_to)
+
+      simulate_message(channel_id: 1, message_id: 1)
+      simulate_message(channel_id: 2, message_id: 2)
+      simulate_message(channel_id: 3, message_id: 3)
+    end
+  end
+
+  context "with match_symbol_only_messages false" do
+    it "does not trigger on punctuation-only messages across channels" do
+      expect(Discord::Components).not_to receive(:send_to)
+
+      simulate_message(channel_id: 1, message_id: 1, content: "!!!")
+      simulate_message(channel_id: 2, message_id: 2, content: "???")
+      simulate_message(channel_id: 3, message_id: 3, content: "...")
+      simulate_message(channel_id: 4, message_id: 4, content: "---")
+    end
+  end
+
+  context "with match_symbol_only_messages true" do
+    let(:match_symbol_only_messages) { true }
+
+    before do
+      allow(bot).to receive(:channel).and_return(double("ch", delete_message: nil))
+      allow(Discord::Components).to receive(:send_to)
+    end
+
+    it "triggers on mixed punctuation-only messages across channels (all blank after canonicalization)" do
+      expect(Discord::Components).to receive(:send_to)
+
+      simulate_message(channel_id: 1, message_id: 1, content: "!!!")
+      simulate_message(channel_id: 2, message_id: 2, content: "???")
+      simulate_message(channel_id: 3, message_id: 3, content: "...")
+    end
+  end
+
+  context "when the same attachment is posted across channels" do
+    let(:attachment) { double("attachment", filename: "scam.png", size: 1024) }
+
+    before do
+      allow(bot).to receive(:channel).and_return(double("ch", delete_message: nil))
+      allow(Discord::Components).to receive(:send_to)
+    end
+
+    it "fingerprints attachments and triggers on the threshold" do
+      expect(Discord::Components).to receive(:send_to)
+
+      simulate_message(channel_id: 1, message_id: 1, content: "", attachments: [attachment])
+      simulate_message(channel_id: 2, message_id: 2, content: "", attachments: [attachment])
+      simulate_message(channel_id: 3, message_id: 3, content: "", attachments: [attachment])
+    end
+  end
+
+  context "when a source channel is missing or deletion fails" do
+    before do
+      allow(bot).to receive(:channel).with(1).and_return(double("ch1", delete_message: nil))
+      allow(bot).to receive(:channel).with(2).and_return(nil)
+      allow(bot).to receive(:channel).with(3).and_raise(RuntimeError, "forbidden")
+      allow(Discord::Components).to receive(:send_to)
+    end
+
+    it "skips the missing channel, logs the failure, and still notifies" do
+      expect(Discord::Components).to receive(:send_to)
+
+      simulate_message(channel_id: 1, message_id: 10)
+      simulate_message(channel_id: 2, message_id: 20)
+      expect { simulate_message(channel_id: 3, message_id: 30) }.not_to raise_error
+    end
+  end
+
+  context "when the log channel is unset" do
+    let(:action) { "notify_only" }
+    let(:logging_setting) { double("logging_setting", channel_id: nil) }
+
+    it "does not attempt to notify" do
+      expect(Discord::Components).not_to receive(:send_to)
+
+      simulate_message(channel_id: 1, message_id: 1)
+      simulate_message(channel_id: 2, message_id: 2)
+      simulate_message(channel_id: 3, message_id: 3)
+    end
+  end
+
+  context "when the log channel no longer exists" do
+    let(:action) { "notify_only" }
+
+    before do
+      allow(bot).to receive(:channel).with(log_channel_id).and_return(nil)
+    end
+
+    it "does not attempt to notify" do
+      expect(Discord::Components).not_to receive(:send_to)
+
+      simulate_message(channel_id: 1, message_id: 1)
+      simulate_message(channel_id: 2, message_id: 2)
+      simulate_message(channel_id: 3, message_id: 3)
+    end
+  end
+
+  context "when the notification send fails" do
+    let(:action) { "notify_only" }
+
+    before do
+      allow(Discord::Components).to receive(:send_to).and_raise(RuntimeError, "no perms")
+    end
+
+    it "rescues and does not raise into the handler" do
+      simulate_message(channel_id: 1, message_id: 1)
+      simulate_message(channel_id: 2, message_id: 2)
+      expect { simulate_message(channel_id: 3, message_id: 3) }.not_to raise_error
+    end
+  end
+
+  context "when no staff role is configured" do
+    let(:action) { "notify_only" }
+    let(:moderation_settings) { double("moderation_settings", staff_role_id: nil) }
+
+    before do
+      allow(Discord::Components).to receive(:send_to)
+    end
+
+    it "notifies without a staff-role ping" do
+      expect(Discord::Components).to receive(:send_to).with(
+        log_channel,
+        anything,
+        allowed_mentions: {parse: [], roles: []}
+      )
+
+      simulate_message(channel_id: 1, message_id: 1)
+      simulate_message(channel_id: 2, message_id: 2)
+      simulate_message(channel_id: 3, message_id: 3)
+    end
+  end
+
+  context "when punishment is set" do
+    let(:action) { "notify_only" }
+    let(:punishment) { "kick" }
+
+    before do
+      allow(Discord::Components).to receive(:send_to)
+    end
+
+    it "invokes Punisher.call on threshold hit" do
+      expect(Moderation::Punisher).to receive(:call).with(
+        member: author,
+        server:,
+        punishment: "kick",
+        timeout_seconds: 300,
+        reason: "Cross-channel spam"
+      )
+
+      simulate_message(channel_id: 1, message_id: 1)
+      simulate_message(channel_id: 2, message_id: 2)
+      simulate_message(channel_id: 3, message_id: 3)
+    end
+  end
+end

--- a/spec/plugins/moderation/punisher_spec.rb
+++ b/spec/plugins/moderation/punisher_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Moderation::Punisher do
+  subject(:call) { described_class.call(member:, server:, punishment:, timeout_seconds:, reason:) }
+
+  let(:member) { double("member") }
+  let(:server) { double("server") }
+  let(:timeout_seconds) { 300 }
+  let(:reason) { "spamming" }
+
+  context "with punishment 'none'" do
+    let(:punishment) { "none" }
+
+    it "sends no messages to member or server" do
+      expect(member).not_to receive(:communication_disabled_until=)
+      expect(server).not_to receive(:kick)
+      expect(server).not_to receive(:ban)
+      call
+    end
+  end
+
+  context "with punishment 'timeout'" do
+    let(:punishment) { "timeout" }
+
+    it "sets communication_disabled_until on the member" do
+      expect(member).to receive(:communication_disabled_until=)
+      call
+    end
+  end
+
+  context "with punishment 'kick'" do
+    let(:punishment) { "kick" }
+
+    it "kicks the member from the server" do
+      expect(server).to receive(:kick).with(member, "spamming")
+      call
+    end
+  end
+
+  context "with punishment 'ban'" do
+    let(:punishment) { "ban" }
+
+    it "bans the member with zero message seconds" do
+      expect(server).to receive(:ban).with(member, message_seconds: 0, reason: "spamming")
+      call
+    end
+  end
+
+  context "when discordrb raises an error" do
+    let(:punishment) { "kick" }
+
+    it "rescues the error and does not re-raise" do
+      allow(server).to receive(:kick).and_raise(RuntimeError, "forbidden")
+      expect { call }.not_to raise_error
+    end
+  end
+end

--- a/spec/plugins/moderation/sim_hash_spec.rb
+++ b/spec/plugins/moderation/sim_hash_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Moderation::SimHash do
+  describe ".fingerprint" do
+    it "is deterministic — same text produces same integer on repeated calls" do
+      expect(described_class.fingerprint("hello world foo bar")).to eq(
+        described_class.fingerprint("hello world foo bar")
+      )
+    end
+
+    it "returns an Integer" do
+      expect(described_class.fingerprint("some text")).to be_a(Integer)
+    end
+
+    it "returns 0 for empty string" do
+      expect(described_class.fingerprint("")).to eq(0)
+    end
+  end
+
+  describe ".hamming_distance" do
+    it "returns 0 for identical strings" do
+      fp = described_class.fingerprint("the quick brown fox")
+      expect(described_class.hamming_distance(fp, fp)).to eq(0)
+    end
+
+    it "returns a small distance for a near-identical string (one word changed)" do
+      fp_a = described_class.fingerprint("the quick brown fox jumps over the lazy dog")
+      fp_b = described_class.fingerprint("the quick brown fox jumps over the lazy cat")
+      expect(described_class.hamming_distance(fp_a, fp_b)).to be <= 10
+    end
+
+    it "returns a large distance for unrelated text" do
+      fp_a = described_class.fingerprint("completely different content here one two three")
+      fp_b = described_class.fingerprint("zephyr quartz jolly vexing backlash")
+      expect(described_class.hamming_distance(fp_a, fp_b)).to be > 10
+    end
+  end
+
+  describe ".similar?" do
+    let(:base_text) { "the quick brown fox jumps over the lazy dog" }
+    let(:near_text) { "the quick brown fox jumps over the lazy cat" }
+
+    it "returns true at similarity 1.0 only when hamming distance is 0" do
+      fp = described_class.fingerprint(base_text)
+      expect(described_class.similar?(fp, fp, similarity: 1.0)).to be true
+    end
+
+    it "returns false at similarity 1.0 for unrelated text" do
+      fp_a = described_class.fingerprint("completely different content here one two three")
+      fp_b = described_class.fingerprint("zephyr quartz jolly vexing backlash")
+      expect(described_class.similar?(fp_a, fp_b, similarity: 1.0)).to be false
+    end
+
+    it "returns true at similarity 0.85 for a near-identical pair" do
+      fp_a = described_class.fingerprint(base_text)
+      fp_b = described_class.fingerprint(near_text)
+      expect(described_class.similar?(fp_a, fp_b, similarity: 0.85)).to be true
+    end
+  end
+end

--- a/spec/plugins/moderation/spam_tracker_spec.rb
+++ b/spec/plugins/moderation/spam_tracker_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Moderation::SpamTracker do
+  subject(:tracker) { described_class.new }
+
+  let(:guild_id) { 1 }
+  let(:author_id) { 42 }
+  let(:fingerprint) { 999 }
+  let(:window) { 60 }
+  let(:threshold) { 3 }
+  let(:similarity) { 1.0 }
+  let(:base_time) { Time.now }
+
+  def record(channel_id:, at: base_time, fp: fingerprint)
+    tracker.record(
+      guild_id:,
+      author_id:,
+      fingerprint: fp,
+      message_id: rand(100_000),
+      channel_id:,
+      at:,
+      window:,
+      threshold:,
+      similarity:
+    )
+  end
+
+  it "returns nil when below threshold" do
+    record(channel_id: 1)
+    record(channel_id: 2)
+    expect(record(channel_id: 2)).to be_nil
+  end
+
+  it "returns entries when distinct channels reach threshold" do
+    record(channel_id: 1)
+    record(channel_id: 2)
+    result = record(channel_id: 3)
+    expect(result).to be_an(Array)
+    expect(result.map(&:channel_id)).to contain_exactly(1, 2, 3)
+  end
+
+  it "does NOT reach threshold when same channel repeated" do
+    record(channel_id: 1)
+    record(channel_id: 1)
+    expect(record(channel_id: 1)).to be_nil
+  end
+
+  it "sweeps entries older than window so they do not count" do
+    record(channel_id: 1, at: base_time - 61)
+    record(channel_id: 2, at: base_time - 61)
+    record(channel_id: 3, at: base_time)
+    expect(record(channel_id: 4, at: base_time)).to be_nil
+  end
+
+  it "counts distinct channel_ids regardless of thread/order" do
+    record(channel_id: 10)
+    record(channel_id: 20)
+    expect(record(channel_id: 30)).to be_an(Array)
+  end
+
+  context "with similarity < 1.0" do
+    let(:similarity) { 0.85 }
+    let(:text_a) { "the quick brown fox jumps over the lazy dog" }
+    let(:text_b) { "the quick brown fox jumps over the lazy cat" }
+
+    it "groups two near-duplicate fingerprints into one bucket" do
+      fp_a = Moderation::SimHash.fingerprint(text_a)
+      fp_b = Moderation::SimHash.fingerprint(text_b)
+
+      tracker.record(
+        guild_id:, author_id:, fingerprint: fp_a, message_id: 1,
+        channel_id: 1, at: base_time, window:, threshold:, similarity:
+      )
+      tracker.record(
+        guild_id:, author_id:, fingerprint: fp_b, message_id: 2,
+        channel_id: 2, at: base_time, window:, threshold:, similarity:
+      )
+      result = tracker.record(
+        guild_id:, author_id:, fingerprint: fp_a, message_id: 3,
+        channel_id: 3, at: base_time, window:, threshold:, similarity:
+      )
+      expect(result).to be_an(Array)
+    end
+  end
+
+  it "recording a String fingerprint then an Integer fingerprint raises no error" do
+    expect {
+      record(channel_id: 1, fp: "blank")
+      record(channel_id: 2, fp: 12_345)
+    }.not_to raise_error
+  end
+
+  it "clears the bucket after a hit so next record starts fresh" do
+    record(channel_id: 1)
+    record(channel_id: 2)
+    record(channel_id: 3)
+    record(channel_id: 4)
+    expect(record(channel_id: 5)).to be_nil
+  end
+
+  describe ".instance" do
+    it "memoizes a single shared instance" do
+      expect(described_class.instance).to be(described_class.instance)
+    end
+  end
+end


### PR DESCRIPTION
Server Shield PR 2 of the moderation suite: **Cross-Channel Spam Guard** (feature A, complete). Builds on the PR 1 scaffold (#109).

## What it does
Detects the same message blasted across multiple channels within a time window and purges it before it spreads, then pings staff in the log channel. Matching is SimHash fingerprint-based over canonicalized content — **message content is never stored** (in-memory, hash-only; honours the privacy policy).

## Pieces
- `Moderation::Canonicalizer` — NFKC + invisible-char strip + downcase + punctuation (and optionally digit) folding. `strip_digits: true` on the spam path defeats "append 1/2/3" variation.
- `Moderation::SimHash` — 64-bit SimHash (token + bigram shingles, weighted per-bit vote); `similar?` / `hamming_distance`. Per-server similarity threshold (1.0 = exact).
- `Moderation::SpamTracker` — mutex-synchronized in-memory bucketing keyed by (guild, author, fingerprint); sweeps the window, groups near-duplicate fingerprints below similarity 1.0, clears a bucket on a hit. Process singleton.
- `Moderation::Punisher` — none/timeout/kick/ban dispatch, rescues Discord errors without re-raising. Shared with the upcoming image-scanning feature.
- `Moderation::SpamGuard` (`:message` event) — guards (bot/webhook/DM/staff), builds content + attachment fingerprints, records them, and on a threshold hit purges (or notify-only), applies punishment, and posts a staff-pinging notification carrying no message content.

## Framework / ops
- `bin/bot` gains the `server_messages` intent **plus raw gateway bit 15 (MESSAGE CONTENT)** — discordrb exposes no `:message_content` symbol, so it's OR'd in as an integer. Requires the privileged MESSAGE CONTENT toggle in the Discord dev portal (documented in `docs/deployment.md`); without it `event.message.content` is empty.

## Tests / gates
All green locally: rspec (1087 examples), standardrb, active_record_doctor, undercover (`--compare origin/main`), i18n-tasks missing + check-normalized.

## Notes for review
- No new stored data → no privacy-policy change (in-memory, hash-only; notification omits content).
- Two BUILD_PLAN specifics were corrected against the actual discordrb fork: the event class is `Moderation::SpamGuard` (the `events/` dir is Zeitwerk-collapsed), and message deletion goes through `bot.channel(id)&.delete_message(id)` (`Bot#delete_message` is the event-handler stub, not a REST call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)