### PR TITLE
Bump websocket-driver to 0.8.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -529,7 +529,7 @@ GEM
       event_emitter
       mutex_m
       websocket
-    websocket-driver (0.8.1)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -782,7 +782,7 @@ CHECKSUMS
   web-console (4.3.0) sha256=e13b71301cdfc2093f155b5aa3a622db80b4672d1f2f713119cc7ec7ac6a6da4
   websocket (1.2.11) sha256=b7e7a74e2410b5e85c25858b26b3322f29161e300935f70a0e0d3c35e0462737
   websocket-client-simple (0.9.0) sha256=f9a37c5e4922b35a711e21e6d73ed1e25892efa47d183203ab2f5beb4e563109
-  websocket-driver (0.8.1) sha256=5ab238238ce230e5d4b262d2be39624c867914eab99171dc4952b58b577c2d96
+  websocket-driver (0.8.2) sha256=97c556b019bf3410b4961002ac501621e9322d3f8a7bc02161a09301cc4c4146
   websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
   zeitwerk (2.8.2) sha256=7212a61311083c604184b1ea2574b9aa05cd14f855a0841c06985cabe9181d12
 


### PR DESCRIPTION
bundler-audit started failing on every branch: [GHSA-2x63-gw47-w4mm](https://github.com/faye/websocket-driver-ruby/security/advisories/GHSA-2x63-gw47-w4mm) (DoS via malformed Host header) published against the locked 0.8.1. Conservative transitive bump to 0.8.2, nothing else moves. rspec + standardrb green locally.

Merging this unblocks CI on #111 (it will pull the fix via main).