### PR TITLE
Add image-scanning OCR path (Server Shield)

### DIFF
--- a/app/bot/activity_log.rb
+++ b/app/bot/activity_log.rb
@@ -5,11 +5,11 @@ module ActivityLog
 
   module_function
 
-  def post(server_configuration, bot:, title:, body:, meta:, allowed_mentions: SUPPRESS_MENTIONS)
+  def post(server_configuration, bot:, title:, body:, meta:, image_url: nil, allowed_mentions: SUPPRESS_MENTIONS)
     channel_id = server_configuration.logging_setting.channel_id
     return unless channel_id
 
-    deliver(bot, channel_id, entry(title, body, meta), allowed_mentions:)
+    deliver(bot, channel_id, entry(title, body, meta, image_url:), allowed_mentions:)
   end
 
   def enabled?(server_configuration, action)
@@ -18,10 +18,10 @@ module ActivityLog
     server_configuration.logging_setting.action_enabled?(action)
   end
 
-  def entry(title, body, meta)
-    Discord::Components.container(
-      [Discord::Components.text("**#{title}**\n#{body}\n-# #{meta}")]
-    )
+  def entry(title, body, meta, image_url: nil)
+    blocks = [Discord::Components.text("**#{title}**\n#{body}\n-# #{meta}")]
+    blocks << Discord::Components.media_gallery([image_url]) if image_url
+    Discord::Components.container(blocks)
   end
 
   def deliver(bot, channel_id, entry, allowed_mentions: SUPPRESS_MENTIONS)

--- a/app/bot/discord/components.rb
+++ b/app/bot/discord/components.rb
@@ -5,6 +5,7 @@ module Discord
     CONTAINER = 17
     TEXT_DISPLAY = 10
     SEPARATOR = 14
+    MEDIA_GALLERY = 12
     COMPONENTS_V2 = 1 << 15
 
     module_function
@@ -19,6 +20,10 @@ module Discord
 
     def separator
       {type: SEPARATOR, divider: true}
+    end
+
+    def media_gallery(urls)
+      {type: MEDIA_GALLERY, items: urls.map { |url| {media: {url:}} }}
     end
 
     def send_to(channel, rendered, allowed_mentions: nil)

--- a/app/plugins/moderation/classifier.rb
+++ b/app/plugins/moderation/classifier.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+module Moderation
+  module Classifier
+    THRESHOLDS = {
+      "relaxed" => {flag: 5, remove: 8},
+      "standard" => {flag: 3, remove: 6},
+      "strict" => {flag: 2, remove: 4.5}
+    }.freeze
+    NEW_ACCOUNT_DAYS = 7
+    KEYWORD_WEIGHT = 2
+    OWN_CONFIRMED_RISK = 6
+    FUZZY_RATIO = 0.2
+
+    module_function
+
+    def call(ocr_text:, hash_state:, signals:, settings:)
+      canon = Canonicalizer.call(ocr_text)
+      reasons = []
+
+      ocr_score = scam_rule_score(canon, reasons) + keyword_score(canon, settings, reasons)
+
+      risk = ocr_score
+      risk += OWN_CONFIRMED_RISK if hash_state == :own_confirmed
+      risk += amplifier_score(signals, reasons)
+
+      reasons << hash_state unless hash_state == :none
+
+      content_signal = ocr_score > 0 || hash_state != :none
+      keyword_gate = reasons.include?(:custom_keywords)
+      thresholds = THRESHOLDS.fetch(settings.sensitivity)
+      action = decide(risk, ocr_score, hash_state, content_signal, keyword_gate, thresholds)
+
+      Verdict.new(action:, risk:, reasons:)
+    end
+
+    def decide(risk, ocr_score, hash_state, content_signal, keyword_gate, thresholds)
+      return :allow unless content_signal
+
+      action =
+        if risk >= thresholds[:remove] && (ocr_score > 0 || hash_state == :own_confirmed)
+          (hash_state == :foreign_confirmed) ? :flag_for_review : :remove
+        elsif risk >= thresholds[:flag]
+          :flag_for_review
+        else
+          :allow
+        end
+
+      (keyword_gate && action == :allow) ? :flag_for_review : action
+    end
+
+    def amplifier_score(signals, reasons)
+      score = 0
+      if signals[:account_age_days] < NEW_ACCOUNT_DAYS
+        score += 2
+        reasons << :new_account
+      end
+      if signals[:has_link]
+        score += 1
+        reasons << :has_link
+      end
+      unless signals[:has_role]
+        score += 0.5
+        reasons << :no_role
+      end
+      score
+    end
+
+    def scam_rule_score(canon, reasons)
+      matched = ScamRules::RULES.select { |rule| FuzzyMatcher.match?(matchable(rule), canon, ratio: FUZZY_RATIO) }
+      reasons.concat(matched.map { |rule| rule[:pattern] })
+      matched.sum { |rule| rule[:weight] }
+    end
+
+    def matchable(rule)
+      rule[:regex] ? Regexp.new(rule[:pattern]) : rule[:pattern]
+    end
+
+    def keyword_score(canon, settings, reasons)
+      keywords = settings.custom_keywords
+      return 0 if keywords.empty?
+
+      hits = keywords.count { |keyword| FuzzyMatcher.match?(Canonicalizer.call(keyword), canon, ratio: FUZZY_RATIO) }
+      return 0 if hits < settings.custom_keyword_min_hits
+
+      reasons << :custom_keywords
+      KEYWORD_WEIGHT * hits
+    end
+
+    private_class_method :decide, :amplifier_score, :scam_rule_score, :matchable, :keyword_score
+  end
+end

--- a/app/plugins/moderation/events/image_scan.rb
+++ b/app/plugins/moderation/events/image_scan.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Moderation
+  class ImageScan < BaseEvent
+    on :message
+
+    IMAGE_CONTENT_TYPES = %w[image/png image/jpeg image/webp].freeze
+    MAX_ATTACHMENTS = 3
+    MAX_BYTES = 10 * 1024 * 1024
+
+    def handle
+      return if event.from_bot? || event.message.webhook? || event.channel.pm?
+
+      settings = ImageScanning::Settings.active_for(event.server.id)
+      return unless settings
+
+      attachments = eligible_attachments
+      return if attachments.empty?
+
+      signals = Signals.call(author: event.author, content: event.message.content, server_id: event.server.id)
+
+      attachments.each do |attachment|
+        context = context_for(attachment, settings, signals)
+        ScanQueue.enqueue(-> { ScanProcessor.call(context) })
+      end
+    end
+
+    private
+
+    def eligible_attachments
+      event.message.attachments
+        .select { |attachment| IMAGE_CONTENT_TYPES.include?(attachment.content_type) && attachment.size <= MAX_BYTES }
+        .first(MAX_ATTACHMENTS)
+    end
+
+    def context_for(attachment, settings, signals)
+      ScanContext.new(
+        bot: event.bot,
+        server: event.server,
+        member: event.author,
+        channel_id: event.channel.id,
+        message_id: event.message.id,
+        attachment_url: attachment.url,
+        signals:,
+        settings:
+      )
+    end
+  end
+end

--- a/app/plugins/moderation/events/spam_guard.rb
+++ b/app/plugins/moderation/events/spam_guard.rb
@@ -88,13 +88,12 @@ module Moderation
 
     def notify(config, settings, staff_role_id, hit)
       channels = hit.map(&:channel_id).uniq
-      ping = staff_role_id ? "<@&#{staff_role_id}> " : ""
 
       ActivityLog.post(
         config,
         bot: event.bot,
         title: I18n.t("moderation.spam_protection.notification.title.#{settings.action}"),
-        body: ping + I18n.t(
+        body: StaffPing.prefix(staff_role_id) + I18n.t(
           "moderation.spam_protection.notification.body",
           author: "<@#{event.author.id}>",
           count: channels.size,

--- a/app/plugins/moderation/fuzzy_matcher.rb
+++ b/app/plugins/moderation/fuzzy_matcher.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Moderation
+  module FuzzyMatcher
+    module_function
+
+    def match?(pattern, text, ratio: 0.2)
+      return pattern.match?(text) if pattern.is_a?(Regexp)
+      return true if text.include?(pattern)
+
+      max_dist = (pattern.length * ratio).floor
+      return false if max_dist <= 0
+
+      fuzzy_substring_distance(pattern, text) <= max_dist
+    end
+
+    def fuzzy_substring_distance(pattern, text)
+      m = pattern.length
+      n = text.length
+      return m if n.zero?
+
+      prev = Array.new(n + 1, 0)
+      (1..m).each do |i|
+        cur = Array.new(n + 1, 0)
+        cur[0] = i
+        pc = pattern[i - 1]
+        (1..n).each do |j|
+          cost = (pc == text[j - 1]) ? 0 : 1
+          cur[j] = [prev[j] + 1, cur[j - 1] + 1, prev[j - 1] + cost].min
+        end
+        prev = cur
+      end
+      prev.min
+    end
+
+    private_class_method :fuzzy_substring_distance
+  end
+end

--- a/app/plugins/moderation/ocr/client.rb
+++ b/app/plugins/moderation/ocr/client.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "net/http"
+require "json"
+
+module Moderation
+  module Ocr
+    class Client
+      def initialize
+        @base = URI(ENV.fetch("OCR_URL"))
+      end
+
+      def phash(bytes)
+        post("/phash", bytes).fetch("phash")
+      end
+
+      def scan(bytes)
+        post("/scan", bytes)
+      end
+
+      private
+
+      def post(path, bytes)
+        uri = @base.dup
+        uri.path = path
+        response = Net::HTTP.start(
+          uri.host,
+          uri.port,
+          use_ssl: uri.scheme == "https",
+          open_timeout: 5,
+          read_timeout: 60
+        ) do |http|
+          request = Net::HTTP::Post.new(uri)
+          request.body = bytes
+          request["Content-Type"] = "application/octet-stream"
+          http.request(request)
+        end
+        unless response.code.to_i.between?(200, 299)
+          raise Error, "OCR sidecar responded with #{response.code}"
+        end
+
+        JSON.parse(response.body)
+      rescue Net::OpenTimeout, Net::ReadTimeout, SocketError, JSON::ParserError => e
+        raise Error, e.message
+      end
+    end
+  end
+end

--- a/app/plugins/moderation/ocr/error.rb
+++ b/app/plugins/moderation/ocr/error.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Moderation
+  module Ocr
+    class Error < StandardError; end
+  end
+end

--- a/app/plugins/moderation/scam_rules.rb
+++ b/app/plugins/moderation/scam_rules.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Moderation
+  module ScamRules
+    RULES = [
+      {pattern: "tuzawin", weight: 3, regex: false},
+      {pattern: "5[\\s,]?600", weight: 3, regex: true},
+      {pattern: "cryptocurrency", weight: 3, regex: false},
+      {pattern: "promo code", weight: 3, regex: false},
+      {pattern: "withdraw", weight: 3, regex: false},
+      {pattern: "usdt", weight: 3, regex: false},
+      {pattern: "withdrawal success", weight: 3, regex: false},
+      {pattern: "tether", weight: 3, regex: false},
+      {pattern: "vyro", weight: 2, regex: false},
+      {pattern: "casino", weight: 2, regex: false},
+      {pattern: "wallet address", weight: 2, regex: false},
+      {pattern: "receive usdt", weight: 2, regex: false}
+    ].freeze
+  end
+end

--- a/app/plugins/moderation/scan_context.rb
+++ b/app/plugins/moderation/scan_context.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Moderation
+  ScanContext = Data.define(
+    :bot,
+    :server,
+    :member,
+    :channel_id,
+    :message_id,
+    :attachment_url,
+    :signals,
+    :settings
+  )
+end

--- a/app/plugins/moderation/scan_processor.rb
+++ b/app/plugins/moderation/scan_processor.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "net/http"
+require "uri"
+
+module Moderation
+  module ScanProcessor
+    module_function
+
+    def call(context)
+      bytes = download(context.attachment_url)
+      result = Ocr::Client.new.scan(bytes)
+      verdict = Classifier.call(
+        ocr_text: result["text"],
+        hash_state: :none,
+        signals: context.signals,
+        settings: context.settings
+      )
+      VerdictExecutor.call(verdict:, context:)
+    rescue Ocr::Error => e
+      Rails.logger.warn("[Moderation::ScanProcessor] scan failed: #{e.class}: #{e.message}")
+    end
+
+    def download(attachment_url)
+      uri = URI(attachment_url)
+      Net::HTTP.start(
+        uri.host,
+        uri.port,
+        use_ssl: uri.scheme == "https",
+        open_timeout: 5,
+        read_timeout: 30
+      ) do |http|
+        response = http.get(uri)
+        unless response.code.to_i.between?(200, 299)
+          raise Ocr::Error, "attachment download failed: #{response.code}"
+        end
+
+        response.body
+      end
+    rescue Net::OpenTimeout, Net::ReadTimeout, SocketError => e
+      raise Ocr::Error, e.message
+    end
+
+    private_class_method :download
+  end
+end

--- a/app/plugins/moderation/scan_queue.rb
+++ b/app/plugins/moderation/scan_queue.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Moderation
+  class ScanQueue
+    INSTANCE_MUTEX = Mutex.new
+
+    def self.instance
+      INSTANCE_MUTEX.synchronize { @instance ||= new }
+    end
+
+    def self.enqueue(job)
+      instance.enqueue(job)
+    end
+
+    def initialize(size: 10, workers: 2)
+      @queue = SizedQueue.new(size)
+      @workers = workers
+      @mutex = Mutex.new
+      @started = false
+    end
+
+    def enqueue(job)
+      ensure_workers
+      @queue.push(job, true)
+    rescue ThreadError
+      Rails.logger.warn("[Moderation::ScanQueue] queue full, dropping scan job")
+    end
+
+    private
+
+    def ensure_workers
+      @mutex.synchronize do
+        return if @started
+        @started = true
+        @workers.times { spawn_worker }
+      end
+    end
+
+    def spawn_worker
+      Thread.new do
+        loop do
+          job = @queue.pop
+          job.call
+        rescue => e
+          Rails.logger.error("[Moderation::ScanQueue] worker crashed: #{e.class}: #{e.message}")
+        end
+      end
+    end
+  end
+end

--- a/app/plugins/moderation/signals.rb
+++ b/app/plugins/moderation/signals.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Moderation
+  module Signals
+    module_function
+
+    DISCORD_EPOCH_MS = 1_420_070_400_000
+    LINK_PATTERN = %r{https?://}i
+
+    def call(author:, content:, server_id:)
+      {
+        account_age_days: account_age_days(author.id),
+        has_link: LINK_PATTERN.match?(content.to_s),
+        has_role: author.roles.any? { |role| role.id != server_id }
+      }
+    end
+
+    def account_age_days(discord_id)
+      created_ms = (discord_id >> 22) + DISCORD_EPOCH_MS
+      ((Time.current.to_f * 1000) - created_ms) / 86_400_000.0
+    end
+    private_class_method :account_age_days
+  end
+end

--- a/app/plugins/moderation/staff_ping.rb
+++ b/app/plugins/moderation/staff_ping.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Moderation
+  module StaffPing
+    module_function
+
+    def prefix(staff_role_id)
+      staff_role_id ? "<@&#{staff_role_id}> " : ""
+    end
+  end
+end

--- a/app/plugins/moderation/verdict.rb
+++ b/app/plugins/moderation/verdict.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Moderation
+  Verdict = Data.define(:action, :risk, :reasons)
+end

--- a/app/plugins/moderation/verdict_executor.rb
+++ b/app/plugins/moderation/verdict_executor.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Moderation
+  module VerdictExecutor
+    module_function
+
+    def call(verdict:, context:)
+      case verdict.action
+      when :flag_for_review
+        flag(verdict, context, removed: false)
+      when :remove
+        delete_message(context) if context.settings.action == "delete"
+        punish(context)
+        flag(verdict, context, removed: true)
+      end
+    end
+
+    def delete_message(context)
+      context.bot.channel(context.channel_id)&.delete_message(context.message_id)
+    rescue => e
+      Rails.logger.warn("[Moderation::VerdictExecutor] delete failed in ##{context.channel_id}: #{e.class}: #{e.message}")
+    end
+
+    def punish(context)
+      return if context.settings.punishment == "none"
+
+      Punisher.call(
+        member: context.member,
+        server: context.server,
+        punishment: context.settings.punishment,
+        timeout_seconds: context.settings.timeout_seconds,
+        reason: I18n.t("moderation.image_scanning.punishment.reason")
+      )
+    end
+
+    def flag(verdict, context, removed:)
+      config = context.settings.server_configuration
+      staff_role_id = config.moderation_settings.staff_role_id
+      state = removed ? "removed" : "flagged"
+
+      ActivityLog.post(
+        config,
+        bot: context.bot,
+        title: I18n.t("moderation.image_scanning.flag.title.#{state}"),
+        body: StaffPing.prefix(staff_role_id) + I18n.t(
+          "moderation.image_scanning.flag.body",
+          author: "<@#{context.member.id}>",
+          channel: "<##{context.channel_id}>",
+          jump_url: jump_url(context),
+          risk: verdict.risk.round(1),
+          reasons: format_reasons(verdict.reasons)
+        ),
+        meta: I18n.t("moderation.image_scanning.flag.meta.#{state}"),
+        image_url: context.attachment_url,
+        allowed_mentions: {parse: [], roles: [staff_role_id].compact}
+      )
+    end
+
+    def jump_url(context)
+      "https://discord.com/channels/#{context.server.id}/#{context.channel_id}/#{context.message_id}"
+    end
+
+    def format_reasons(reasons)
+      reasons.map { |reason| reason.to_s.tr("_", " ") }.join(", ")
+    end
+
+    private_class_method :delete_message, :punish, :flag, :jump_url, :format_reasons
+  end
+end

--- a/config/locales/moderation.en.yml
+++ b/config/locales/moderation.en.yml
@@ -1,6 +1,18 @@
 ---
 en:
   moderation:
+    image_scanning:
+      flag:
+        body: "%{author} posted an image in %{channel}. [Jump to message](%{jump_url}).
+          Risk %{risk}: %{reasons}."
+        meta:
+          flagged: Flagged for review — no automatic action taken.
+          removed: The message was deleted automatically.
+        title:
+          flagged: Possible scam image flagged for review
+          removed: Scam image removed
+      punishment:
+        reason: Scam image detected
     spam_protection:
       notification:
         body: "%{author} posted the same message in %{count} channels: %{channels}."

--- a/spec/bot/activity_log_spec.rb
+++ b/spec/bot/activity_log_spec.rb
@@ -48,6 +48,28 @@ RSpec.describe ActivityLog do
       post
     end
 
+    context "with an image_url" do
+      subject(:post) do
+        described_class.post(
+          server_config,
+          bot:,
+          title: "Scam image removed",
+          body: "<@42> posted an image.",
+          meta: "The message was deleted automatically.",
+          image_url: "https://cdn.example/scam.png"
+        )
+      end
+
+      it "appends a media gallery block pointing at the image" do
+        expect(channel).to receive(:send_message) do |*args|
+          blocks = args[6].first[:components]
+          gallery = blocks.find { |block| block[:type] == Discord::Components::MEDIA_GALLERY }
+          expect(gallery[:items]).to eq([{media: {url: "https://cdn.example/scam.png"}}])
+        end
+        post
+      end
+    end
+
     context "when no logging channel is set" do
       before do
         server_config.logging_setting.update!(channel_id: nil)

--- a/spec/plugins/moderation/classifier_spec.rb
+++ b/spec/plugins/moderation/classifier_spec.rb
@@ -1,0 +1,312 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Moderation::Classifier do
+  subject(:verdict) do
+    described_class.call(
+      ocr_text:,
+      hash_state:,
+      signals:,
+      settings:
+    )
+  end
+
+  let(:ocr_text) { "" }
+  let(:hash_state) { :none }
+  let(:signals) { {account_age_days: 365, has_link: false, has_role: true} }
+  let(:sensitivity) { "standard" }
+  let(:custom_keywords) { [] }
+  let(:custom_keyword_min_hits) { 1 }
+  let(:settings) do
+    instance_double(
+      "Settings",
+      sensitivity:,
+      custom_keywords:,
+      custom_keyword_min_hits:
+    )
+  end
+
+  context "content-signal lock with only amplifier signals" do
+    let(:ocr_text) { "hello friends nice weather" }
+    let(:signals) { {account_age_days: 1, has_link: true, has_role: false} }
+
+    it "allows despite amplifier-driven risk" do
+      expect(verdict.action).to eq(:allow)
+    end
+
+    it "still accumulates amplifier risk" do
+      expect(verdict.risk).to eq(3.5)
+    end
+  end
+
+  context "clear scam text on standard sensitivity" do
+    let(:ocr_text) { "promo code withdraw tuzawin" }
+
+    it "removes" do
+      expect(verdict.action).to eq(:remove)
+    end
+  end
+
+  describe "sensitivity presets" do
+    context "relaxed (flag 5, remove 8)" do
+      let(:sensitivity) { "relaxed" }
+
+      context "score 4" do
+        let(:ocr_text) { "casino vyro" }
+
+        it "allows below flag" do
+          expect(verdict.action).to eq(:allow)
+        end
+      end
+
+      context "score 5" do
+        let(:ocr_text) { "casino withdraw" }
+
+        it "flags at threshold" do
+          expect(verdict.action).to eq(:flag_for_review)
+        end
+      end
+
+      context "score 8" do
+        let(:ocr_text) { "casino withdraw tuzawin" }
+
+        it "removes at threshold" do
+          expect(verdict.action).to eq(:remove)
+        end
+      end
+    end
+
+    context "standard (flag 3, remove 6)" do
+      let(:sensitivity) { "standard" }
+
+      context "score 2" do
+        let(:ocr_text) { "casino" }
+
+        it "allows below flag" do
+          expect(verdict.action).to eq(:allow)
+        end
+      end
+
+      context "score 4" do
+        let(:ocr_text) { "casino vyro" }
+
+        it "flags between thresholds" do
+          expect(verdict.action).to eq(:flag_for_review)
+        end
+      end
+
+      context "score 6" do
+        let(:ocr_text) { "withdraw tuzawin" }
+
+        it "removes at threshold" do
+          expect(verdict.action).to eq(:remove)
+        end
+      end
+    end
+
+    context "strict (flag 2, remove 4.5)" do
+      let(:sensitivity) { "strict" }
+
+      context "score 2" do
+        let(:ocr_text) { "casino" }
+
+        it "flags at threshold" do
+          expect(verdict.action).to eq(:flag_for_review)
+        end
+      end
+
+      context "score 4" do
+        let(:ocr_text) { "casino vyro" }
+
+        it "flags below remove" do
+          expect(verdict.action).to eq(:flag_for_review)
+        end
+      end
+
+      context "score 5" do
+        let(:ocr_text) { "casino withdraw" }
+
+        it "removes above threshold" do
+          expect(verdict.action).to eq(:remove)
+        end
+      end
+    end
+  end
+
+  describe "amplifiers" do
+    let(:ocr_text) { "casino" }
+
+    context "new account" do
+      let(:signals) { {account_age_days: 1, has_link: false, has_role: true} }
+
+      it "adds 2 to risk" do
+        expect(verdict.risk).to eq(4)
+      end
+
+      it "records the reason" do
+        expect(verdict.reasons).to include(:new_account)
+      end
+    end
+
+    context "has link" do
+      let(:signals) { {account_age_days: 365, has_link: true, has_role: true} }
+
+      it "adds 1 to risk" do
+        expect(verdict.risk).to eq(3)
+      end
+
+      it "records the reason" do
+        expect(verdict.reasons).to include(:has_link)
+      end
+    end
+
+    context "no role" do
+      let(:signals) { {account_age_days: 365, has_link: false, has_role: false} }
+
+      it "adds 0.5 to risk" do
+        expect(verdict.risk).to eq(2.5)
+      end
+
+      it "records the reason" do
+        expect(verdict.reasons).to include(:no_role)
+      end
+    end
+
+    context "aged account with role and no link" do
+      it "adds no amplifier risk" do
+        expect(verdict.risk).to eq(2)
+      end
+    end
+  end
+
+  describe "custom keywords" do
+    let(:ocr_text) { "join our discord group chat" }
+    let(:custom_keywords) { ["discord"] }
+
+    context "hits meet the minimum" do
+      let(:custom_keyword_min_hits) { 1 }
+
+      it "adds 2 per hit" do
+        expect(verdict.risk).to eq(2)
+      end
+
+      it "records the reason" do
+        expect(verdict.reasons).to include(:custom_keywords)
+      end
+
+      it "floors the verdict at flag even when the score is below the flag threshold" do
+        expect(verdict.action).to eq(:flag_for_review)
+      end
+    end
+
+    context "hits below the minimum" do
+      let(:custom_keyword_min_hits) { 2 }
+
+      it "contributes nothing" do
+        expect(verdict.risk).to eq(0)
+      end
+
+      it "produces no content signal" do
+        expect(verdict.action).to eq(:allow)
+      end
+    end
+
+    context "phrase keyword" do
+      let(:ocr_text) { "join our private group today" }
+      let(:custom_keywords) { ["private group"] }
+
+      it "matches multi-word keywords" do
+        expect(verdict.reasons).to include(:custom_keywords)
+      end
+    end
+
+    context "fuzzy keyword variant" do
+      let(:ocr_text) { "join telegran now" }
+      let(:custom_keywords) { ["telegram"] }
+
+      it "matches a typo variant" do
+        expect(verdict.reasons).to include(:custom_keywords)
+      end
+    end
+
+    context "empty keyword list" do
+      let(:custom_keywords) { [] }
+
+      it "contributes no keyword risk" do
+        expect(verdict.risk).to eq(0)
+      end
+    end
+
+    context "multiple hits" do
+      let(:ocr_text) { "discord telegram group" }
+      let(:custom_keywords) { ["discord", "telegram"] }
+      let(:custom_keyword_min_hits) { 2 }
+
+      it "adds 2 per hit" do
+        expect(verdict.risk).to eq(4)
+      end
+    end
+  end
+
+  describe "hash state" do
+    context "foreign-hash cap" do
+      let(:hash_state) { :foreign_confirmed }
+      let(:ocr_text) { "promo code withdraw tuzawin" }
+
+      it "caps at flag despite reaching remove risk" do
+        expect(verdict.action).to eq(:flag_for_review)
+      end
+
+      it "never removes" do
+        expect(verdict.action).not_to eq(:remove)
+      end
+    end
+
+    context "own_confirmed" do
+      let(:hash_state) { :own_confirmed }
+
+      it "adds 6 to risk" do
+        expect(verdict.risk).to eq(6)
+      end
+
+      context "standard sensitivity with empty ocr text" do
+        let(:sensitivity) { "standard" }
+
+        it "removes on the hash content signal" do
+          expect(verdict.action).to eq(:remove)
+        end
+      end
+
+      context "strict sensitivity with empty ocr text" do
+        let(:sensitivity) { "strict" }
+
+        it "removes on the hash content signal" do
+          expect(verdict.action).to eq(:remove)
+        end
+      end
+
+      context "relaxed sensitivity alone" do
+        let(:sensitivity) { "relaxed" }
+
+        it "flags below the remove threshold" do
+          expect(verdict.action).to eq(:flag_for_review)
+        end
+      end
+    end
+
+    context "foreign_confirmed with amplifier-only risk" do
+      let(:hash_state) { :foreign_confirmed }
+      let(:sensitivity) { "strict" }
+      let(:signals) { {account_age_days: 1, has_link: true, has_role: false} }
+
+      it "does not remove without ocr score or own hash" do
+        expect(verdict.action).not_to eq(:remove)
+      end
+
+      it "flags instead" do
+        expect(verdict.action).to eq(:flag_for_review)
+      end
+    end
+  end
+end

--- a/spec/plugins/moderation/events/image_scan_spec.rb
+++ b/spec/plugins/moderation/events/image_scan_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Moderation::ImageScan do
+  subject(:handle) { described_class.new(event).handle }
+
+  let(:guild_id) { 111 }
+  let(:author_id) { 222 }
+
+  let(:server) { double("server", id: guild_id) }
+  let(:author) { double("author", id: author_id) }
+  let(:attachments) { [image_attachment] }
+  let(:message) { double("message", id: 1, webhook?: false, content: "hello", attachments:) }
+  let(:channel) { double("channel", id: 1, pm?: false) }
+  let(:bot) { double("bot") }
+  let(:event) { double("event", from_bot?: false, server:, author:, message:, channel:, bot:) }
+
+  let(:settings) { double("settings") }
+  let(:signals) { {account_age_days: 2, has_link: false, has_role: false} }
+
+  let(:image_attachment) { double("att", content_type: "image/png", size: 1234, url: "https://cdn/x.png") }
+
+  before do
+    allow(Moderation::ImageScanning::Settings).to receive(:active_for).with(guild_id).and_return(settings)
+    allow(Moderation::Signals).to receive(:call).and_return(signals)
+    allow(Moderation::ScanQueue).to receive(:enqueue)
+  end
+
+  context "when the message is from a bot" do
+    before { allow(event).to receive(:from_bot?).and_return(true) }
+
+    it "skips processing" do
+      expect(Moderation::ImageScanning::Settings).not_to receive(:active_for)
+      expect(Moderation::ScanQueue).not_to receive(:enqueue)
+      handle
+    end
+  end
+
+  context "when the message is a webhook" do
+    before { allow(message).to receive(:webhook?).and_return(true) }
+
+    it "skips processing" do
+      expect(Moderation::ImageScanning::Settings).not_to receive(:active_for)
+      expect(Moderation::ScanQueue).not_to receive(:enqueue)
+      handle
+    end
+  end
+
+  context "when the channel is a DM" do
+    before { allow(channel).to receive(:pm?).and_return(true) }
+
+    it "skips processing" do
+      expect(Moderation::ImageScanning::Settings).not_to receive(:active_for)
+      expect(Moderation::ScanQueue).not_to receive(:enqueue)
+      handle
+    end
+  end
+
+  context "when image scanning is inactive" do
+    before { allow(Moderation::ImageScanning::Settings).to receive(:active_for).and_return(nil) }
+
+    it "does not enqueue" do
+      expect(Moderation::ScanQueue).not_to receive(:enqueue)
+      handle
+    end
+  end
+
+  context "when there are no image attachments" do
+    let(:attachments) { [] }
+
+    it "does not enqueue" do
+      expect(Moderation::ScanQueue).not_to receive(:enqueue)
+      handle
+    end
+  end
+
+  context "when an attachment has a non-image content type" do
+    let(:attachments) { [double("att", content_type: "application/pdf", size: 1234, url: "https://cdn/x.pdf")] }
+
+    it "skips it and does not enqueue" do
+      expect(Moderation::ScanQueue).not_to receive(:enqueue)
+      handle
+    end
+  end
+
+  context "when an attachment is oversized" do
+    let(:attachments) do
+      [double("att", content_type: "image/png", size: 11 * 1024 * 1024, url: "https://cdn/big.png")]
+    end
+
+    it "skips it and does not enqueue" do
+      expect(Moderation::ScanQueue).not_to receive(:enqueue)
+      handle
+    end
+  end
+
+  context "when there are more eligible attachments than the cap" do
+    let(:attachments) do
+      Array.new(5) { |i| double("att#{i}", content_type: "image/png", size: 1234, url: "https://cdn/#{i}.png") }
+    end
+
+    it "enqueues at most MAX_ATTACHMENTS processors" do
+      expect(Moderation::ScanQueue).to receive(:enqueue).with(kind_of(Proc)).exactly(3).times
+      handle
+    end
+  end
+
+  context "with a single valid image" do
+    it "computes signals and enqueues one processor" do
+      expect(Moderation::Signals).to receive(:call).with(author:, content: "hello", server_id: guild_id).and_return(signals)
+      expect(Moderation::ScanQueue).to receive(:enqueue).with(kind_of(Proc)).once
+      handle
+    end
+  end
+end

--- a/spec/plugins/moderation/fuzzy_matcher_spec.rb
+++ b/spec/plugins/moderation/fuzzy_matcher_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Moderation::FuzzyMatcher do
+  describe ".match?" do
+    fixture = JSON.parse(File.read(Rails.root.join("spec/fixtures/fuzzy_vectors.json")))
+
+    fixture.each do |vector|
+      description = vector["note"] || "#{vector["pattern"].inspect} vs #{vector["text"].inspect} → #{vector["expected"]}"
+
+      it description do
+        pattern = vector["regex"] ? Regexp.new(vector["pattern"]) : vector["pattern"]
+
+        expect(described_class.match?(pattern, vector["text"], ratio: vector["ratio"])).to eq(vector["expected"])
+      end
+    end
+
+    context "exact substring" do
+      it "returns true without computing distance" do
+        expect(described_class.match?("code", "promo code here")).to be(true)
+      end
+    end
+
+    context "single edit within tolerance" do
+      it "matches a one-character typo" do
+        expect(described_class.match?("tuzawin", "visit tuzowin now", ratio: 0.2)).to be(true)
+      end
+    end
+
+    context "distance exceeds tolerance" do
+      it "rejects too many edits" do
+        expect(described_class.match?("withdrawal", "xxxxxxxxxx", ratio: 0.2)).to be(false)
+      end
+    end
+
+    context "regex pattern" do
+      it "delegates to Regexp#match?" do
+        expect(described_class.match?(/\bbet\b/, "place your bet now")).to be(true)
+      end
+    end
+
+    context "ratio floors to zero" do
+      it "requires an exact match for short patterns" do
+        expect(described_class.match?("bet", "bat", ratio: 0.2)).to be(false)
+      end
+    end
+
+    context "empty text" do
+      it "cannot match a non-empty pattern" do
+        expect(described_class.match?("hello", "", ratio: 0.2)).to be(false)
+      end
+    end
+  end
+end

--- a/spec/plugins/moderation/ocr/client_spec.rb
+++ b/spec/plugins/moderation/ocr/client_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Moderation::Ocr::Client do
+  subject(:client) { described_class.new }
+
+  let(:response) { double(code: "200", body: response_body) }
+  let(:response_body) { {"phash" => "0123456789abcdef"}.to_json }
+  let(:http) { double }
+
+  before do
+    allow(ENV).to receive(:fetch).with("OCR_URL").and_return("http://ocr:8000")
+    allow(Net::HTTP).to receive(:start).and_yield(http).and_return(response)
+    allow(http).to receive(:request).and_return(response)
+  end
+
+  describe "#phash" do
+    it "returns the hex string from the parsed body" do
+      expect(client.phash("bytes")).to eq("0123456789abcdef")
+    end
+  end
+
+  describe "#scan" do
+    let(:response_body) do
+      {
+        "text" => "hello",
+        "mean_conf" => 0.9,
+        "n_boxes" => 3,
+        "phash" => "0123456789abcdef"
+      }.to_json
+    end
+
+    it "returns the parsed hash" do
+      expect(client.scan("bytes")).to eq(
+        "text" => "hello",
+        "mean_conf" => 0.9,
+        "n_boxes" => 3,
+        "phash" => "0123456789abcdef"
+      )
+    end
+  end
+
+  context "when the sidecar responds with a non-2xx status" do
+    let(:response) { double(code: "500", body: "boom") }
+
+    it "raises Moderation::Ocr::Error" do
+      expect { client.phash("bytes") }.to raise_error(Moderation::Ocr::Error, /500/)
+    end
+  end
+
+  context "when the request times out" do
+    before do
+      allow(http).to receive(:request).and_raise(Net::ReadTimeout)
+    end
+
+    it "raises Moderation::Ocr::Error" do
+      expect { client.phash("bytes") }.to raise_error(Moderation::Ocr::Error)
+    end
+  end
+
+  context "when the body is malformed JSON" do
+    let(:response) { double(code: "200", body: "not json") }
+
+    it "raises Moderation::Ocr::Error" do
+      expect { client.phash("bytes") }.to raise_error(Moderation::Ocr::Error)
+    end
+  end
+end

--- a/spec/plugins/moderation/scan_processor_spec.rb
+++ b/spec/plugins/moderation/scan_processor_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Moderation::ScanProcessor do
+  subject(:process) { described_class.call(context) }
+
+  let(:signals) { {account_age_days: 2, has_link: true, has_role: false} }
+  let(:settings) { double("settings") }
+  let(:context) do
+    Moderation::ScanContext.new(
+      bot: double("bot"),
+      server: double("server", id: 1),
+      member: double("member", id: 2),
+      channel_id: 3,
+      message_id: 4,
+      attachment_url: "https://cdn/x.png",
+      signals:,
+      settings:
+    )
+  end
+
+  let(:client_double) { double("client") }
+  let(:verdict) { Moderation::Verdict.new(action: :allow, risk: 0.0, reasons: []) }
+  let(:http) { double("http") }
+  let(:response) { double("response", code: "200", body: "bytes") }
+
+  before do
+    allow(Net::HTTP).to receive(:start) { |*_args, &block| block.call(http) }
+    allow(http).to receive(:get).and_return(response)
+    allow(Moderation::Ocr::Client).to receive(:new).and_return(client_double)
+    allow(client_double).to receive(:scan).with("bytes").and_return({"text" => "won usdt bonus"})
+    allow(Moderation::Classifier).to receive(:call).and_return(verdict)
+    allow(Moderation::VerdictExecutor).to receive(:call)
+  end
+
+  context "on the happy path" do
+    it "classifies the OCR text and hands the verdict to the executor" do
+      process
+
+      expect(Moderation::Classifier).to have_received(:call).with(
+        ocr_text: "won usdt bonus",
+        hash_state: :none,
+        signals:,
+        settings:
+      )
+      expect(Moderation::VerdictExecutor).to have_received(:call).with(verdict:, context:)
+    end
+  end
+
+  context "when the OCR scan raises an Ocr::Error" do
+    before do
+      allow(client_double).to receive(:scan).and_raise(Moderation::Ocr::Error, "boom")
+    end
+
+    it "rescues without raising and does not run the executor" do
+      expect { process }.not_to raise_error
+      expect(Moderation::VerdictExecutor).not_to have_received(:call)
+    end
+  end
+
+  context "when the attachment download returns a non-success status" do
+    let(:response) { double("response", code: "404", body: "") }
+
+    it "rescues without raising and does not run the executor" do
+      expect { process }.not_to raise_error
+      expect(Moderation::VerdictExecutor).not_to have_received(:call)
+    end
+  end
+
+  context "when the attachment download connection fails" do
+    before do
+      allow(Net::HTTP).to receive(:start).and_raise(SocketError, "no dns")
+    end
+
+    it "rescues without raising and does not run the executor" do
+      expect { process }.not_to raise_error
+      expect(Moderation::VerdictExecutor).not_to have_received(:call)
+    end
+  end
+end

--- a/spec/plugins/moderation/scan_queue_spec.rb
+++ b/spec/plugins/moderation/scan_queue_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "timeout"
+
+RSpec.describe Moderation::ScanQueue do
+  describe "dropping jobs when the queue is full" do
+    subject(:queue) { described_class.new(size: 1, workers: 1) }
+
+    let(:ready) { Queue.new }
+    let(:release) { Queue.new }
+    let(:ran) { Queue.new }
+
+    let(:blocking_job) do
+      lambda do
+        ready << :running
+        release.pop
+      end
+    end
+
+    let(:filler_job) { lambda { release.pop } }
+    let(:dropped_job) { lambda { ran << :ran } }
+
+    after do
+      release << :go
+      release << :go
+    end
+
+    it "logs and drops the job instead of running it" do
+      allow(Rails.logger).to receive(:warn)
+
+      queue.enqueue(blocking_job)
+      Timeout.timeout(2) { ready.pop }
+
+      queue.enqueue(filler_job)
+
+      expect(Rails.logger).to receive(:warn).with(/queue full/)
+      queue.enqueue(dropped_job)
+
+      expect(ran).to be_empty
+    end
+  end
+
+  describe ".instance" do
+    it "memoizes a single process-wide instance" do
+      expect(described_class.instance).to be_a(described_class)
+      expect(described_class.instance).to equal(described_class.instance)
+    end
+  end
+
+  describe ".enqueue" do
+    let(:singleton) { instance_double(described_class, enqueue: nil) }
+
+    before { allow(described_class).to receive(:instance).and_return(singleton) }
+
+    it "delegates to the singleton instance so callers need not reach for .instance" do
+      job = -> {}
+      described_class.enqueue(job)
+      expect(singleton).to have_received(:enqueue).with(job)
+    end
+  end
+
+  describe "isolating worker crashes" do
+    subject(:queue) { described_class.new(size: 5, workers: 1) }
+
+    let(:done) { Queue.new }
+    let(:crashing_job) { lambda { raise "boom" } }
+    let(:surviving_job) { lambda { done << :ok } }
+
+    before do
+      allow(Rails.logger).to receive(:error)
+    end
+
+    it "keeps the worker alive after a job raises" do
+      queue.enqueue(crashing_job)
+      queue.enqueue(surviving_job)
+
+      expect(Timeout.timeout(2) { done.pop }).to eq(:ok)
+    end
+  end
+end

--- a/spec/plugins/moderation/signals_spec.rb
+++ b/spec/plugins/moderation/signals_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Moderation::Signals do
+  subject(:signals) { described_class.call(author:, content:, server_id:) }
+
+  let(:server_id) { 100 }
+  let(:everyone_role) { double(id: 100) }
+  let(:extra_role) { double(id: 200) }
+  let(:roles) { [everyone_role] }
+  let(:discord_id) { fresh_snowflake }
+  let(:content) { "no links here" }
+  let(:author) { double(id: discord_id, roles:) }
+
+  def fresh_snowflake
+    ((Time.current.to_f * 1000 - described_class::DISCORD_EPOCH_MS).to_i << 22)
+  end
+
+  describe "account_age_days" do
+    context "with a freshly created account" do
+      it "is approximately zero days old" do
+        expect(signals[:account_age_days]).to be_within(0.01).of(0.0)
+      end
+    end
+
+    context "with a very old snowflake" do
+      let(:discord_id) { 4_194_304 }
+
+      it "is a large positive number of days" do
+        expect(signals[:account_age_days]).to be > 2000
+      end
+    end
+  end
+
+  describe "has_link" do
+    context "with a link in the content" do
+      let(:content) { "check https://x.com" }
+
+      it "is true" do
+        expect(signals[:has_link]).to be(true)
+      end
+    end
+
+    context "without a link" do
+      let(:content) { "no links here" }
+
+      it "is false" do
+        expect(signals[:has_link]).to be(false)
+      end
+    end
+  end
+
+  describe "has_role" do
+    context "with only the @everyone role" do
+      let(:roles) { [everyone_role] }
+
+      it "is false" do
+        expect(signals[:has_role]).to be(false)
+      end
+    end
+
+    context "with an extra role" do
+      let(:roles) { [everyone_role, extra_role] }
+
+      it "is true" do
+        expect(signals[:has_role]).to be(true)
+      end
+    end
+  end
+end

--- a/spec/plugins/moderation/staff_ping_spec.rb
+++ b/spec/plugins/moderation/staff_ping_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Moderation::StaffPing do
+  subject(:prefix) { described_class.prefix(staff_role_id) }
+
+  context "with a staff role id" do
+    let(:staff_role_id) { 123 }
+
+    it "renders a role mention with a trailing space" do
+      expect(prefix).to eq("<@&123> ")
+    end
+  end
+
+  context "without a staff role id" do
+    let(:staff_role_id) { nil }
+
+    it "renders an empty string" do
+      expect(prefix).to eq("")
+    end
+  end
+end

--- a/spec/plugins/moderation/verdict_executor_spec.rb
+++ b/spec/plugins/moderation/verdict_executor_spec.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Moderation::VerdictExecutor do
+  subject(:execute) { described_class.call(verdict:, context:) }
+
+  let(:server_id) { 111 }
+  let(:member_id) { 222 }
+  let(:staff_role_id) { 333 }
+  let(:channel_id) { 444 }
+  let(:message_id) { 555 }
+  let(:attachment_url) { "https://cdn/x.png" }
+
+  let(:server) { double("server", id: server_id) }
+  let(:member) { double("member", id: member_id) }
+  let(:message_channel) { double("message_channel", delete_message: nil) }
+  let(:bot) { double("bot", channel: message_channel) }
+
+  let(:logging_setting) { double("logging_setting", channel_id: channel_id) }
+  let(:moderation_settings) { double("moderation_settings", staff_role_id:) }
+  let(:server_configuration) do
+    double(
+      "server_configuration",
+      logging_setting:,
+      moderation_settings:
+    )
+  end
+
+  let(:settings_action) { "delete" }
+  let(:punishment) { "none" }
+  let(:settings) do
+    double(
+      "settings",
+      action: settings_action,
+      punishment:,
+      timeout_seconds: 300,
+      server_configuration:
+    )
+  end
+
+  let(:context) do
+    Moderation::ScanContext.new(
+      bot:,
+      server:,
+      member:,
+      channel_id:,
+      message_id:,
+      attachment_url:,
+      signals: {},
+      settings:
+    )
+  end
+
+  let(:action) { :remove }
+  let(:verdict) { Moderation::Verdict.new(action:, risk: 7.0, reasons: [:new_account, "usdt"]) }
+
+  before do
+    allow(ActivityLog).to receive(:post)
+    allow(Moderation::Punisher).to receive(:call)
+  end
+
+  context "when the action is :allow" do
+    let(:action) { :allow }
+
+    it "does not log, delete, or punish" do
+      expect(ActivityLog).not_to receive(:post)
+      expect(bot).not_to receive(:channel)
+      expect(Moderation::Punisher).not_to receive(:call)
+      execute
+    end
+  end
+
+  context "when the action is :flag_for_review" do
+    let(:action) { :flag_for_review }
+
+    it "logs the image with the flagged title and the staff role in allowed_mentions" do
+      execute
+
+      expect(ActivityLog).to have_received(:post).with(
+        server_configuration,
+        hash_including(
+          title: I18n.t("moderation.image_scanning.flag.title.flagged"),
+          image_url: attachment_url,
+          allowed_mentions: {parse: [], roles: [staff_role_id]}
+        )
+      )
+    end
+
+    it "does not delete or punish" do
+      expect(bot).not_to receive(:channel)
+      expect(Moderation::Punisher).not_to receive(:call)
+      execute
+    end
+  end
+
+  context "when the action is :remove with settings.action 'delete'" do
+    let(:settings_action) { "delete" }
+
+    it "deletes the message and logs the removed title" do
+      execute
+
+      expect(bot).to have_received(:channel).with(channel_id)
+      expect(message_channel).to have_received(:delete_message).with(message_id)
+      expect(ActivityLog).to have_received(:post).with(
+        server_configuration,
+        hash_including(title: I18n.t("moderation.image_scanning.flag.title.removed"))
+      )
+    end
+
+    context "when the message channel no longer exists" do
+      let(:bot) { double("bot", channel: nil) }
+
+      it "does not raise and still logs" do
+        expect { execute }.not_to raise_error
+        expect(ActivityLog).to have_received(:post)
+      end
+    end
+
+    context "when deleting the message fails" do
+      before do
+        allow(message_channel).to receive(:delete_message).and_raise(RuntimeError, "forbidden")
+      end
+
+      it "rescues the failure and still logs" do
+        expect { execute }.not_to raise_error
+        expect(ActivityLog).to have_received(:post)
+      end
+    end
+  end
+
+  context "when the action is :remove with settings.action 'none'" do
+    let(:settings_action) { "none" }
+    let(:punishment) { "kick" }
+
+    it "does not delete but still logs the removed title" do
+      expect(bot).not_to receive(:channel)
+      execute
+
+      expect(ActivityLog).to have_received(:post).with(
+        server_configuration,
+        hash_including(title: I18n.t("moderation.image_scanning.flag.title.removed"))
+      )
+    end
+
+    it "runs the punish path" do
+      execute
+
+      expect(Moderation::Punisher).to have_received(:call).with(
+        member:,
+        server:,
+        punishment: "kick",
+        timeout_seconds: 300,
+        reason: I18n.t("moderation.image_scanning.punishment.reason")
+      )
+    end
+  end
+
+  context "when the punishment is 'none'" do
+    let(:punishment) { "none" }
+
+    it "does not invoke the punisher" do
+      expect(Moderation::Punisher).not_to receive(:call)
+      execute
+    end
+  end
+
+  context "when no staff role is configured" do
+    let(:staff_role_id) { nil }
+
+    it "logs with empty roles" do
+      execute
+
+      expect(ActivityLog).to have_received(:post).with(
+        server_configuration,
+        hash_including(allowed_mentions: {parse: [], roles: []})
+      )
+    end
+  end
+end


### PR DESCRIPTION
Second sub-plugin feature of the **Server Shield** moderation group (PR 4 of the suite): scans posted images for scam content over the OCR path. **Bot-side only — no perceptual-hash store yet** (that's PR 5); `hash_state` is always `:none` here.

## Flow

```
message (bot process)
  Moderation::ImageScan (on :message)
    eligible image attachments (png/jpeg/webp, ≤10MB, first 3)
    → Signals (account age / link / role, derived in-bot)
    → ScanQueue (SizedQueue, 2 workers, drop-on-full)
        worker: download bytes → Ocr::Client#scan (PaddleOCR sidecar)
          → Classifier (scam rules + custom keywords, amplified, gated by preset)
          → VerdictExecutor: allow / flag_for_review / remove
```

## What's here

- **Pure logic:** `FuzzyMatcher` (Sellers approximate-substring port of the sidecar's Python matcher — driven by the shared `spec/fixtures/fuzzy_vectors.json` so the two stay equivalent), `ScamRules`, `Classifier` (+ `Verdict`), `Signals`, `StaffPing`.
- **Infra:** `Ocr::Client`/`Ocr::Error` (Net::HTTP to the sidecar, `OCR_URL` sourced internally), `ScanQueue` (bounded in-process thread pool, non-blocking push → log-drop on overflow).
- **Wiring:** `ImageScan` event, `ScanContext`, `ScanProcessor`, `VerdictExecutor`. `remove` deletes (when configured) and optionally punishes; both non-allow verdicts post to the logging channel with a staff ping, jump link, risk + reasons and the image embedded.
- **Shared edits:** `ActivityLog.post` gains an optional `image_url:` (Components-V2 media gallery); `Discord::Components.media_gallery`.

## Classifier contract (locked in `BUILD_PLAN.md`)

Content-signal lock (OCR score > 0 or a hash match required for any non-allow); `:foreign_confirmed` capped at flag-for-review; `remove` requires reaching the preset's remove threshold **and** (OCR signal or own-confirmed hash). Encoded as specs.

## Privacy

Nothing new persisted — OCR is in-memory, the queue is in-process. No policy / `Ops::Users::Destroy` / purge changes needed.

## Gates

`rspec` (1180 examples, 0 failures), `standardrb`, `active_record_doctor`, `undercover --compare origin/main`, `i18n-tasks missing`/`check-normalized` — all green locally. Convention-reviewer pass applied (staff-ping extraction, narrowed processor rescue, classifier amplifier extraction, `Signals` takes `server_id:`).

## Note for review

`ScamRules` is seeded faithfully from the bakeoff w2/w3 tokens; a few (e.g. `completed`, `network fee`) are FP-prone and are expected to be pruned during your threshold calibration on your own guilds before public promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)