### PR TITLE
Server Shield config UI

### DIFF
--- a/app/components/app_shell.rb
+++ b/app/components/app_shell.rb
@@ -20,12 +20,15 @@ class Components::AppShell < Components::Base
       if @sidebar
         div(class: "flex flex-1") do
           render @sidebar
-          main(class: "min-w-0 flex-1") { yield }
+          main(class: "flex min-w-0 flex-1 flex-col") do
+            div(class: "flex-1") { yield }
+            footer_bar
+          end
         end
       else
         main(class: "flex-1") { yield }
+        footer_bar
       end
-      footer_bar
     end
   end
 

--- a/app/components/icon.rb
+++ b/app/components/icon.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 
 class Components::Icon < Components::Base
+  CUSTOM_GLYPHS = {
+    "megaphone-slash" => <<~SVG
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" %<attrs>s>
+        <path d="M224,42a8,8,0,0,0-7.94.14L104,112H48A24,24,0,0,0,24,136v8a24,24,0,0,0,24,24H62.2l6.06,29.09A16,16,0,0,0,84,211.64a15.8,15.8,0,0,0,3.37-.36,16,16,0,0,0,12.26-18.94L94.72,168H104l112,69.86A8,8,0,0,0,224,238a8,8,0,0,0,8-8V50A8,8,0,0,0,224,42ZM85.81,196.81,80.22,169H95.09l5.7,27.38A8,8,0,0,1,85.81,196.81ZM40,144v-8a8,8,0,0,1,8-8h56v24H48A8,8,0,0,1,40,144ZM216,219.86,112,153.06V126.94L216,60.14Z"/>
+        <line x1="40" y1="24" x2="216" y2="232" stroke="currentColor" stroke-width="16" stroke-linecap="round"/>
+      </svg>
+    SVG
+  }.freeze
+
   def initialize(name, weight: :regular, **options)
     @name = name.to_s
     @weight = weight
@@ -9,6 +18,17 @@ class Components::Icon < Components::Base
   end
 
   def view_template
-    raw(safe(PhosphorIcons::Icon.new(@name, style: @weight, **@options).to_svg))
+    if CUSTOM_GLYPHS.key?(@name)
+      raw(safe(custom_glyph))
+    else
+      raw(safe(PhosphorIcons::Icon.new(@name, style: @weight, **@options).to_svg))
+    end
+  end
+
+  private
+
+  def custom_glyph
+    attrs_str = @options.map { |k, v| "#{k.to_s.tr("_", "-")}=\"#{v}\"" }.join(" ")
+    CUSTOM_GLYPHS[@name] % {attrs: attrs_str}
   end
 end

--- a/app/components/moderation/config_shell.rb
+++ b/app/components/moderation/config_shell.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+class Components::Moderation::ConfigShell < Components::Base
+  include Phlex::Rails::Helpers::FormWith
+
+  def initialize(header:, server_configuration:, url:, toggle:, gate: nil, breadcrumb_extra: nil)
+    @header = header
+    @server_configuration = server_configuration
+    @url = url
+    @gate = gate
+    @toggle = toggle
+    @breadcrumb_extra = breadcrumb_extra
+  end
+
+  def view_template(&block)
+    div(class: "mx-auto max-w-3xl px-6 pb-28 pt-8") do
+      render Components::Breadcrumb.new(breadcrumb_crumbs)
+      form_with(
+        url: @url,
+        method: :patch,
+        data: form_data
+      ) do
+        page_header
+        body(&block)
+        render Components::SaveBar.new
+      end
+    end
+  end
+
+  private
+
+  def breadcrumb_crumbs
+    base = [
+      {label: t("components.config_page.servers"), href: servers_path},
+      {label: @server_configuration.name || t("components.config_page.dashboard"), href: server_path(@server_configuration.discord_id)},
+      {label: t("views.servers.moderation.show.title"), href: @breadcrumb_extra ? server_moderation_path(@server_configuration.discord_id) : nil}
+    ]
+    base << {label: @breadcrumb_extra} if @breadcrumb_extra
+    base
+  end
+
+  def form_data
+    controllers = ["save-bar"]
+    controllers.unshift("enable-gate") if gate_type == :enable
+    {
+      controller: controllers.join(" "),
+      action: "input->save-bar#check change->save-bar#check turbo:submit-end->save-bar#saved"
+    }
+  end
+
+  def page_header
+    div(class: "mb-6 flex items-start gap-4") do
+      render Components::PluginTile.new(icon: @header.icon, size: :lg)
+      div(class: "flex-1") do
+        div(class: "flex flex-wrap items-center gap-3") do
+          h1(class: "font-display text-2xl font-bold tracking-tight") { @header.title }
+          render Components::Badge.new(variant: :copper) { @header.badge } if @header.badge
+        end
+        p(class: "mt-1 text-sm text-text-secondary") { @header.description }
+      end
+      enable_control
+    end
+  end
+
+  def enable_control
+    div(class: "flex flex-none items-center gap-2.5 pt-1") do
+      if @toggle[:locked]
+        locked_enable_control
+      else
+        interactive_enable_control
+      end
+    end
+  end
+
+  def locked_enable_control
+    span(class: "text-sm font-medium text-text-secondary") do
+      @toggle[:enabled] ? t("components.config_page.enabled") : t("components.config_page.disabled")
+    end
+    render Components::Tooltip.new(text: @toggle[:reason]) do
+      render Components::Toggle.new(
+        name: @toggle[:field],
+        checked: @toggle[:enabled],
+        label: t("components.config_page.enable", plugin: @header.title),
+        disabled: true
+      )
+    end
+  end
+
+  def interactive_enable_control
+    span(
+      class: "text-sm font-medium text-text-secondary",
+      data: enable_gate_type? ? {enable_gate_target: "label", on: t("components.config_page.enabled"), off: t("components.config_page.disabled")} : {}
+    ) { @toggle[:enabled] ? t("components.config_page.enabled") : t("components.config_page.disabled") }
+    render Components::Toggle.new(
+      name: @toggle[:field],
+      checked: @toggle[:enabled],
+      label: t("components.config_page.enable", plugin: @header.title),
+      data: enable_gate_type? ? {enable_gate_target: "toggle", action: "change->enable-gate#update"} : {}
+    )
+  end
+
+  def body(&block)
+    case gate_type
+    when :prereq
+      render Components::PrereqGate.new(
+        title: @gate[:title],
+        message: @gate[:message],
+        cta_label: @gate[:cta_label],
+        cta_href: @gate[:cta_href],
+        icon: @gate[:icon] || "lock"
+      ) { yield }
+    when :enable
+      render Components::EnableGate.new(
+        enabled: @toggle[:enabled],
+        title: t("components.config_page.disabled_title", plugin: @header.title),
+        message: @gate[:message],
+        enable_label: t("components.config_page.enable", plugin: @header.title)
+      ) { yield }
+    else
+      yield
+    end
+  end
+
+  def gate_type
+    @gate&.fetch(:type)
+  end
+
+  def enable_gate_type?
+    gate_type == :enable
+  end
+end

--- a/app/components/moderation/image_scanning_form.rb
+++ b/app/components/moderation/image_scanning_form.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+class Components::Moderation::ImageScanningForm < Components::Base
+  def initialize(server_configuration:, context:, enable_error: nil)
+    @settings = context.settings
+    @enable_error = enable_error
+  end
+
+  def view_template
+    div(id: "image_scanning-config", class: "flex flex-col gap-5") do
+      enable_error_callout
+      consent_callout
+      sensitivity_card
+      custom_keywords_card
+      response_card
+      image_explainer
+      report_scam_hint
+    end
+  end
+
+  private
+
+  def enable_error_callout
+    return unless @enable_error
+
+    render Components::Callout.new(variant: :danger) { @enable_error }
+  end
+
+  def consent_callout
+    render Components::Callout.new(variant: :warning) do
+      div do
+        p(class: "font-semibold") { t(".consent.title") }
+        p(class: "mt-1") { t(".consent.body") }
+      end
+    end
+  end
+
+  def sensitivity_card
+    render Components::Card.new do
+      label(class: "block text-sm font-semibold mb-1.5") { t(".detection.sensitivity.label") }
+      render Components::RadioCardGroup.new(
+        name: "image_scanning[sensitivity]",
+        value: @settings.sensitivity,
+        label: t(".detection.sensitivity.label"),
+        options: [
+          {
+            value: "relaxed",
+            title: t(".detection.sensitivity.relaxed_title"),
+            description: t(".detection.sensitivity.relaxed_description")
+          },
+          {
+            value: "standard",
+            title: t(".detection.sensitivity.standard_title"),
+            description: t(".detection.sensitivity.standard_description")
+          },
+          {
+            value: "strict",
+            title: t(".detection.sensitivity.strict_title"),
+            description: t(".detection.sensitivity.strict_description")
+          }
+        ]
+      )
+    end
+  end
+
+  def custom_keywords_card
+    render Components::Card.new do
+      div(class: "grid gap-5") do
+        keywords_field
+        min_hits_field
+      end
+    end
+  end
+
+  def keywords_field
+    div do
+      label(class: "block text-sm font-semibold mb-1.5") { t(".custom_keywords.keywords_label") }
+      render Components::TomSelect.new(
+        name: "image_scanning[custom_keywords][]",
+        options: keyword_options,
+        selected: @settings.custom_keywords,
+        multiple: true,
+        controller_data: {tom_select_create_value: true}
+      )
+      p(class: "text-xs text-text-muted mt-1.5") { t(".custom_keywords.keywords_help") }
+    end
+  end
+
+  def min_hits_field
+    keyword_count = @settings.custom_keywords.size
+    max = keyword_count.positive? ? keyword_count : nil
+
+    div do
+      label(class: "block text-sm font-semibold mb-1.5") { t(".custom_keywords.min_hits_label") }
+      div(class: "flex items-start gap-2.5") do
+        render Components::NumberStepper.new(
+          name: "image_scanning[custom_keyword_min_hits]",
+          value: @settings.custom_keyword_min_hits,
+          min: 1,
+          default: 2,
+          max:
+        )
+        span(class: "text-sm text-text-secondary h-10 inline-flex items-center") do
+          t(".custom_keywords.min_hits_suffix")
+        end
+      end
+      p(class: "text-xs text-text-muted mt-1.5") { t(".custom_keywords.min_hits_help") }
+    end
+  end
+
+  def response_card
+    render Components::Card.new do
+      div(class: "grid gap-5") do
+        action_field
+        punishment_field
+      end
+    end
+  end
+
+  def action_field
+    div do
+      label(class: "block text-sm font-semibold mb-1.5") { t(".response.action.label") }
+      render Components::SegmentedControl.new(
+        name: "image_scanning[action]",
+        value: @settings.action,
+        options: [
+          {value: "delete", label: t(".response.action.delete")},
+          {value: "none", label: t(".response.action.flag_only")}
+        ]
+      )
+      p(class: "text-xs text-text-muted mt-1.5") { t(".response.action.help") }
+    end
+  end
+
+  def punishment_field
+    div do
+      label(class: "block text-sm font-semibold mb-1.5") { t(".response.punishment.label") }
+      render Components::Moderation::PunishmentControl.new(
+        name: "image_scanning[punishment]",
+        value: @settings.punishment,
+        timeout_seconds: @settings.timeout_seconds
+      )
+    end
+  end
+
+  def image_explainer
+    details(class: "rounded-card border border-border-default bg-surface-card shadow-sm overflow-hidden") do
+      summary(class: "flex cursor-pointer select-none list-none items-center gap-3 border-b border-border-subtle bg-surface-sunken px-5 py-3.5") do
+        render Components::Icon.new("caret-down", class: "size-4 text-text-muted")
+        span(class: "text-sm font-semibold flex-1") { t(".explainer.title") }
+      end
+      div(class: "grid gap-3 px-5 py-4") do
+        explainer_line("cpu", t(".explainer.line_memory"))
+        explainer_line("check-square", t(".explainer.line_staff"))
+        explainer_line("fingerprint", t(".explainer.line_fingerprint"))
+      end
+    end
+  end
+
+  def explainer_line(icon, text)
+    p(class: "flex items-start gap-2.5 text-sm text-text-secondary") do
+      render Components::Icon.new(icon, class: "size-4 mt-0.5 text-text-muted flex-none")
+      span { text }
+    end
+  end
+
+  def report_scam_hint
+    p(class: "mt-2 flex items-center gap-1.5 text-xs text-text-muted") do
+      render Components::Icon.new("terminal-window", class: "size-4")
+      span { t(".report_scam_hint") }
+    end
+  end
+
+  def keyword_options
+    @settings.custom_keywords.map do |kw|
+      Components::TomSelect::Option.for(value: kw, label: kw)
+    end
+  end
+end

--- a/app/components/moderation/image_scanning_form.rb
+++ b/app/components/moderation/image_scanning_form.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Components::Moderation::ImageScanningForm < Components::Base
-  def initialize(server_configuration:, context:, enable_error: nil)
+  def initialize(context:, enable_error: nil)
     @settings = context.settings
     @enable_error = enable_error
   end

--- a/app/components/moderation/image_scanning_form.rb
+++ b/app/components/moderation/image_scanning_form.rb
@@ -144,12 +144,21 @@ class Components::Moderation::ImageScanningForm < Components::Base
   end
 
   def image_explainer
-    details(class: "rounded-card border border-border-default bg-surface-card shadow-sm overflow-hidden") do
-      summary(class: "flex cursor-pointer select-none list-none items-center gap-3 border-b border-border-subtle bg-surface-sunken px-5 py-3.5") do
-        render Components::Icon.new("caret-down", class: "size-4 text-text-muted")
+    details(
+      class: "rounded-card border border-border-default bg-surface-card shadow-sm overflow-hidden",
+      data: {controller: "dropdown", dropdown_dismiss_on_outside_value: "false"}
+    ) do
+      summary(
+        class: "flex cursor-pointer select-none list-none items-center gap-3 border-b border-border-subtle bg-surface-sunken px-5 py-3.5 [&::-webkit-details-marker]:hidden",
+        data: {action: "click->dropdown#toggle"}
+      ) do
+        render Components::Icon.new("caret-down", class: "dropdown-chevron size-4 text-text-muted")
         span(class: "text-sm font-semibold flex-1") { t(".explainer.title") }
       end
-      div(class: "grid gap-3 px-5 py-4") do
+      div(
+        class: "dropdown-menu grid gap-3 px-5 py-4",
+        data: {dropdown_target: "menu"}
+      ) do
         explainer_line("cpu", t(".explainer.line_memory"))
         explainer_line("check-square", t(".explainer.line_staff"))
         explainer_line("fingerprint", t(".explainer.line_fingerprint"))

--- a/app/components/moderation/matching_explainer.rb
+++ b/app/components/moderation/matching_explainer.rb
@@ -16,7 +16,10 @@ class Components::Moderation::MatchingExplainer < Components::Base
           render Components::Icon.new("caret-down", class: "dropdown-chevron size-4 flex-none text-text-muted")
           span(class: "flex-1 text-sm font-semibold") { t(".title") }
         end
-        div(class: "grid gap-3 px-5 py-4") do
+        div(
+          class: "dropdown-menu grid gap-3 px-5 py-4",
+          data: {dropdown_target: "menu"}
+        ) do
           explainer_row("text-aa", t(".row_normalize"))
           explainer_row("mask-happy", t(".row_lookalike"))
           explainer_row("megaphone-slash", t(".row_spam"))

--- a/app/components/moderation/matching_explainer.rb
+++ b/app/components/moderation/matching_explainer.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class Components::Moderation::MatchingExplainer < Components::Base
+  def view_template
+    div(
+      id: "matching",
+      class: "overflow-hidden rounded-card border border-border-default bg-surface-card shadow-sm"
+    ) do
+      details(
+        data: {controller: "dropdown", dropdown_dismiss_on_outside_value: "false"}
+      ) do
+        summary(
+          class: "flex cursor-pointer list-none select-none items-center gap-3 bg-surface-sunken border-b border-border-subtle px-5 py-3.5 [&::-webkit-details-marker]:hidden",
+          data: {action: "click->dropdown#toggle"}
+        ) do
+          render Components::Icon.new("caret-down", class: "dropdown-chevron size-4 flex-none text-text-muted")
+          span(class: "flex-1 text-sm font-semibold") { t(".title") }
+        end
+        div(class: "grid gap-3 px-5 py-4") do
+          explainer_row("text-aa", t(".row_normalize"))
+          explainer_row("mask-happy", t(".row_lookalike"))
+          explainer_row("megaphone-slash", t(".row_spam"))
+          explainer_row("scan", t(".row_keywords"))
+        end
+      end
+    end
+  end
+
+  private
+
+  def explainer_row(icon, text)
+    p(class: "flex items-start gap-2.5 text-sm text-text-secondary") do
+      render Components::Icon.new(icon, class: "mt-0.5 size-4 flex-none text-text-muted")
+      span { text }
+    end
+  end
+end

--- a/app/components/moderation/overview_form.rb
+++ b/app/components/moderation/overview_form.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Components::Moderation::OverviewForm < Components::Base
+  def initialize(server_configuration:, context:, enable_error: nil)
+    @config = server_configuration
+    @context = context
+    @enable_error = enable_error
+  end
+
+  def view_template
+    div(id: "moderation-config", class: "flex flex-col gap-5") do
+      enable_error_callout
+      render Components::Moderation::StaffRoleCard.new(
+        server_configuration: @config,
+        staff_role_id: @context.staff_role_id,
+        missing: !@context.staff_role_present?,
+        permission_warning: @context.permission_warning?
+      )
+      render Components::Moderation::SubPluginDirectory.new(
+        server_configuration: @config,
+        context: @context
+      )
+      render Components::Moderation::MatchingExplainer.new
+    end
+  end
+
+  private
+
+  def enable_error_callout
+    return unless @enable_error
+
+    render Components::Callout.new(variant: :danger) { @enable_error }
+  end
+end

--- a/app/components/moderation/punishment_control.rb
+++ b/app/components/moderation/punishment_control.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+class Components::Moderation::PunishmentControl < Components::Base
+  DURATION_OPTIONS = [
+    {seconds: 300, label: "5 minutes"},
+    {seconds: 600, label: "10 minutes"},
+    {seconds: 1_800, label: "30 minutes"},
+    {seconds: 3_600, label: "1 hour"},
+    {seconds: 7_200, label: "2 hours"},
+    {seconds: 21_600, label: "6 hours"},
+    {seconds: 43_200, label: "12 hours"},
+    {seconds: 86_400, label: "1 day"},
+    {seconds: 604_800, label: "7 days"},
+    {seconds: 2_419_200, label: "28 days"}
+  ].freeze
+
+  def initialize(name:, value:, timeout_seconds:)
+    @name = name
+    @value = value.to_s
+    @timeout_seconds = timeout_seconds
+  end
+
+  def view_template
+    div(data: {controller: "punishment"}) do
+      render Components::SegmentedControl.new(
+        name: @name,
+        value: @value,
+        options: [
+          {value: "none", label: t("components.moderation.punishment_control.none")},
+          {value: "timeout", label: t("components.moderation.punishment_control.timeout")},
+          {value: "kick", label: t("components.moderation.punishment_control.kick")},
+          {value: "ban", label: t("components.moderation.punishment_control.ban")}
+        ]
+      )
+      duration_block
+      ban_warning
+    end
+  end
+
+  private
+
+  def duration_block
+    div(
+      class: "mt-3",
+      data: {punishment_target: "duration"},
+      hidden: @value != "timeout"
+    ) do
+      label(class: "block text-xs font-semibold mb-1.5") do
+        t("components.moderation.punishment_control.duration_label")
+      end
+      render Components::TomSelect.new(
+        name: timeout_field_name,
+        options: duration_options,
+        selected: @timeout_seconds
+      )
+      p(class: "text-xs text-text-muted mt-1.5") do
+        t("components.moderation.punishment_control.duration_help")
+      end
+    end
+  end
+
+  def ban_warning
+    div(
+      data: {punishment_target: "banWarning"},
+      hidden: @value != "ban"
+    ) do
+      render Components::Callout.new(variant: :danger, class: "mt-3") do
+        t("components.moderation.punishment_control.ban_warning")
+      end
+    end
+  end
+
+  def duration_options
+    DURATION_OPTIONS.map do |opt|
+      Components::TomSelect::Option.for(
+        value: opt[:seconds],
+        label: opt[:label]
+      )
+    end
+  end
+
+  def timeout_field_name
+    prefix = @name.sub(/\[punishment\]$/, "")
+    "#{prefix}[timeout_seconds]"
+  end
+end

--- a/app/components/moderation/spam_protection_form.rb
+++ b/app/components/moderation/spam_protection_form.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+class Components::Moderation::SpamProtectionForm < Components::Base
+  def initialize(server_configuration:, context:, enable_error: nil)
+    @settings = context.settings
+    @enable_error = enable_error
+  end
+
+  def view_template
+    div(id: "spam_protection-config", class: "flex flex-col gap-5") do
+      enable_error_callout
+      detection_card
+      response_card
+    end
+  end
+
+  private
+
+  def enable_error_callout
+    return unless @enable_error
+
+    render Components::Callout.new(variant: :danger) { @enable_error }
+  end
+
+  def detection_card
+    render Components::Card.new do
+      div(class: "grid gap-5") do
+        trigger_threshold_field
+        match_strictness_field
+        symbol_only_field
+      end
+    end
+  end
+
+  def trigger_threshold_field
+    div do
+      label(class: "block text-sm font-semibold mb-1.5") do
+        t(".detection.trigger_threshold.label")
+      end
+      div(class: "flex items-start gap-2.5 flex-wrap") do
+        render Components::NumberStepper.new(
+          name: "spam_protection[channel_threshold]",
+          value: @settings.channel_threshold,
+          min: 2,
+          default: 4,
+          unit: t(".detection.trigger_threshold.channels_unit")
+        )
+        span(class: "text-sm text-text-secondary h-10 inline-flex items-center") do
+          t(".detection.trigger_threshold.within")
+        end
+        render Components::NumberStepper.new(
+          name: "spam_protection[window_seconds]",
+          value: @settings.window_seconds,
+          min: 1,
+          default: 15,
+          unit: t(".detection.trigger_threshold.seconds_unit")
+        )
+      end
+      p(class: "text-xs text-text-muted mt-1.5") { t(".detection.trigger_threshold.help") }
+    end
+  end
+
+  def match_strictness_field
+    div do
+      label(class: "block text-sm font-semibold mb-1.5") { t(".detection.match_strictness.label") }
+      render Components::RangeSlider.new(
+        name: "spam_protection[similarity]",
+        value: @settings.similarity,
+        min: 75,
+        max: 100
+      )
+      p(class: "text-xs text-text-muted mt-1.5") { t(".detection.match_strictness.help") }
+      p(class: "text-xs text-text-muted mt-1") { t(".detection.match_strictness.recommended") }
+    end
+  end
+
+  def symbol_only_field
+    div do
+      div(class: "flex items-center justify-between max-w-md gap-4") do
+        label(class: "text-sm font-semibold") { t(".detection.symbol_only.label") }
+        render Components::Toggle.new(
+          name: "spam_protection[match_symbol_only_messages]",
+          checked: @settings.match_symbol_only_messages,
+          label: t(".detection.symbol_only.label"),
+          size: :md
+        )
+      end
+      p(class: "text-xs text-text-muted mt-1.5 max-w-md") { t(".detection.symbol_only.help") }
+      p(class: "text-xs text-text-muted mt-1") { t(".detection.symbol_only.recommended") }
+    end
+  end
+
+  def response_card
+    render Components::Card.new do
+      div(class: "grid gap-5") do
+        action_field
+        punishment_field
+      end
+    end
+  end
+
+  def action_field
+    div do
+      label(class: "block text-sm font-semibold mb-1.5") { t(".response.action.label") }
+      render Components::SegmentedControl.new(
+        name: "spam_protection[action]",
+        value: @settings.action,
+        options: [
+          {value: "purge", label: t(".response.action.purge")},
+          {value: "notify_only", label: t(".response.action.notify_only")}
+        ]
+      )
+      p(class: "text-xs text-text-muted mt-1.5") { t(".response.action.help") }
+    end
+  end
+
+  def punishment_field
+    div do
+      label(class: "block text-sm font-semibold mb-1.5") { t(".response.punishment.label") }
+      render Components::Moderation::PunishmentControl.new(
+        name: "spam_protection[punishment]",
+        value: @settings.punishment,
+        timeout_seconds: @settings.timeout_seconds
+      )
+    end
+  end
+end

--- a/app/components/moderation/spam_protection_form.rb
+++ b/app/components/moderation/spam_protection_form.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Components::Moderation::SpamProtectionForm < Components::Base
-  def initialize(server_configuration:, context:, enable_error: nil)
+  def initialize(context:, enable_error: nil)
     @settings = context.settings
     @enable_error = enable_error
   end
@@ -66,6 +66,9 @@ class Components::Moderation::SpamProtectionForm < Components::Base
       render Components::RangeSlider.new(
         name: "spam_protection[similarity]",
         value: @settings.similarity,
+        label: t(".detection.match_strictness.label"),
+        min_caption: t(".detection.match_strictness.min_caption"),
+        max_caption: t(".detection.match_strictness.max_caption"),
         min: 75,
         max: 100
       )

--- a/app/components/moderation/staff_role_card.rb
+++ b/app/components/moderation/staff_role_card.rb
@@ -46,9 +46,9 @@ class Components::Moderation::StaffRoleCard < Components::Base
   end
 
   def color_hex(color)
-    return DEFAULT_COLOR if color.nil? || color.zero?
+    return DEFAULT_COLOR if color.zero?
 
-    format("#%06x", color & 0xFFFFFF)
+    "#%06x" % (color & 0xFFFFFF)
   end
 
   def missing_warning

--- a/app/components/moderation/staff_role_card.rb
+++ b/app/components/moderation/staff_role_card.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+class Components::Moderation::StaffRoleCard < Components::Base
+  DEFAULT_COLOR = "#99aab5"
+
+  def initialize(server_configuration:, staff_role_id:, missing:, permission_warning:)
+    @config = server_configuration
+    @staff_role_id = staff_role_id
+    @missing = missing
+    @permission_warning = permission_warning
+  end
+
+  def view_template
+    render Components::Card.new do
+      label(class: "block text-sm font-semibold mb-1.5") do
+        plain t(".label")
+        span(class: "ml-1 text-xs font-semibold text-danger") { "*" }
+      end
+      render Components::TomSelect.new(
+        name: "moderation[staff_role_id]",
+        options: role_options,
+        selected: @staff_role_id,
+        multiple: false,
+        include_blank: true,
+        controller_data: {
+          tom_select_color_dots_value: true,
+          tom_select_placeholder_value: t(".placeholder")
+        }
+      )
+      missing_warning if @missing
+      p(class: "mt-1.5 text-xs text-text-muted") { t(".help") } unless @missing
+      permission_warning_callout if @permission_warning
+    end
+  end
+
+  private
+
+  def role_options
+    @config.server_roles.order(:position).map do |role|
+      Components::TomSelect::Option.for(
+        value: role.discord_id,
+        label: role.name,
+        color: color_hex(role.color)
+      )
+    end
+  end
+
+  def color_hex(color)
+    return DEFAULT_COLOR if color.nil? || color.zero?
+
+    format("#%06x", color & 0xFFFFFF)
+  end
+
+  def missing_warning
+    p(class: "mt-1.5 flex items-center gap-1 text-xs font-medium text-warning") do
+      render Components::Icon.new("warning", class: "size-3.5")
+      span { t(".missing_warning") }
+    end
+  end
+
+  def permission_warning_callout
+    div(class: "mt-3") do
+      render Components::Callout.new(variant: :warning) do
+        plain ""
+        span do
+          b(class: "text-warning") { t(".permission_warning_bold") }
+          whitespace
+          plain t(".permission_warning_body")
+        end
+      end
+    end
+  end
+end

--- a/app/components/moderation/sub_plugin_directory.rb
+++ b/app/components/moderation/sub_plugin_directory.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Components::Moderation::SubPluginDirectory < Components::Base
+  def initialize(server_configuration:, context:)
+    @config = server_configuration
+    @context = context
+  end
+
+  def view_template
+    div do
+      p(class: "mb-3 text-[11px] font-semibold uppercase tracking-widest text-text-muted") do
+        t(".eyebrow")
+      end
+      div(class: "flex flex-col gap-3") do
+        @context.sub_plugin_rows.each do |row|
+          render Components::Moderation::SubPluginRow.new(
+            server_id: @config.discord_id,
+            key: row.key,
+            name: row.name,
+            description: row.description,
+            enabled: row.enabled,
+            configured: row.configured,
+            settings: row.settings,
+            group_enabled: @context.group_enabled?
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/components/moderation/sub_plugin_row.rb
+++ b/app/components/moderation/sub_plugin_row.rb
@@ -14,6 +14,10 @@ class Components::Moderation::SubPluginRow < Components::Base
     image_scanning: "scan"
   }.freeze
 
+  def self.toggle_form_id(key)
+    "#{key}-overview-toggle-form"
+  end
+
   def initialize(server_id:, key:, name:, description:, enabled:, configured:, settings:, group_enabled:)
     @server_id = server_id
     @key = key
@@ -143,6 +147,6 @@ class Components::Moderation::SubPluginRow < Components::Base
   end
 
   def stub_form_id
-    "#{@key}-overview-toggle-form"
+    self.class.toggle_form_id(@key)
   end
 end

--- a/app/components/moderation/sub_plugin_row.rb
+++ b/app/components/moderation/sub_plugin_row.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+class Components::Moderation::SubPluginRow < Components::Base
+  include Phlex::Rails::Helpers::FormWith
+
+  STATUS_VARIANTS = {
+    enabled: :success,
+    needs_setup: :warning,
+    disabled: :neutral
+  }.freeze
+
+  ICONS = {
+    spam_protection: "megaphone-slash",
+    image_scanning: "scan"
+  }.freeze
+
+  def initialize(server_id:, key:, name:, description:, enabled:, configured:, settings:, group_enabled:)
+    @server_id = server_id
+    @key = key
+    @name = name
+    @description = description
+    @enabled = enabled
+    @configured = configured
+    @settings = settings
+    @group_enabled = group_enabled
+  end
+
+  def view_template
+    render Components::Card.new(enabled: @enabled, class: "flex items-center gap-4") do
+      render Components::PluginTile.new(icon: ICONS.fetch(@key), enabled: @enabled)
+      div(class: "min-w-0 flex-1") do
+        div(class: "flex flex-wrap items-center gap-2") do
+          span(class: "font-display font-semibold") { @name }
+          status_badge
+        end
+        p(class: "mt-0.5 text-sm text-text-secondary") { @description }
+        needs_setup_inline_warning if needs_setup?
+      end
+      configure_link
+      toggle_control
+    end
+  end
+
+  private
+
+  def status_badge
+    render Components::Badge.new(variant: STATUS_VARIANTS.fetch(status), dot: true) do
+      t(".status.#{status}")
+    end
+  end
+
+  def status
+    return :needs_setup unless @configured
+    @enabled ? :enabled : :disabled
+  end
+
+  def needs_setup?
+    !@configured && @group_enabled
+  end
+
+  def needs_setup_inline_warning
+    p(class: "mt-1 flex items-center gap-1 text-xs font-medium text-warning") do
+      render Components::Icon.new("warning", class: "size-3.5")
+      span { t(".needs_setup_hint") }
+    end
+  end
+
+  def configure_link
+    render Components::Button.new(
+      variant: :secondary,
+      href: configure_href,
+      label: t(".configure"),
+      trailing_icon: "arrow-right",
+      class: "flex-none"
+    )
+  end
+
+  def configure_href
+    case @key
+    when :spam_protection then server_spam_protection_path(@server_id)
+    when :image_scanning then server_image_scanning_path(@server_id)
+    end
+  end
+
+  def sub_path
+    case @key
+    when :spam_protection then server_spam_protection_path(@server_id)
+    when :image_scanning then server_image_scanning_path(@server_id)
+    end
+  end
+
+  def toggle_control
+    if needs_setup?
+      locked_toggle
+    else
+      enabled_toggle
+    end
+  end
+
+  def locked_toggle
+    render Components::Tooltip.new(text: t(".locked_reason")) do
+      render Components::Toggle.new(
+        name: "#{@key}[enabled]",
+        checked: @enabled,
+        label: t(".toggle_label", name: @name),
+        disabled: true
+      )
+    end
+  end
+
+  def enabled_toggle
+    form_with(url: sub_path, method: :patch, class: "flex-none", autocomplete: "off") do |f|
+      settings_hidden_fields
+      render Components::Toggle.new(
+        name: "#{@key}[enabled]",
+        checked: @enabled,
+        label: t(".toggle_label", name: @name),
+        submit_on_change: true
+      )
+    end
+  end
+
+  def settings_hidden_fields
+    return unless @settings
+
+    case @key
+    when :spam_protection
+      spam_protection_hidden_fields
+    when :image_scanning
+      image_scanning_hidden_fields
+    end
+  end
+
+  def spam_protection_hidden_fields
+    input(type: "hidden", name: "spam_protection[channel_threshold]", value: @settings.channel_threshold)
+    input(type: "hidden", name: "spam_protection[window_seconds]", value: @settings.window_seconds)
+    input(type: "hidden", name: "spam_protection[similarity]", value: @settings.similarity)
+    input(type: "hidden", name: "spam_protection[match_symbol_only_messages]", value: @settings.match_symbol_only_messages ? "1" : "0")
+    input(type: "hidden", name: "spam_protection[action]", value: @settings.action)
+    input(type: "hidden", name: "spam_protection[punishment]", value: @settings.punishment)
+    input(type: "hidden", name: "spam_protection[timeout_seconds]", value: @settings.timeout_seconds)
+  end
+
+  def image_scanning_hidden_fields
+    input(type: "hidden", name: "image_scanning[sensitivity]", value: @settings.sensitivity)
+    input(type: "hidden", name: "image_scanning[action]", value: @settings.action)
+    input(type: "hidden", name: "image_scanning[punishment]", value: @settings.punishment)
+    input(type: "hidden", name: "image_scanning[timeout_seconds]", value: @settings.timeout_seconds)
+    input(type: "hidden", name: "image_scanning[custom_keyword_min_hits]", value: @settings.custom_keyword_min_hits)
+    @settings.custom_keywords.each do |keyword|
+      input(type: "hidden", name: "image_scanning[custom_keywords][]", value: keyword)
+    end
+  end
+end

--- a/app/components/moderation/sub_plugin_row.rb
+++ b/app/components/moderation/sub_plugin_row.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class Components::Moderation::SubPluginRow < Components::Base
-  include Phlex::Rails::Helpers::FormWith
   include Components::PluginNav
 
   STATUS_VARIANTS = {
@@ -100,15 +99,20 @@ class Components::Moderation::SubPluginRow < Components::Base
   end
 
   def enabled_toggle
-    form_with(url: sub_path, method: :patch, class: "flex-none", autocomplete: "off") do |f|
-      settings_hidden_fields
-      render Components::Toggle.new(
-        name: "#{@key}[enabled]",
-        checked: @enabled,
-        label: t(".toggle_label", name: @name),
-        submit_on_change: true
-      )
-    end
+    input(
+      type: "hidden",
+      name: "from_overview",
+      value: "1",
+      form: stub_form_id
+    )
+    settings_hidden_fields
+    render Components::Toggle.new(
+      name: "#{@key}[enabled]",
+      checked: @enabled,
+      label: t(".toggle_label", name: @name),
+      submit_on_change: true,
+      form: stub_form_id
+    )
   end
 
   def settings_hidden_fields
@@ -118,23 +122,27 @@ class Components::Moderation::SubPluginRow < Components::Base
   end
 
   def spam_protection_hidden_fields
-    input(type: "hidden", name: "spam_protection[channel_threshold]", value: @settings.channel_threshold)
-    input(type: "hidden", name: "spam_protection[window_seconds]", value: @settings.window_seconds)
-    input(type: "hidden", name: "spam_protection[similarity]", value: @settings.similarity)
-    input(type: "hidden", name: "spam_protection[match_symbol_only_messages]", value: @settings.match_symbol_only_messages ? "1" : "0")
-    input(type: "hidden", name: "spam_protection[action]", value: @settings.action)
-    input(type: "hidden", name: "spam_protection[punishment]", value: @settings.punishment)
-    input(type: "hidden", name: "spam_protection[timeout_seconds]", value: @settings.timeout_seconds)
+    input(type: "hidden", name: "spam_protection[channel_threshold]", value: @settings.channel_threshold, form: stub_form_id)
+    input(type: "hidden", name: "spam_protection[window_seconds]", value: @settings.window_seconds, form: stub_form_id)
+    input(type: "hidden", name: "spam_protection[similarity]", value: @settings.similarity, form: stub_form_id)
+    input(type: "hidden", name: "spam_protection[match_symbol_only_messages]", value: @settings.match_symbol_only_messages ? "1" : "0", form: stub_form_id)
+    input(type: "hidden", name: "spam_protection[action]", value: @settings.action, form: stub_form_id)
+    input(type: "hidden", name: "spam_protection[punishment]", value: @settings.punishment, form: stub_form_id)
+    input(type: "hidden", name: "spam_protection[timeout_seconds]", value: @settings.timeout_seconds, form: stub_form_id)
   end
 
   def image_scanning_hidden_fields
-    input(type: "hidden", name: "image_scanning[sensitivity]", value: @settings.sensitivity)
-    input(type: "hidden", name: "image_scanning[action]", value: @settings.action)
-    input(type: "hidden", name: "image_scanning[punishment]", value: @settings.punishment)
-    input(type: "hidden", name: "image_scanning[timeout_seconds]", value: @settings.timeout_seconds)
-    input(type: "hidden", name: "image_scanning[custom_keyword_min_hits]", value: @settings.custom_keyword_min_hits)
+    input(type: "hidden", name: "image_scanning[sensitivity]", value: @settings.sensitivity, form: stub_form_id)
+    input(type: "hidden", name: "image_scanning[action]", value: @settings.action, form: stub_form_id)
+    input(type: "hidden", name: "image_scanning[punishment]", value: @settings.punishment, form: stub_form_id)
+    input(type: "hidden", name: "image_scanning[timeout_seconds]", value: @settings.timeout_seconds, form: stub_form_id)
+    input(type: "hidden", name: "image_scanning[custom_keyword_min_hits]", value: @settings.custom_keyword_min_hits, form: stub_form_id)
     @settings.custom_keywords.each do |keyword|
-      input(type: "hidden", name: "image_scanning[custom_keywords][]", value: keyword)
+      input(type: "hidden", name: "image_scanning[custom_keywords][]", value: keyword, form: stub_form_id)
     end
+  end
+
+  def stub_form_id
+    "#{@key}-overview-toggle-form"
   end
 end

--- a/app/components/moderation/sub_plugin_row.rb
+++ b/app/components/moderation/sub_plugin_row.rb
@@ -68,25 +68,15 @@ class Components::Moderation::SubPluginRow < Components::Base
   def configure_link
     render Components::Button.new(
       variant: :secondary,
-      href: configure_href,
+      href: sub_path,
       label: t(".configure"),
       trailing_icon: "arrow-right",
       class: "flex-none"
     )
   end
 
-  def configure_href
-    case @key
-    when :spam_protection then server_spam_protection_path(@server_id)
-    when :image_scanning then server_image_scanning_path(@server_id)
-    end
-  end
-
   def sub_path
-    case @key
-    when :spam_protection then server_spam_protection_path(@server_id)
-    when :image_scanning then server_image_scanning_path(@server_id)
-    end
+    (@key == :spam_protection) ? server_spam_protection_path(@server_id) : server_image_scanning_path(@server_id)
   end
 
   def toggle_control
@@ -123,12 +113,7 @@ class Components::Moderation::SubPluginRow < Components::Base
   def settings_hidden_fields
     return unless @settings
 
-    case @key
-    when :spam_protection
-      spam_protection_hidden_fields
-    when :image_scanning
-      image_scanning_hidden_fields
-    end
+    (@key == :spam_protection) ? spam_protection_hidden_fields : image_scanning_hidden_fields
   end
 
   def spam_protection_hidden_fields

--- a/app/components/moderation/sub_plugin_row.rb
+++ b/app/components/moderation/sub_plugin_row.rb
@@ -2,6 +2,7 @@
 
 class Components::Moderation::SubPluginRow < Components::Base
   include Phlex::Rails::Helpers::FormWith
+  include Components::PluginNav
 
   STATUS_VARIANTS = {
     enabled: :success,
@@ -76,7 +77,7 @@ class Components::Moderation::SubPluginRow < Components::Base
   end
 
   def sub_path
-    (@key == :spam_protection) ? server_spam_protection_path(@server_id) : server_image_scanning_path(@server_id)
+    plugin_config_path(@server_id, @key)
   end
 
   def toggle_control

--- a/app/components/number_stepper.rb
+++ b/app/components/number_stepper.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+class Components::NumberStepper < Components::Base
+  def initialize(name:, value:, min:, default:, unit: nil, max: nil)
+    @name = name
+    @value = value
+    @min = min
+    @default = default
+    @unit = unit
+    @max = max
+  end
+
+  def view_template
+    div(class: "flex flex-col gap-1") do
+      stepper_row
+      subscript
+    end
+  end
+
+  private
+
+  def stepper_row
+    div(
+      class: "flex items-center gap-2",
+      data: controller_data
+    ) do
+      decrement_button
+      number_input
+      increment_button
+      unit_label if @unit
+    end
+  end
+
+  def controller_data
+    data = {controller: "number-stepper", number_stepper_min_value: @min}
+    data[:number_stepper_max_value] = @max if @max
+    data
+  end
+
+  def decrement_button
+    button(
+      type: "button",
+      class: "flex size-8 items-center justify-center rounded-control border border-border-default bg-surface-card text-text-secondary transition-colors hover:bg-surface-sunken hover:text-text-primary",
+      data: {action: "click->number-stepper#decrement"}
+    ) do
+      render Components::Icon.new("minus", class: "size-4")
+    end
+  end
+
+  def increment_button
+    button(
+      type: "button",
+      class: "flex size-8 items-center justify-center rounded-control border border-border-default bg-surface-card text-text-secondary transition-colors hover:bg-surface-sunken hover:text-text-primary",
+      data: {action: "click->number-stepper#increment"}
+    ) do
+      render Components::Icon.new("plus", class: "size-4")
+    end
+  end
+
+  def number_input
+    input(
+      type: "number",
+      name: @name,
+      value: @value,
+      min: @min,
+      max: @max,
+      step: 1,
+      class: "w-11 rounded-control border border-border-default bg-surface-card px-1 py-1 text-center font-mono text-sm text-text-primary focus:border-accent focus:outline-none",
+      data: {number_stepper_target: "input"}
+    )
+  end
+
+  def unit_label
+    span(class: "text-sm text-text-secondary") { @unit }
+  end
+
+  def subscript
+    p(class: "text-xs text-text-muted") { "Recommended default: #{@default}" }
+  end
+end

--- a/app/components/number_stepper.rb
+++ b/app/components/number_stepper.rb
@@ -75,6 +75,6 @@ class Components::NumberStepper < Components::Base
   end
 
   def subscript
-    p(class: "text-xs text-text-muted") { "Recommended default: #{@default}" }
+    p(class: "text-xs text-text-muted") { t(".recommended_default", value: @default) }
   end
 end

--- a/app/components/number_stepper.rb
+++ b/app/components/number_stepper.rb
@@ -65,7 +65,7 @@ class Components::NumberStepper < Components::Base
       min: @min,
       max: @max,
       step: 1,
-      class: "w-11 rounded-control border border-border-default bg-surface-card px-1 py-1 text-center font-mono text-sm text-text-primary focus:border-accent focus:outline-none",
+      class: "w-11 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none rounded-control border border-border-default bg-surface-card px-1 py-1 text-center font-mono text-sm text-text-primary focus:border-accent focus:outline-none",
       data: {number_stepper_target: "input"}
     )
   end

--- a/app/components/plugin_nav.rb
+++ b/app/components/plugin_nav.rb
@@ -5,7 +5,10 @@ module Components::PluginNav
     roles: "users-three",
     welcomes: "hand-waving",
     logging: "scroll",
-    reminders: "bell-ringing"
+    reminders: "bell-ringing",
+    moderation: "shield",
+    spam_protection: "megaphone-slash",
+    image_scanning: "scan"
   }.freeze
 
   def plugin_icon(key)
@@ -18,6 +21,9 @@ module Components::PluginNav
     when :welcomes then server_welcomes_path(server_id)
     when :logging then server_logging_path(server_id)
     when :reminders then server_reminders_path(server_id)
+    when :moderation then server_moderation_path(server_id)
+    when :spam_protection then server_spam_protection_path(server_id)
+    when :image_scanning then server_image_scanning_path(server_id)
     end
   end
 end

--- a/app/components/plugin_sidebar.rb
+++ b/app/components/plugin_sidebar.rb
@@ -15,7 +15,11 @@ class Components::PluginSidebar < Components::Base
         div(class: "my-3 h-px bg-border-subtle")
         p(class: "mb-2 px-2 text-[10px] font-semibold uppercase tracking-widest text-eyebrow") { t(".plugins") }
         nav(class: "flex flex-col gap-0.5") do
-          items.each { |row| nav_item(row) }
+          items.each do |row|
+            next if sub_plugin?(row.key)
+
+            (row.key == :moderation) ? moderation_group : nav_item(row)
+          end
         end
       end
     end
@@ -23,8 +27,58 @@ class Components::PluginSidebar < Components::Base
 
   private
 
+  SUB_PLUGIN_KEYS = %i[spam_protection image_scanning].freeze
+
+  def all_rows
+    @all_rows ||= PluginStatus.rows(@config)
+  end
+
   def items
-    PluginStatus.rows(@config).select { |row| plugin_config_path(@config.discord_id, row.key) }
+    all_rows.select { |row| plugin_config_path(@config.discord_id, row.key) }
+  end
+
+  def sub_plugin?(key)
+    SUB_PLUGIN_KEYS.include?(key)
+  end
+
+  def moderation_group
+    render Components::SidebarGroup.new(
+      label: PluginCatalog.find(:moderation).name,
+      icon: plugin_icon(:moderation),
+      open: group_active?,
+      items: group_items,
+      storage_key: "sidebar-group-moderation"
+    )
+  end
+
+  def group_active?
+    @active_key == :moderation || sub_plugin?(@active_key)
+  end
+
+  def group_items
+    overview = {
+      label: t(".overview"),
+      href: server_moderation_path(@config.discord_id),
+      active: @active_key == :moderation,
+      status: nil
+    }
+    [overview] + SUB_PLUGIN_KEYS.map { |key| sub_item(key) }
+  end
+
+  def sub_item(key)
+    row = all_rows.find { |candidate| candidate.key == key }
+    {
+      label: PluginCatalog.find(key).name,
+      href: plugin_config_path(@config.discord_id, key),
+      active: @active_key == key,
+      status: sub_status(row)
+    }
+  end
+
+  def sub_status(row)
+    return :enabled if row.enabled
+
+    row.configured ? :disabled : :needs_setup
   end
 
   def back_link

--- a/app/components/plugin_sidebar.rb
+++ b/app/components/plugin_sidebar.rb
@@ -9,7 +9,7 @@ class Components::PluginSidebar < Components::Base
   end
 
   def view_template
-    aside(class: "sticky top-16 hidden h-[calc(100vh-4rem)] w-56 flex-none overflow-y-auto border-r border-border-default bg-surface-sunken md:block") do
+    aside(id: "plugin-sidebar", class: "sticky top-16 hidden h-[calc(100vh-4rem)] w-56 flex-none overflow-y-auto border-r border-border-default bg-surface-sunken md:block") do
       div(class: "p-4") do
         back_link
         div(class: "my-3 h-px bg-border-subtle")

--- a/app/components/plugin_sidebar.rb
+++ b/app/components/plugin_sidebar.rb
@@ -27,8 +27,6 @@ class Components::PluginSidebar < Components::Base
 
   private
 
-  SUB_PLUGIN_KEYS = %i[spam_protection image_scanning].freeze
-
   def all_rows
     @all_rows ||= PluginStatus.rows(@config)
   end
@@ -38,7 +36,7 @@ class Components::PluginSidebar < Components::Base
   end
 
   def sub_plugin?(key)
-    SUB_PLUGIN_KEYS.include?(key)
+    PluginCatalog.sub_plugin?(key)
   end
 
   def moderation_group
@@ -62,7 +60,7 @@ class Components::PluginSidebar < Components::Base
       active: @active_key == :moderation,
       status: nil
     }
-    [overview] + SUB_PLUGIN_KEYS.map { |key| sub_item(key) }
+    [overview] + PluginCatalog.sub_plugin_keys(:moderation).map { |key| sub_item(key) }
   end
 
   def sub_item(key)

--- a/app/components/plugin_sidebar.rb
+++ b/app/components/plugin_sidebar.rb
@@ -45,7 +45,8 @@ class Components::PluginSidebar < Components::Base
       icon: plugin_icon(:moderation),
       open: group_active?,
       items: group_items,
-      storage_key: "sidebar-group-moderation"
+      storage_key: "sidebar-group-moderation",
+      enabled: all_rows.find { |row| row.key == :moderation }.enabled
     )
   end
 

--- a/app/components/prereq_gate.rb
+++ b/app/components/prereq_gate.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class Components::PrereqGate < Components::Base
+  def initialize(title:, message:, cta_label:, cta_href:, icon: "lock")
+    @title = title
+    @message = message
+    @cta_label = cta_label
+    @cta_href = cta_href
+    @icon = icon
+  end
+
+  def view_template(&block)
+    div(class: "relative") do
+      overlay
+      div(
+        inert: true,
+        class: "flex flex-col gap-5 opacity-45"
+      ) { yield }
+    end
+  end
+
+  private
+
+  def overlay
+    div(class: "anim-fade absolute inset-0 z-20 flex items-center justify-center rounded-card bg-surface-page/70 backdrop-blur-[1px]") do
+      div(class: "max-w-xs rounded-card border border-border-default bg-surface-card px-6 py-5 text-center shadow-md") do
+        render Components::Icon.new(@icon, class: "mx-auto block size-5 text-text-muted")
+        p(class: "mt-2 text-sm font-semibold text-text-primary") { @title }
+        p(class: "mb-4 mt-1 text-xs text-text-secondary") { @message }
+        render Components::Button.new(
+          variant: :secondary,
+          href: @cta_href,
+          label: @cta_label,
+          trailing_icon: "arrow-right"
+        )
+      end
+    end
+  end
+end

--- a/app/components/radio_card_group.rb
+++ b/app/components/radio_card_group.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class Components::RadioCardGroup < Components::Base
+  def initialize(name:, value:, options:, label: nil)
+    @name = name
+    @value = value.to_s
+    @options = options
+    @label = label
+  end
+
+  def view_template
+    div(
+      role: "radiogroup",
+      aria_label: @label,
+      class: "flex flex-col gap-3"
+    ) do
+      @options.each { |opt| radio_card(opt) }
+    end
+  end
+
+  private
+
+  def radio_card(opt)
+    label(class: card_css) do
+      input(
+        type: "radio",
+        name: @name,
+        value: opt[:value],
+        checked: opt[:value].to_s == @value,
+        class: "mt-0.5 size-4 flex-none appearance-none rounded-full border-2 border-border-strong bg-surface-card transition-colors checked:border-[5px] checked:border-accent"
+      )
+      div do
+        p(class: "text-sm font-semibold text-text-primary") { opt[:title] }
+        p(class: "mt-0.5 text-xs text-text-secondary") { opt[:description] }
+      end
+    end
+  end
+
+  def card_css
+    "flex cursor-pointer items-start gap-3 rounded-card border-[1.5px] " \
+      "border-border-default bg-surface-card px-4 py-3 transition-colors " \
+      "hover:bg-surface-sunken has-[:checked]:border-accent has-[:checked]:bg-accent-soft"
+  end
+end

--- a/app/components/range_slider.rb
+++ b/app/components/range_slider.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 class Components::RangeSlider < Components::Base
-  def initialize(name:, value:, min: 75, max: 100)
+  def initialize(name:, value:, label:, min_caption:, max_caption:, min: 75, max: 100)
     @name = name
     @value = value
+    @label = label
+    @min_caption = min_caption
+    @max_caption = max_caption
     @min = min
     @max = max
   end
@@ -39,7 +42,7 @@ class Components::RangeSlider < Components::Base
       step: 1,
       value: (@value * 100).round,
       class: "w-full accent-accent",
-      aria_label: "Similarity threshold",
+      aria_label: @label,
       data: {
         range_slider_target: "range",
         action: "input->range-slider#update"
@@ -58,8 +61,8 @@ class Components::RangeSlider < Components::Base
 
   def caption_row
     div(class: "flex justify-between text-xs text-text-muted") do
-      span { "#{@min}% · loosely similar" }
-      span { "#{@max}% · identical" }
+      span { "#{@min}% · #{@min_caption}" }
+      span { "#{@max}% · #{@max_caption}" }
     end
   end
 end

--- a/app/components/range_slider.rb
+++ b/app/components/range_slider.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+class Components::RangeSlider < Components::Base
+  def initialize(name:, value:, min: 75, max: 100)
+    @name = name
+    @value = value
+    @min = min
+    @max = max
+  end
+
+  def view_template
+    div(
+      class: "flex flex-col gap-3",
+      data: {controller: "range-slider"}
+    ) do
+      readout_row
+      range_input
+      caption_row
+      hidden_input
+    end
+  end
+
+  private
+
+  def hidden_input
+    input(
+      type: "hidden",
+      name: @name,
+      value: @value,
+      data: {range_slider_target: "hidden"}
+    )
+  end
+
+  def range_input
+    input(
+      type: "range",
+      min: @min,
+      max: @max,
+      step: 1,
+      value: (@value * 100).round,
+      class: "w-full accent-accent",
+      aria_label: "Similarity threshold",
+      data: {
+        range_slider_target: "range",
+        action: "input->range-slider#update"
+      }
+    )
+  end
+
+  def readout_row
+    div(class: "flex items-center gap-2") do
+      span(
+        class: "font-mono text-sm font-semibold text-text-primary",
+        data: {range_slider_target: "readout"}
+      ) { "#{(@value * 100).round}%" }
+    end
+  end
+
+  def caption_row
+    div(class: "flex justify-between text-xs text-text-muted") do
+      span { "#{@min}% · loosely similar" }
+      span { "#{@max}% · identical" }
+    end
+  end
+end

--- a/app/components/sidebar_group.rb
+++ b/app/components/sidebar_group.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+class Components::SidebarGroup < Components::Base
+  STATUS_TONES = {
+    enabled: "bg-success",
+    disabled: "bg-border-strong",
+    needs_setup: "bg-warning"
+  }.freeze
+
+  def initialize(label:, icon:, open:, items:, storage_key:)
+    @label = label
+    @icon = icon
+    @open = open
+    @items = items
+    @storage_key = storage_key
+  end
+
+  def view_template
+    details(
+      open: @open || nil,
+      class: "group/details",
+      data: {
+        controller: "disclosure",
+        disclosure_key_value: @storage_key
+      }
+    ) do
+      summary_row
+      sub_items
+    end
+  end
+
+  private
+
+  def summary_row
+    summary(
+      class: "flex cursor-pointer list-none items-center gap-2.5 rounded-md px-2.5 py-2 text-text-secondary transition-colors hover:bg-surface-card [&::-webkit-details-marker]:hidden",
+      data: {action: "click->disclosure#toggle"}
+    ) do
+      parent_tile
+      span(class: "flex-1 text-[13px] font-medium") { @label }
+      chevron
+    end
+  end
+
+  def parent_tile
+    span(class: "flex size-7 flex-none items-center justify-center rounded-md bg-surface-card text-text-muted") do
+      render Components::Icon.new(@icon, class: "size-4")
+    end
+  end
+
+  def chevron
+    span(class: "text-text-muted") do
+      render Components::Icon.new("caret-right", class: "size-3.5 transition-transform group-open/details:rotate-90")
+    end
+  end
+
+  def sub_items
+    div(class: "ml-3 mt-0.5 border-l border-border-subtle pl-2") do
+      @items.each { |item| sub_item(item) }
+    end
+  end
+
+  def sub_item(item)
+    active = item[:active]
+    tone = active ? "bg-accent-soft font-semibold text-accent-soft-fg" : "text-text-secondary hover:bg-surface-card"
+    a(
+      href: item[:href],
+      aria_current: ("page" if active),
+      class: "flex items-center gap-2 rounded-md px-2.5 py-1.5 text-[13px] transition-colors #{tone}"
+    ) do
+      span(class: "flex-1") { item[:label] }
+      sub_item_dot(item[:status]) if item[:status]
+    end
+  end
+
+  def sub_item_dot(status)
+    tone = STATUS_TONES.fetch(status, "bg-border-strong")
+    span(class: "size-1.5 flex-none rounded-full #{tone}")
+  end
+end

--- a/app/components/sidebar_group.rb
+++ b/app/components/sidebar_group.rb
@@ -7,12 +7,13 @@ class Components::SidebarGroup < Components::Base
     needs_setup: "bg-warning"
   }.freeze
 
-  def initialize(label:, icon:, open:, items:, storage_key:)
+  def initialize(label:, icon:, open:, items:, storage_key:, enabled: false)
     @label = label
     @icon = icon
     @open = open
     @items = items
     @storage_key = storage_key
+    @enabled = enabled
   end
 
   def view_template
@@ -43,8 +44,10 @@ class Components::SidebarGroup < Components::Base
   end
 
   def parent_tile
-    span(class: "flex size-7 flex-none items-center justify-center rounded-md bg-surface-card text-text-muted") do
-      render Components::Icon.new(@icon, class: "size-4")
+    on = @enabled || @items.any? { |item| item[:active] }
+    tone = on ? "bg-accent-fill text-white" : "bg-surface-card text-text-muted"
+    span(class: "flex size-7 flex-none items-center justify-center rounded-md #{tone}") do
+      render Components::Icon.new(@icon, weight: (on ? :fill : :regular), class: "size-4")
     end
   end
 

--- a/app/components/toggle.rb
+++ b/app/components/toggle.rb
@@ -12,7 +12,7 @@ class Components::Toggle < Components::Base
     mini: "relative h-[18px] w-8 after:size-3.5 peer-checked:after:translate-x-3.5"
   }.freeze
 
-  def initialize(checked:, label:, name: nil, size: :md, url: nil, submit_on_change: false, dom_id: nil, disabled: false, data: {})
+  def initialize(checked:, label:, name: nil, size: :md, url: nil, submit_on_change: false, dom_id: nil, disabled: false, data: {}, form: nil)
     @name = name&.to_s
     @checked = checked
     @label = label
@@ -22,6 +22,7 @@ class Components::Toggle < Components::Base
     @dom_id = dom_id
     @disabled = disabled
     @data = data
+    @form = form
   end
 
   def view_template
@@ -37,7 +38,7 @@ class Components::Toggle < Components::Base
   private
 
   def switch
-    input(type: "hidden", name: @name, value: "0", autocomplete: "off") if @name && !@disabled
+    input(type: "hidden", name: @name, value: "0", autocomplete: "off", form: @form) if @name && !@disabled
     label(class: "inline-flex items-center #{@disabled ? "cursor-not-allowed opacity-60" : "cursor-pointer"}", aria_label: @label) do
       input(
         type: "checkbox",
@@ -47,7 +48,8 @@ class Components::Toggle < Components::Base
         disabled: @disabled,
         autocomplete: "off",
         class: "peer sr-only",
-        data: switch_data
+        data: switch_data,
+        form: @form
       )
       div(class: "#{SIZES.fetch(@size)} #{COMMON}")
     end

--- a/app/controllers/servers/image_scanning_controller.rb
+++ b/app/controllers/servers/image_scanning_controller.rb
@@ -29,7 +29,7 @@ class Servers::ImageScanningController < ApplicationController
     @enabled = activation.enabled?
     @enable_error = activation.errors[:enabled].first
     @toast = {level: "notice", message: t("servers.image_scanning.saved")} if result.success?
-    return redirect_to server_moderation_path(params[:server_id]), **flash_for(result) if params[:from_overview]
+    return redirect_to server_moderation_path(params[:server_id]), status: :see_other, **flash_for(result) if params[:from_overview]
 
     respond_to do |format|
       format.turbo_stream { render status: result.success? ? :ok : :unprocessable_content }

--- a/app/controllers/servers/image_scanning_controller.rb
+++ b/app/controllers/servers/image_scanning_controller.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class Servers::ImageScanningController < ApplicationController
+  include RequiresManageableServer
+  include ConfiguresPlugin
+
+  def show
+    render Views::Servers::ImageScanning::Show.new(
+      server_configuration: @server_configuration,
+      user: current_user,
+      enabled: plugin_enabled?
+    )
+  end
+
+  def update
+    result = Ops::Moderation::ImageScanning::Configure.call(
+      server_configuration: @server_configuration,
+      sensitivity: image_scanning_params[:sensitivity],
+      action: image_scanning_params[:action],
+      punishment: image_scanning_params[:punishment],
+      timeout_seconds: image_scanning_params[:timeout_seconds],
+      custom_keyword_min_hits: image_scanning_params[:custom_keyword_min_hits],
+      custom_keywords: image_scanning_params[:custom_keywords],
+      enabled: image_scanning_params[:enabled]
+    )
+    activation = result.value
+    @enabled = activation.enabled?
+    @enable_error = activation.errors[:enabled].first
+    @toast = {level: "notice", message: t("servers.image_scanning.saved")} if result.success?
+
+    respond_to do |format|
+      format.turbo_stream { render status: result.success? ? :ok : :unprocessable_content }
+      format.html { redirect_to server_image_scanning_path(params[:server_id]), **flash_for(result) }
+    end
+  end
+
+  private
+
+  def image_scanning_params
+    params.expect(
+      image_scanning: [
+        :sensitivity,
+        :action,
+        :punishment,
+        :timeout_seconds,
+        :custom_keyword_min_hits,
+        :enabled,
+        custom_keywords: []
+      ]
+    )
+  end
+end

--- a/app/controllers/servers/image_scanning_controller.rb
+++ b/app/controllers/servers/image_scanning_controller.rb
@@ -4,11 +4,13 @@ class Servers::ImageScanningController < ApplicationController
   include RequiresManageableServer
   include ConfiguresPlugin
 
+  before_action :build_context
+
   def show
     render Views::Servers::ImageScanning::Show.new(
       server_configuration: @server_configuration,
       user: current_user,
-      enabled: plugin_enabled?
+      context: @context
     )
   end
 
@@ -48,5 +50,9 @@ class Servers::ImageScanningController < ApplicationController
         custom_keywords: []
       ]
     )
+  end
+
+  def build_context
+    @context = Moderation::SubPluginContext.new(@server_configuration, :image_scanning)
   end
 end

--- a/app/controllers/servers/image_scanning_controller.rb
+++ b/app/controllers/servers/image_scanning_controller.rb
@@ -29,6 +29,7 @@ class Servers::ImageScanningController < ApplicationController
     @enabled = activation.enabled?
     @enable_error = activation.errors[:enabled].first
     @toast = {level: "notice", message: t("servers.image_scanning.saved")} if result.success?
+    return redirect_to server_moderation_path(params[:server_id]), **flash_for(result) if params[:from_overview]
 
     respond_to do |format|
       format.turbo_stream { render status: result.success? ? :ok : :unprocessable_content }

--- a/app/controllers/servers/moderation_controller.rb
+++ b/app/controllers/servers/moderation_controller.rb
@@ -22,7 +22,7 @@ class Servers::ModerationController < ApplicationController
     )
     activation = result.value
     @enabled = activation.enabled?
-    @enable_error = activation.errors[:enabled].first
+    @enable_error = activation.errors[:enabled].first || activation.errors[:staff_role_id].first
     @toast = {level: "notice", message: t("servers.moderation.saved")} if result.success?
 
     respond_to do |format|

--- a/app/controllers/servers/moderation_controller.rb
+++ b/app/controllers/servers/moderation_controller.rb
@@ -4,11 +4,13 @@ class Servers::ModerationController < ApplicationController
   include RequiresManageableServer
   include ConfiguresPlugin
 
+  before_action :build_context
+
   def show
     render Views::Servers::Moderation::Show.new(
       server_configuration: @server_configuration,
       user: current_user,
-      context: moderation_context
+      context: @context
     )
   end
 
@@ -35,7 +37,7 @@ class Servers::ModerationController < ApplicationController
     params.expect(moderation: [:staff_role_id, :enabled])
   end
 
-  def moderation_context
-    Moderation::OverviewContext.new(@server_configuration)
+  def build_context
+    @context = Moderation::OverviewContext.new(@server_configuration)
   end
 end

--- a/app/controllers/servers/moderation_controller.rb
+++ b/app/controllers/servers/moderation_controller.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class Servers::ModerationController < ApplicationController
+  include RequiresManageableServer
+  include ConfiguresPlugin
+
+  def show
+    render Views::Servers::Moderation::Show.new(
+      server_configuration: @server_configuration,
+      user: current_user,
+      context: moderation_context
+    )
+  end
+
+  def update
+    result = Ops::Moderation::Configure.call(
+      server_configuration: @server_configuration,
+      staff_role_id: moderation_params[:staff_role_id],
+      enabled: moderation_params[:enabled]
+    )
+    activation = result.value
+    @enabled = activation.enabled?
+    @enable_error = activation.errors[:enabled].first
+    @toast = {level: "notice", message: t("servers.moderation.saved")} if result.success?
+
+    respond_to do |format|
+      format.turbo_stream { render status: result.success? ? :ok : :unprocessable_content }
+      format.html { redirect_to server_moderation_path(params[:server_id]), **flash_for(result) }
+    end
+  end
+
+  private
+
+  def moderation_params
+    params.expect(moderation: [:staff_role_id, :enabled])
+  end
+
+  def moderation_context
+    Moderation::OverviewContext.new(@server_configuration)
+  end
+end

--- a/app/controllers/servers/spam_protection_controller.rb
+++ b/app/controllers/servers/spam_protection_controller.rb
@@ -30,6 +30,7 @@ class Servers::SpamProtectionController < ApplicationController
     @enabled = activation.enabled?
     @enable_error = activation.errors[:enabled].first
     @toast = {level: "notice", message: t("servers.spam_protection.saved")} if result.success?
+    return redirect_to server_moderation_path(params[:server_id]), **flash_for(result) if params[:from_overview]
 
     respond_to do |format|
       format.turbo_stream { render status: result.success? ? :ok : :unprocessable_content }

--- a/app/controllers/servers/spam_protection_controller.rb
+++ b/app/controllers/servers/spam_protection_controller.rb
@@ -30,7 +30,7 @@ class Servers::SpamProtectionController < ApplicationController
     @enabled = activation.enabled?
     @enable_error = activation.errors[:enabled].first
     @toast = {level: "notice", message: t("servers.spam_protection.saved")} if result.success?
-    return redirect_to server_moderation_path(params[:server_id]), **flash_for(result) if params[:from_overview]
+    return redirect_to server_moderation_path(params[:server_id]), status: :see_other, **flash_for(result) if params[:from_overview]
 
     respond_to do |format|
       format.turbo_stream { render status: result.success? ? :ok : :unprocessable_content }

--- a/app/controllers/servers/spam_protection_controller.rb
+++ b/app/controllers/servers/spam_protection_controller.rb
@@ -4,11 +4,13 @@ class Servers::SpamProtectionController < ApplicationController
   include RequiresManageableServer
   include ConfiguresPlugin
 
+  before_action :build_context
+
   def show
     render Views::Servers::SpamProtection::Show.new(
       server_configuration: @server_configuration,
       user: current_user,
-      enabled: plugin_enabled?
+      context: @context
     )
   end
 
@@ -50,5 +52,9 @@ class Servers::SpamProtectionController < ApplicationController
         :enabled
       ]
     )
+  end
+
+  def build_context
+    @context = Moderation::SubPluginContext.new(@server_configuration, :spam_protection)
   end
 end

--- a/app/controllers/servers/spam_protection_controller.rb
+++ b/app/controllers/servers/spam_protection_controller.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class Servers::SpamProtectionController < ApplicationController
+  include RequiresManageableServer
+  include ConfiguresPlugin
+
+  def show
+    render Views::Servers::SpamProtection::Show.new(
+      server_configuration: @server_configuration,
+      user: current_user,
+      enabled: plugin_enabled?
+    )
+  end
+
+  def update
+    result = Ops::Moderation::SpamProtection::Configure.call(
+      server_configuration: @server_configuration,
+      channel_threshold: spam_protection_params[:channel_threshold],
+      window_seconds: spam_protection_params[:window_seconds],
+      similarity: spam_protection_params[:similarity],
+      match_symbol_only_messages: spam_protection_params[:match_symbol_only_messages],
+      action: spam_protection_params[:action],
+      punishment: spam_protection_params[:punishment],
+      timeout_seconds: spam_protection_params[:timeout_seconds],
+      enabled: spam_protection_params[:enabled]
+    )
+    activation = result.value
+    @enabled = activation.enabled?
+    @enable_error = activation.errors[:enabled].first
+    @toast = {level: "notice", message: t("servers.spam_protection.saved")} if result.success?
+
+    respond_to do |format|
+      format.turbo_stream { render status: result.success? ? :ok : :unprocessable_content }
+      format.html { redirect_to server_spam_protection_path(params[:server_id]), **flash_for(result) }
+    end
+  end
+
+  private
+
+  def spam_protection_params
+    params.expect(
+      spam_protection: [
+        :channel_threshold,
+        :window_seconds,
+        :similarity,
+        :match_symbol_only_messages,
+        :action,
+        :punishment,
+        :timeout_seconds,
+        :enabled
+      ]
+    )
+  end
+end

--- a/app/javascript/controllers/disclosure_controller.js
+++ b/app/javascript/controllers/disclosure_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = { key: String }
+
+  connect() {
+    if (this.element.open) return
+
+    const stored = localStorage.getItem(this.keyValue)
+    if (stored === "open") this.element.open = true
+  }
+
+  toggle(event) {
+    event.preventDefault()
+    this.element.open = !this.element.open
+    localStorage.setItem(this.keyValue, this.element.open ? "open" : "closed")
+  }
+}

--- a/app/javascript/controllers/number_stepper_controller.js
+++ b/app/javascript/controllers/number_stepper_controller.js
@@ -1,0 +1,25 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["input"]
+  static values = { min: Number, max: Number }
+
+  increment() {
+    const current = parseInt(this.inputTarget.value, 10) || 0
+    const next = current + 1
+    const cap = this.hasMaxValue ? this.maxValue : Infinity
+    this.inputTarget.value = Math.min(next, cap)
+    this.#dispatch()
+  }
+
+  decrement() {
+    const current = parseInt(this.inputTarget.value, 10) || 0
+    const next = current - 1
+    this.inputTarget.value = Math.max(next, this.minValue)
+    this.#dispatch()
+  }
+
+  #dispatch() {
+    this.inputTarget.dispatchEvent(new Event("input", { bubbles: true }))
+  }
+}

--- a/app/javascript/controllers/punishment_controller.js
+++ b/app/javascript/controllers/punishment_controller.js
@@ -1,0 +1,29 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["duration", "banWarning"]
+
+  connect() {
+    this.update()
+    this.element.addEventListener("input", this.onInput)
+  }
+
+  disconnect() {
+    this.element.removeEventListener("input", this.onInput)
+  }
+
+  onInput = (event) => {
+    if (event.target.type === "hidden" && event.target.closest("[data-controller~='segmented']")) {
+      this.update()
+    }
+  }
+
+  update() {
+    const input = this.element.querySelector("[data-segmented-target='input']")
+    if (!input) return
+
+    const value = input.value
+    if (this.hasDurationTarget) this.durationTarget.hidden = value !== "timeout"
+    if (this.hasBanWarningTarget) this.banWarningTarget.hidden = value !== "ban"
+  }
+}

--- a/app/javascript/controllers/range_slider_controller.js
+++ b/app/javascript/controllers/range_slider_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["range", "hidden", "readout"]
+
+  update() {
+    const pct = parseInt(this.rangeTarget.value, 10)
+    this.readoutTarget.textContent = `${pct}%`
+    this.hiddenTarget.value = (pct / 100).toFixed(2)
+    this.hiddenTarget.dispatchEvent(new Event("input", { bubbles: true }))
+  }
+}

--- a/app/javascript/controllers/toggle_controller.js
+++ b/app/javascript/controllers/toggle_controller.js
@@ -4,6 +4,7 @@ export default class extends Controller {
   submit() {
     // requestSubmit (not submit) fires the submit event so Turbo intercepts it
     // and the flip saves in place instead of doing a full-page navigation.
-    this.element.closest("form").requestSubmit()
+    // element.form also honors a form="" attribute, which closest() would miss.
+    this.element.form.requestSubmit()
   }
 }

--- a/app/javascript/controllers/tom_select_controller.js
+++ b/app/javascript/controllers/tom_select_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 import TomSelect from "tom-select"
 
 export default class extends Controller {
-  static values = { placeholder: String, prefix: String, colorDots: Boolean, lockIcon: String }
+  static values = { placeholder: String, prefix: String, colorDots: Boolean, lockIcon: String, create: Boolean }
 
   connect() {
     this.select = new TomSelect(this.element, {
@@ -10,11 +10,14 @@ export default class extends Controller {
       allowEmptyOption: false,
       maxOptions: null,
       plugins: this.plugins(),
-      render: this.renderers()
+      render: this.renderers(),
+      create: this.createValue || false,
+      persist: this.createValue ? false : undefined
     })
   }
 
   plugins() {
+    if (this.createValue) return ["remove_button"]
     return this.colorDotsValue ? ["dropdown_input", "remove_button"] : ["dropdown_input", "clear_button"]
   }
 

--- a/app/javascript/controllers/tom_select_controller.js
+++ b/app/javascript/controllers/tom_select_controller.js
@@ -18,7 +18,8 @@ export default class extends Controller {
 
   plugins() {
     if (this.createValue) return ["remove_button"]
-    return this.colorDotsValue ? ["dropdown_input", "remove_button"] : ["dropdown_input", "clear_button"]
+    const removal = this.element.multiple ? "remove_button" : "clear_button"
+    return ["dropdown_input", removal]
   }
 
   renderers() {

--- a/app/models/plugin_catalog.rb
+++ b/app/models/plugin_catalog.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class PluginCatalog
-  Definition = Data.define(:key, :name, :description, :channel_setting, :requires_plugin, :parent) do
-    def initialize(key:, name:, description:, channel_setting: nil, requires_plugin: nil, parent: nil)
+  Definition = Data.define(:key, :name, :description, :channel_setting, :requires_plugin, :parent, :prerequisite) do
+    def initialize(key:, name:, description:, channel_setting: nil, requires_plugin: nil, parent: nil, prerequisite: nil)
       super
     end
 
@@ -12,9 +12,10 @@ class PluginCatalog
 
     def prerequisites_met?(server_configuration)
       return false unless required_plugins_enabled?(server_configuration)
-      return true unless channel_backed?
+      return false unless channel_met?(server_configuration)
+      return false unless prerequisite.nil? || prerequisite.call(server_configuration)
 
-      server_configuration.public_send(channel_setting)&.channel_id.present?
+      true
     end
 
     private
@@ -24,15 +25,21 @@ class PluginCatalog
         server_configuration.plugins.enabled.exists?(key:)
       end
     end
+
+    def channel_met?(server_configuration)
+      return true unless channel_backed?
+
+      server_configuration.public_send(channel_setting)&.channel_id.present?
+    end
   end
 
   DEFINITIONS = [
     Definition.new(key: :logging, name: "Logging", description: "Writes moderation actions to a log channel.", channel_setting: :logging_setting),
     Definition.new(key: :roles, name: "Roles", description: "Self-assignable roles.", channel_setting: :role_setting),
     Definition.new(key: :welcomes, name: "Welcomes", description: "Join and leave messages.", channel_setting: :welcome_settings),
-    Definition.new(key: :moderation, name: "Server Shield", description: "Your server's aegis: automated moderation beyond Discord's AutoMod.", requires_plugin: :logging),
-    Definition.new(key: :spam_protection, name: "Cross-Channel Spam Guard", description: "Detects the same message blasted across multiple channels within seconds and purges it before it spreads. Matching is fingerprint-based — message content is never stored.", parent: :moderation),
-    Definition.new(key: :image_scanning, name: "Scam Image Detection", description: "Reads the text inside posted images and checks it against known scam patterns and previously confirmed scam images. Staff confirm or dismiss every catch, and the bot remembers.", parent: :moderation)
+    Definition.new(key: :moderation, name: "Server Shield", description: "Your server's aegis: automated moderation beyond Discord's AutoMod.", requires_plugin: :logging, prerequisite: ->(c) { c.logging_setting&.channel_id.present? }),
+    Definition.new(key: :spam_protection, name: "Cross-Channel Spam Guard", description: "Detects the same message blasted across multiple channels within seconds and purges it before it spreads. Matching is fingerprint-based — message content is never stored.", parent: :moderation, prerequisite: ->(c) { c.moderation_settings&.staff_role_id.present? }),
+    Definition.new(key: :image_scanning, name: "Scam Image Detection", description: "Reads the text inside posted images and checks it against known scam patterns and previously confirmed scam images. Staff confirm or dismiss every catch, and the bot remembers.", parent: :moderation, prerequisite: ->(c) { c.moderation_settings&.staff_role_id.present? })
   ].freeze
 
   def self.all

--- a/app/models/plugin_catalog.rb
+++ b/app/models/plugin_catalog.rb
@@ -53,4 +53,12 @@ class PluginCatalog
   def self.channel_backed
     DEFINITIONS.select(&:channel_backed?)
   end
+
+  def self.sub_plugin?(key)
+    find(key)&.parent.present?
+  end
+
+  def self.sub_plugin_keys(parent_key)
+    all.select { |definition| definition.parent == parent_key }.map(&:key)
+  end
 end

--- a/app/operations/moderation/configure.rb
+++ b/app/operations/moderation/configure.rb
@@ -13,6 +13,7 @@ module Ops
         activation = staged_activation
 
         return logging_guard_failure(activation) if enabling? && !logging_ready?
+        return staff_role_clear_failure(activation) if staff_role_id.blank? && sub_plugin_enabled?
 
         settings.save!
         activation.save!
@@ -26,9 +27,18 @@ module Ops
           server_configuration.logging_setting&.channel_id.present?
       end
 
+      def sub_plugin_enabled?
+        server_configuration.plugins.enabled.exists?(key: [:spam_protection, :image_scanning])
+      end
+
       def logging_guard_failure(activation)
         activation.errors.add(:enabled, "requires the Logging plugin enabled with a log channel set")
         failure(activation.errors[:enabled], value: activation)
+      end
+
+      def staff_role_clear_failure(activation)
+        activation.errors.add(:staff_role_id, "A staff role is required while a sub-plugin is enabled.")
+        failure(activation.errors[:staff_role_id], value: activation)
       end
 
       def plugin_key

--- a/app/operations/moderation/image_scanning/configure.rb
+++ b/app/operations/moderation/image_scanning/configure.rb
@@ -24,7 +24,7 @@ module Ops
             punishment:,
             timeout_seconds:,
             custom_keyword_min_hits:,
-            custom_keywords: Array(custom_keywords)
+            custom_keywords: Array(custom_keywords).reject(&:blank?)
           )
           activation = staged_activation
 

--- a/app/plugins/moderation/events/spam_guard.rb
+++ b/app/plugins/moderation/events/spam_guard.rb
@@ -100,7 +100,7 @@ module Moderation
           channels: channels.map { |id| "<##{id}>" }.join(", ")
         ),
         meta: I18n.t("moderation.spam_protection.notification.meta.#{settings.action}"),
-        allowed_mentions: {parse: [], roles: [staff_role_id].compact}
+        allowed_mentions: {parse: [], roles: [staff_role_id]}
       )
     end
   end

--- a/app/plugins/moderation/staff_ping.rb
+++ b/app/plugins/moderation/staff_ping.rb
@@ -5,7 +5,7 @@ module Moderation
     module_function
 
     def prefix(staff_role_id)
-      staff_role_id ? "<@&#{staff_role_id}> " : ""
+      "<@&#{staff_role_id}> "
     end
   end
 end

--- a/app/presenters/moderation/overview_context.rb
+++ b/app/presenters/moderation/overview_context.rb
@@ -31,6 +31,7 @@ module Moderation
     end
 
     def permission_warning?
+      # Mention-All-Roles detection lands here once bot permissions are stored
       false
     end
 

--- a/app/presenters/moderation/overview_context.rb
+++ b/app/presenters/moderation/overview_context.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Moderation
+  class OverviewContext
+    SubPluginRow = Data.define(:key, :name, :description, :enabled, :configured, :settings)
+
+    SUB_PLUGINS = [
+      {key: :spam_protection, settings_method: :spam_protection_settings},
+      {key: :image_scanning, settings_method: :image_scanning_settings}
+    ].freeze
+
+    def initialize(server_configuration)
+      @config = server_configuration
+    end
+
+    def group_enabled?
+      @config.plugins.enabled.exists?(key: :moderation)
+    end
+
+    def logging_ready?
+      @config.plugins.enabled.exists?(key: :logging) &&
+        @config.logging_setting&.channel_id.present?
+    end
+
+    def staff_role_id
+      @config.moderation_settings&.staff_role_id
+    end
+
+    def staff_role_present?
+      staff_role_id.present?
+    end
+
+    def permission_warning?
+      false
+    end
+
+    def sub_plugin_rows
+      SUB_PLUGINS.map do |sub|
+        key = sub[:key]
+        definition = PluginCatalog.find(key)
+        settings = @config.public_send(sub[:settings_method])
+        SubPluginRow.new(
+          key:,
+          name: definition.name,
+          description: definition.description,
+          enabled: @config.plugins.enabled.exists?(key:),
+          configured: definition.prerequisites_met?(@config),
+          settings:
+        )
+      end
+    end
+
+    def logging_channel_name
+      return unless @config.logging_setting&.channel_id
+
+      @config.server_channels.find_by(discord_id: @config.logging_setting.channel_id)&.name
+    end
+  end
+end

--- a/app/presenters/moderation/sub_plugin_context.rb
+++ b/app/presenters/moderation/sub_plugin_context.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Moderation
+  class SubPluginContext
+    def initialize(server_configuration, plugin_key)
+      @config = server_configuration
+      @plugin_key = plugin_key
+    end
+
+    def group_enabled?
+      @config.plugins.enabled.exists?(key: :moderation)
+    end
+
+    def staff_role_present?
+      @config.moderation_settings&.staff_role_id.present?
+    end
+
+    def plugin_enabled?
+      @config.plugins.enabled.exists?(key: @plugin_key)
+    end
+
+    def settings
+      case @plugin_key
+      when :spam_protection
+        @config.spam_protection_settings
+      when :image_scanning
+        @config.image_scanning_settings
+      end
+    end
+  end
+end

--- a/app/presenters/moderation/sub_plugin_context.rb
+++ b/app/presenters/moderation/sub_plugin_context.rb
@@ -20,10 +20,9 @@ module Moderation
     end
 
     def settings
-      case @plugin_key
-      when :spam_protection
+      if @plugin_key == :spam_protection
         @config.spam_protection_settings
-      when :image_scanning
+      else
         @config.image_scanning_settings
       end
     end

--- a/app/views/servers/image_scanning/show.rb
+++ b/app/views/servers/image_scanning/show.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class Views::Servers::ImageScanning::Show < Views::Base
+  def initialize(server_configuration:, user:, enabled:)
+    @config = server_configuration
+    @user = user
+    @enabled = enabled
+  end
+
+  def view_template
+    render Components::PluginShell.new(
+      user: @user,
+      server_configuration: @config,
+      active_key: :image_scanning
+    ) do
+      render Components::Moderation::ConfigShell.new(
+        header: Components::ConfigPageHeader.new(
+          icon: "scan",
+          title: t(".title"),
+          description: t(".description")
+        ),
+        server_configuration: @config,
+        url: server_image_scanning_path(@config.discord_id),
+        gate: nil,
+        toggle: {
+          field: "image_scanning[enabled]",
+          enabled: @enabled,
+          locked: false
+        },
+        breadcrumb_extra: t(".title")
+      ) do
+        div(id: "image_scanning-config") { "" }
+      end
+    end
+  end
+end

--- a/app/views/servers/image_scanning/show.rb
+++ b/app/views/servers/image_scanning/show.rb
@@ -20,9 +20,6 @@ class Views::Servers::ImageScanning::Show < Views::Servers::Moderation::SubPlugi
   end
 
   def form
-    Components::Moderation::ImageScanningForm.new(
-      server_configuration: @config,
-      context: @context
-    )
+    Components::Moderation::ImageScanningForm.new(context: @context)
   end
 end

--- a/app/views/servers/image_scanning/show.rb
+++ b/app/views/servers/image_scanning/show.rb
@@ -1,36 +1,28 @@
 # frozen_string_literal: true
 
-class Views::Servers::ImageScanning::Show < Views::Base
-  def initialize(server_configuration:, user:, enabled:)
-    @config = server_configuration
-    @user = user
-    @enabled = enabled
+class Views::Servers::ImageScanning::Show < Views::Servers::Moderation::SubPluginShow
+  private
+
+  def active_key
+    :image_scanning
   end
 
-  def view_template
-    render Components::PluginShell.new(
-      user: @user,
+  def icon
+    "scan"
+  end
+
+  def url
+    server_image_scanning_path(@config.discord_id)
+  end
+
+  def enable_field
+    "image_scanning[enabled]"
+  end
+
+  def form
+    Components::Moderation::ImageScanningForm.new(
       server_configuration: @config,
-      active_key: :image_scanning
-    ) do
-      render Components::Moderation::ConfigShell.new(
-        header: Components::ConfigPageHeader.new(
-          icon: "scan",
-          title: t(".title"),
-          description: t(".description")
-        ),
-        server_configuration: @config,
-        url: server_image_scanning_path(@config.discord_id),
-        gate: nil,
-        toggle: {
-          field: "image_scanning[enabled]",
-          enabled: @enabled,
-          locked: false
-        },
-        breadcrumb_extra: t(".title")
-      ) do
-        div(id: "image_scanning-config") { "" }
-      end
-    end
+      context: @context
+    )
   end
 end

--- a/app/views/servers/image_scanning/update.turbo_stream.erb
+++ b/app/views/servers/image_scanning/update.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%= turbo_stream.replace "image_scanning-config", html: render(Components::Moderation::ImageScanningForm.new(server_configuration: @server_configuration, context: @context, enable_error: @enable_error)) %>
+<%= turbo_stream.append "toasts", html: render(Components::Toast.new(**@toast)) if @toast %>

--- a/app/views/servers/image_scanning/update.turbo_stream.erb
+++ b/app/views/servers/image_scanning/update.turbo_stream.erb
@@ -1,2 +1,2 @@
-<%= turbo_stream.replace "image_scanning-config", html: render(Components::Moderation::ImageScanningForm.new(server_configuration: @server_configuration, context: @context, enable_error: @enable_error)) %>
+<%= turbo_stream.replace "image_scanning-config", html: render(Components::Moderation::ImageScanningForm.new(context: @context, enable_error: @enable_error)) %>
 <%= turbo_stream.append "toasts", html: render(Components::Toast.new(**@toast)) if @toast %>

--- a/app/views/servers/image_scanning/update.turbo_stream.erb
+++ b/app/views/servers/image_scanning/update.turbo_stream.erb
@@ -1,2 +1,3 @@
 <%= turbo_stream.replace "image_scanning-config", html: render(Components::Moderation::ImageScanningForm.new(context: @context, enable_error: @enable_error)) %>
 <%= turbo_stream.append "toasts", html: render(Components::Toast.new(**@toast)) if @toast %>
+<%= turbo_stream.replace "plugin-sidebar", html: render(Components::PluginSidebar.new(server_configuration: @server_configuration, active_key: :image_scanning)) %>

--- a/app/views/servers/moderation/show.rb
+++ b/app/views/servers/moderation/show.rb
@@ -2,6 +2,7 @@
 
 class Views::Servers::Moderation::Show < Views::Base
   include Phlex::Rails::Helpers::FormWith
+  include Components::PluginNav
 
   def initialize(server_configuration:, user:, context:)
     @config = server_configuration
@@ -39,19 +40,14 @@ class Views::Servers::Moderation::Show < Views::Base
   private
 
   def sub_plugin_toggle_forms
-    form_with(
-      url: server_spam_protection_path(@config.discord_id),
-      method: :patch,
-      id: "spam_protection-overview-toggle-form",
-      class: "hidden"
-    ) do
-    end
-    form_with(
-      url: server_image_scanning_path(@config.discord_id),
-      method: :patch,
-      id: "image_scanning-overview-toggle-form",
-      class: "hidden"
-    ) do
+    PluginCatalog.sub_plugin_keys(:moderation).each do |key|
+      form_with(
+        url: plugin_config_path(@config.discord_id, key),
+        method: :patch,
+        id: Components::Moderation::SubPluginRow.toggle_form_id(key),
+        class: "hidden"
+      ) do
+      end
     end
   end
 

--- a/app/views/servers/moderation/show.rb
+++ b/app/views/servers/moderation/show.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Views::Servers::Moderation::Show < Views::Base
+  include Phlex::Rails::Helpers::FormWith
+
   def initialize(server_configuration:, user:, context:)
     @config = server_configuration
     @user = user
@@ -30,10 +32,28 @@ class Views::Servers::Moderation::Show < Views::Base
           context: @context
         )
       end
+      sub_plugin_toggle_forms
     end
   end
 
   private
+
+  def sub_plugin_toggle_forms
+    form_with(
+      url: server_spam_protection_path(@config.discord_id),
+      method: :patch,
+      id: "spam_protection-overview-toggle-form",
+      class: "hidden"
+    ) do
+    end
+    form_with(
+      url: server_image_scanning_path(@config.discord_id),
+      method: :patch,
+      id: "image_scanning-overview-toggle-form",
+      class: "hidden"
+    ) do
+    end
+  end
 
   def shell_gate
     if !@context.logging_ready?

--- a/app/views/servers/moderation/show.rb
+++ b/app/views/servers/moderation/show.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+class Views::Servers::Moderation::Show < Views::Base
+  def initialize(server_configuration:, user:, context:)
+    @config = server_configuration
+    @user = user
+    @context = context
+  end
+
+  def view_template
+    render Components::PluginShell.new(
+      user: @user,
+      server_configuration: @config,
+      active_key: :moderation
+    ) do
+      render Components::Moderation::ConfigShell.new(
+        header: Components::ConfigPageHeader.new(
+          icon: "shield",
+          title: t(".title"),
+          description: t(".description")
+        ),
+        server_configuration: @config,
+        url: server_moderation_path(@config.discord_id),
+        gate: shell_gate,
+        toggle: shell_toggle
+      ) do
+        logging_subline
+        render Components::Moderation::OverviewForm.new(
+          server_configuration: @config,
+          context: @context
+        )
+      end
+    end
+  end
+
+  private
+
+  def shell_gate
+    if !@context.logging_ready?
+      {
+        type: :prereq,
+        icon: "scroll",
+        title: t(".prereq_gate_title"),
+        message: t(".prereq_gate_message"),
+        cta_label: t(".prereq_gate_cta"),
+        cta_href: server_logging_path(@config.discord_id)
+      }
+    elsif !@context.group_enabled?
+      {
+        type: :enable,
+        message: t(".gate_message")
+      }
+    end
+  end
+
+  def shell_toggle
+    if !@context.logging_ready?
+      {
+        field: "moderation[enabled]",
+        enabled: @context.group_enabled?,
+        locked: true,
+        reason: t(".toggle_locked_reason")
+      }
+    else
+      {
+        field: "moderation[enabled]",
+        enabled: @context.group_enabled?,
+        locked: false
+      }
+    end
+  end
+
+  def logging_subline
+    return unless @context.logging_ready? && @context.logging_channel_name
+
+    p(class: "mb-6 flex items-center gap-1.5 pl-16 text-xs text-text-muted") do
+      render Components::Icon.new("scroll", class: "size-4")
+      span do
+        plain t(".logging_subline_prefix")
+        code(class: "font-mono") { "##{@context.logging_channel_name}" }
+        plain " "
+        plain t(".logging_subline_suffix")
+      end
+    end
+  end
+end

--- a/app/views/servers/moderation/sub_plugin_show.rb
+++ b/app/views/servers/moderation/sub_plugin_show.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+class Views::Servers::Moderation::SubPluginShow < Views::Base
+  def initialize(server_configuration:, user:, context:)
+    @config = server_configuration
+    @user = user
+    @context = context
+  end
+
+  def view_template
+    render Components::PluginShell.new(
+      user: @user,
+      server_configuration: @config,
+      active_key:
+    ) do
+      render Components::Moderation::ConfigShell.new(
+        header: Components::ConfigPageHeader.new(
+          icon:,
+          title: t(".title"),
+          description: t(".description")
+        ),
+        server_configuration: @config,
+        url:,
+        gate: shell_gate,
+        toggle: shell_toggle,
+        breadcrumb_extra: t(".title")
+      ) do
+        group_subline
+        no_role_callout
+        render form
+      end
+    end
+  end
+
+  private
+
+  def active_key
+    raise AbstractMethodError
+  end
+
+  def icon
+    raise AbstractMethodError
+  end
+
+  def url
+    raise AbstractMethodError
+  end
+
+  def enable_field
+    raise AbstractMethodError
+  end
+
+  def form
+    raise AbstractMethodError
+  end
+
+  def shell_gate
+    return if @context.group_enabled?
+
+    {
+      type: :prereq,
+      icon: "shield",
+      title: t(".prereq_gate_title"),
+      message: t(".prereq_gate_message"),
+      cta_label: t(".prereq_gate_cta"),
+      cta_href: server_moderation_path(@config.discord_id)
+    }
+  end
+
+  def shell_toggle
+    {
+      field: enable_field,
+      enabled: @context.plugin_enabled?,
+      locked: toggle_locked?,
+      reason: toggle_reason
+    }
+  end
+
+  def toggle_locked?
+    !@context.group_enabled? || !@context.staff_role_present?
+  end
+
+  def toggle_reason
+    return t(".group_locked_reason") unless @context.group_enabled?
+
+    t(".role_locked_reason") unless @context.staff_role_present?
+  end
+
+  def group_subline
+    p(class: "text-xs text-text-muted mb-6 flex items-center gap-1.5 pl-16") do
+      render Components::Icon.new("shield", class: "size-4")
+      span do
+        plain t(".subline_prefix")
+        a(href: server_moderation_path(@config.discord_id), class: "underline hover:text-text-secondary") do
+          plain t(".subline_link")
+        end
+        plain t(".subline_suffix")
+      end
+    end
+  end
+
+  def no_role_callout
+    return unless @context.group_enabled? && !@context.staff_role_present?
+
+    render Components::Callout.new(variant: :warning) do
+      span do
+        b(class: "text-warning") { t(".no_role_callout_lead") }
+        plain " "
+        plain t(".no_role_callout_body")
+        plain " "
+        a(href: server_moderation_path(@config.discord_id), class: "underline") { t(".no_role_callout_link") }
+        plain t(".no_role_callout_suffix")
+      end
+    end
+  end
+end

--- a/app/views/servers/moderation/sub_plugin_show.rb
+++ b/app/views/servers/moderation/sub_plugin_show.rb
@@ -34,26 +34,6 @@ class Views::Servers::Moderation::SubPluginShow < Views::Base
 
   private
 
-  def active_key
-    raise AbstractMethodError
-  end
-
-  def icon
-    raise AbstractMethodError
-  end
-
-  def url
-    raise AbstractMethodError
-  end
-
-  def enable_field
-    raise AbstractMethodError
-  end
-
-  def form
-    raise AbstractMethodError
-  end
-
   def shell_gate
     return if @context.group_enabled?
 

--- a/app/views/servers/moderation/update.turbo_stream.erb
+++ b/app/views/servers/moderation/update.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%= turbo_stream.replace "moderation-config", html: render(Components::Moderation::OverviewForm.new(server_configuration: @server_configuration, context: Moderation::OverviewContext.new(@server_configuration), enable_error: @enable_error)) %>
+<%= turbo_stream.append "toasts", html: render(Components::Toast.new(**@toast)) if @toast %>

--- a/app/views/servers/moderation/update.turbo_stream.erb
+++ b/app/views/servers/moderation/update.turbo_stream.erb
@@ -1,2 +1,2 @@
-<%= turbo_stream.replace "moderation-config", html: render(Components::Moderation::OverviewForm.new(server_configuration: @server_configuration, context: Moderation::OverviewContext.new(@server_configuration), enable_error: @enable_error)) %>
+<%= turbo_stream.replace "moderation-config", html: render(Components::Moderation::OverviewForm.new(server_configuration: @server_configuration, context: @context, enable_error: @enable_error)) %>
 <%= turbo_stream.append "toasts", html: render(Components::Toast.new(**@toast)) if @toast %>

--- a/app/views/servers/moderation/update.turbo_stream.erb
+++ b/app/views/servers/moderation/update.turbo_stream.erb
@@ -1,2 +1,3 @@
 <%= turbo_stream.replace "moderation-config", html: render(Components::Moderation::OverviewForm.new(server_configuration: @server_configuration, context: @context, enable_error: @enable_error)) %>
 <%= turbo_stream.append "toasts", html: render(Components::Toast.new(**@toast)) if @toast %>
+<%= turbo_stream.replace "plugin-sidebar", html: render(Components::PluginSidebar.new(server_configuration: @server_configuration, active_key: :moderation)) %>

--- a/app/views/servers/show.rb
+++ b/app/views/servers/show.rb
@@ -58,7 +58,7 @@ class Views::Servers::Show < Views::Base
   def plugins_section
     p(class: "mb-3 text-[11px] font-semibold uppercase tracking-widest text-eyebrow") { t(".plugins") }
     div(class: "flex flex-col gap-3") do
-      @plugins.select { |row| plugin_config_path(@guild.id, row.key) }.each do |row|
+      @plugins.select { |row| plugin_config_path(@guild.id, row.key) && !PluginCatalog.sub_plugin?(row.key) }.each do |row|
         render Components::PluginRow.new(server_id: @guild.id, key: row.key, enabled: row.enabled, configured: row.configured, locked: row.locked)
       end
     end

--- a/app/views/servers/spam_protection/show.rb
+++ b/app/views/servers/spam_protection/show.rb
@@ -1,36 +1,28 @@
 # frozen_string_literal: true
 
-class Views::Servers::SpamProtection::Show < Views::Base
-  def initialize(server_configuration:, user:, enabled:)
-    @config = server_configuration
-    @user = user
-    @enabled = enabled
+class Views::Servers::SpamProtection::Show < Views::Servers::Moderation::SubPluginShow
+  private
+
+  def active_key
+    :spam_protection
   end
 
-  def view_template
-    render Components::PluginShell.new(
-      user: @user,
+  def icon
+    "megaphone-slash"
+  end
+
+  def url
+    server_spam_protection_path(@config.discord_id)
+  end
+
+  def enable_field
+    "spam_protection[enabled]"
+  end
+
+  def form
+    Components::Moderation::SpamProtectionForm.new(
       server_configuration: @config,
-      active_key: :spam_protection
-    ) do
-      render Components::Moderation::ConfigShell.new(
-        header: Components::ConfigPageHeader.new(
-          icon: "megaphone-slash",
-          title: t(".title"),
-          description: t(".description")
-        ),
-        server_configuration: @config,
-        url: server_spam_protection_path(@config.discord_id),
-        gate: nil,
-        toggle: {
-          field: "spam_protection[enabled]",
-          enabled: @enabled,
-          locked: false
-        },
-        breadcrumb_extra: t(".title")
-      ) do
-        div(id: "spam_protection-config") { "" }
-      end
-    end
+      context: @context
+    )
   end
 end

--- a/app/views/servers/spam_protection/show.rb
+++ b/app/views/servers/spam_protection/show.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class Views::Servers::SpamProtection::Show < Views::Base
+  def initialize(server_configuration:, user:, enabled:)
+    @config = server_configuration
+    @user = user
+    @enabled = enabled
+  end
+
+  def view_template
+    render Components::PluginShell.new(
+      user: @user,
+      server_configuration: @config,
+      active_key: :spam_protection
+    ) do
+      render Components::Moderation::ConfigShell.new(
+        header: Components::ConfigPageHeader.new(
+          icon: "megaphone-slash",
+          title: t(".title"),
+          description: t(".description")
+        ),
+        server_configuration: @config,
+        url: server_spam_protection_path(@config.discord_id),
+        gate: nil,
+        toggle: {
+          field: "spam_protection[enabled]",
+          enabled: @enabled,
+          locked: false
+        },
+        breadcrumb_extra: t(".title")
+      ) do
+        div(id: "spam_protection-config") { "" }
+      end
+    end
+  end
+end

--- a/app/views/servers/spam_protection/show.rb
+++ b/app/views/servers/spam_protection/show.rb
@@ -20,9 +20,6 @@ class Views::Servers::SpamProtection::Show < Views::Servers::Moderation::SubPlug
   end
 
   def form
-    Components::Moderation::SpamProtectionForm.new(
-      server_configuration: @config,
-      context: @context
-    )
+    Components::Moderation::SpamProtectionForm.new(context: @context)
   end
 end

--- a/app/views/servers/spam_protection/update.turbo_stream.erb
+++ b/app/views/servers/spam_protection/update.turbo_stream.erb
@@ -1,2 +1,2 @@
-<%= turbo_stream.replace "spam_protection-config", html: render(Components::Moderation::SpamProtectionForm.new(server_configuration: @server_configuration, context: @context, enable_error: @enable_error)) %>
+<%= turbo_stream.replace "spam_protection-config", html: render(Components::Moderation::SpamProtectionForm.new(context: @context, enable_error: @enable_error)) %>
 <%= turbo_stream.append "toasts", html: render(Components::Toast.new(**@toast)) if @toast %>

--- a/app/views/servers/spam_protection/update.turbo_stream.erb
+++ b/app/views/servers/spam_protection/update.turbo_stream.erb
@@ -1,2 +1,3 @@
 <%= turbo_stream.replace "spam_protection-config", html: render(Components::Moderation::SpamProtectionForm.new(context: @context, enable_error: @enable_error)) %>
 <%= turbo_stream.append "toasts", html: render(Components::Toast.new(**@toast)) if @toast %>
+<%= turbo_stream.replace "plugin-sidebar", html: render(Components::PluginSidebar.new(server_configuration: @server_configuration, active_key: :spam_protection)) %>

--- a/app/views/servers/spam_protection/update.turbo_stream.erb
+++ b/app/views/servers/spam_protection/update.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%= turbo_stream.replace "spam_protection-config", html: render(Components::Moderation::SpamProtectionForm.new(server_configuration: @server_configuration, context: @context, enable_error: @enable_error)) %>
+<%= turbo_stream.append "toasts", html: render(Components::Toast.new(**@toast)) if @toast %>

--- a/bin/web-debug
+++ b/bin/web-debug
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-# Boots the app with stubbed Discord auth + seeded fixture guild for browser-driving
-# the web UI without real OAuth. See docs/web-debug-harness.md.
+# See docs/web-debug-harness.md.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 export WEB_DEBUG=1

--- a/bin/web-debug
+++ b/bin/web-debug
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Boots the app with stubbed Discord auth + seeded fixture guild for browser-driving
+# the web UI without real OAuth. See docs/web-debug-harness.md.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export WEB_DEBUG=1
+export RAILS_ENV=development
+export PIDFILE="${PIDFILE:-tmp/pids/web-debug.pid}"
+bin/rails db:prepare
+exec bin/rails server -p "${PORT:-3123}" -b 127.0.0.1

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -12,6 +12,16 @@ data:
     - ["components.legal_page.*", "config/locales/legal.%{locale}.yml"]
     - "config/locales/web.%{locale}.yml"
 
+# Relative keys in Views::Servers::Moderation::SubPluginShow resolve at runtime
+# against the SUBCLASS scope (spam_protection/image_scanning show), which the
+# static file-path scoping above cannot see.
+ignore_missing:
+  - views.servers.moderation.sub_plugin_show.*
+
+ignore_unused:
+  - views.servers.spam_protection.show.*
+  - views.servers.image_scanning.show.*
+
 search:
   paths:
     - app/

--- a/config/initializers/web_debug.rb
+++ b/config/initializers/web_debug.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+if ENV["WEB_DEBUG"] && Rails.env.development?
+  OmniAuth.config.test_mode = true
+  OmniAuth.config.mock_auth[:discord] = OmniAuth::AuthHash.new(
+    provider: "discord",
+    uid: "12345",
+    info: {name: "shrk"},
+    credentials: {token: "web-debug-token"}
+  )
+
+  Rails.application.config.to_prepare do
+    Discord::UserGuilds.define_singleton_method(:call) do |*|
+      [
+        Discord::Guild.new(
+          id: 900_000_001,
+          name: "Dev Refuge",
+          owner: true,
+          permissions: 0,
+          icon: nil,
+          member_count: 5
+        )
+      ]
+    end
+  end
+
+  Rails.application.config.after_initialize do
+    config = ServerConfiguration.find_or_create_by!(discord_id: 900_000_001)
+    %w[logging moderation spam_protection image_scanning].each do |key|
+      plugin = Plugin.find_or_create_by!(key:) do |record|
+        record.name = key.humanize
+      end
+      PluginActivation.find_or_create_by!(server_configuration: config, plugin:)
+    end
+    config.create_logging_setting!(channel_id: 111) unless config.logging_setting
+    config.create_moderation_settings! unless config.moderation_settings
+    config.create_spam_protection_settings! unless config.spam_protection_settings
+    config.create_image_scanning_settings! unless config.image_scanning_settings
+    unless config.server_roles.exists?(discord_id: 500)
+      config.server_roles.create!(discord_id: 500, name: "Moderator", color: 0xE67E22, position: 1)
+    end
+    unless config.server_channels.exists?(discord_id: 111)
+      config.server_channels.create!(discord_id: 111, name: "mod-log", channel_type: 0)
+    end
+  rescue ActiveRecord::NoDatabaseError, ActiveRecord::StatementInvalid
+    warn "web_debug: database not ready, seed skipped — run bin/rails db:prepare first"
+  end
+end

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -62,6 +62,40 @@ en:
             roles: Roles
           toggle_all: Toggle all
           toggle_all_label: Toggle all %{plugin} events
+    moderation:
+      matching_explainer:
+        row_keywords: Custom scam keywords keep digits, so entries like 50 giveaway
+          match.
+        row_lookalike: Stylized and lookalike characters are folded to their plain
+          form (ⓕⓡⓔⓔ, ｆｒｅｅ → free), so disguises don't help.
+        row_normalize: 'Before comparing any text, shrkbot normalizes it: case, punctuation,
+          extra spacing and invisible characters are ignored - FREE N-I-T-R-O!! and
+          free nitro are the same text.'
+        row_spam: Spam protection also ignores digits - message 1, message 2, message
+          3 count as the same message.
+        title: How text matching works
+      staff_role_card:
+        help: Shared by every Moderation sub-plugin. Pinged on every alert, and exempt
+          from spam detection. Pick one before enabling any sub-plugin.
+        label: Staff role
+        missing_warning: Required. Every sub-plugin stays off until a staff role is
+          picked.
+        permission_warning_body: shrkbot is missing the Mention All Roles permission
+          in this server. Alerts still post to the log channel, but nobody gets pinged
+          until it's restored.
+        permission_warning_bold: Staff pings will fail.
+        placeholder: Pick a role…
+      sub_plugin_directory:
+        eyebrow: Sub-plugins
+      sub_plugin_row:
+        configure: Configure
+        locked_reason: Pick a staff role first.
+        needs_setup_hint: Pick a staff role first.
+        status:
+          disabled: Disabled
+          enabled: Enabled
+          needs_setup: Needs setup
+        toggle_label: Enable %{name}
     notification_bell:
       label: Notifications
       unread: Notifications, %{count} unread
@@ -183,8 +217,12 @@ en:
         title: "%{channel_name} was deleted"
         title_unknown: A channel was deleted
   servers:
+    image_scanning:
+      saved: Scam Image Detection settings saved.
     logging:
       saved: Logging settings saved.
+    moderation:
+      saved: Server Shield settings saved.
     not_found: That server isn't available to configure.
     plugin_disabled: "%{plugin} disabled."
     plugin_enabled: "%{plugin} enabled."
@@ -197,6 +235,8 @@ en:
     roles:
       failed: Couldn't save the role settings.
       saved: Role settings saved.
+    spam_protection:
+      saved: Cross-Channel Spam Guard settings saved.
     unknown_plugin: That plugin doesn't exist.
     welcomes:
       saved: Welcomes settings saved.
@@ -250,6 +290,12 @@ en:
       continue: Continue
       title: Signing you back in
     servers:
+      image_scanning:
+        show:
+          description: Reads the text inside posted images and checks it against known
+            scam patterns and previously confirmed scam images. Staff confirm or dismiss
+            every catch, and the bot remembers.
+          title: Scam Image Detection
       index:
         empty_body: You need Manage Server permissions and shrkbot must be present.
           Invite it to get started.
@@ -273,6 +319,21 @@ en:
           description: Record moderation events to a channel of your choice.
           gate_message: Enable the plugin to choose a channel and pick events.
           title: Logging
+      moderation:
+        show:
+          description: 'Your server''s aegis: automated moderation beyond Discord''s
+            AutoMod.'
+          gate_message: Enable the group to configure its sub-plugins and shared settings.
+          logging_subline_prefix: 'Alerts post to '
+          logging_subline_suffix: through the Logging plugin.
+          prereq_gate_cta: Set up Logging
+          prereq_gate_message: Every alert, staff ping and one-click review lands
+            in your log channel. Enable Logging and pick a log channel, then come
+            back.
+          prereq_gate_title: Moderation needs the Logging plugin
+          title: Server Shield
+          toggle_locked_reason: Enable the Logging plugin first - alerts are delivered
+            through your log channel.
       reminders:
         show:
           badge: Global
@@ -298,6 +359,12 @@ en:
           one: "%{count} role"
           other: "%{count} roles"
         synced: "%{channels} and %{roles} synced"
+      spam_protection:
+        show:
+          description: Detects the same message blasted across multiple channels within
+            seconds and purges it before it spreads. Matching is fingerprint-based
+            — message content is never stored.
+          title: Cross-Channel Spam Guard
       welcomes:
         show:
           description: Greet new members and say goodbye when they leave.

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -143,6 +143,8 @@ en:
               for spam. Case, punctuation, digits and disguised characters are ignored
               either way.
             label: Match strictness
+            max_caption: identical
+            min_caption: loosely similar
             recommended: 'Recommended default: 100%'
           symbol_only:
             help: Messages with no matchable text - only emoji, punctuation or digits
@@ -197,6 +199,8 @@ en:
       mark_all_read: Mark all read
       this_server: This server
       title: Notifications
+    number_stepper:
+      recommended_default: 'Recommended default: %{value}'
     plugin_row:
       configure: Configure
       needs_setup_hint: Complete setup before enabling this plugin.

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -63,6 +63,56 @@ en:
           toggle_all: Toggle all
           toggle_all_label: Toggle all %{plugin} events
     moderation:
+      image_scanning_form:
+        consent:
+          body: Deletion is on by default, and detection is automated and imperfect.
+            Screenshots of scams - the kind well-meaning members post as warnings
+            - can be detected and deleted too, so tell your community not to post
+            scam screenshots. Staff are pinged on every action and can mark a decision
+            as wrong with one click in Discord.
+          title: Before you turn this on
+        custom_keywords:
+          keywords_help: Words or phrases that mark an image as a scam when they show
+            up in its text - on top of shrkbot's built-in scam rules. Close misspellings
+            count too, so one entry covers its variations. Short, common words trigger
+            easily; longer phrases make more precise rules. Keywords are matched like
+            all other text - case, punctuation and disguised characters ignored, digits
+            kept.
+          keywords_label: Custom keywords
+          min_hits_help: 1 is aggressive - a single matched word can delete an image.
+            2 or more keeps one stray word from triggering. Up to as many keywords
+            as you've set.
+          min_hits_label: Require at least
+          min_hits_suffix: matching keywords before shrkbot acts
+        detection:
+          sensitivity:
+            label: Sensitivity
+            relaxed_description: Acts only on unmistakable scams. Fewest false positives;
+              more scams slip through.
+            relaxed_title: Relaxed
+            standard_description: Catches most scam images with occasional false positives.
+              Recommended.
+            standard_title: Standard
+            strict_description: Also acts on borderline matches. Expect false positives
+              - best with an active staff team.
+            strict_title: Strict
+        explainer:
+          line_fingerprint: Confirmed scams are remembered by image fingerprint, across
+            every server shrkbot is in.
+          line_memory: shrkbot reads image text in memory. Nothing is stored.
+          line_staff: Staff confirm or dismiss every flag with buttons in your log
+            channel.
+          title: How image scanning works
+        report_scam_hint: You can report any message with images as a scam by right-clicking
+          it → Apps → shrkbot → Report as scam.
+        response:
+          action:
+            delete: Delete the image
+            flag_only: Flag only
+            help: Flag only leaves the image up and pings staff to review it.
+            label: When a scam is detected
+          punishment:
+            label: Also punish the sender
       matching_explainer:
         row_keywords: Custom scam keywords keep digits, so entries like 50 giveaway
           match.
@@ -74,6 +124,47 @@ en:
         row_spam: Spam protection also ignores digits - message 1, message 2, message
           3 count as the same message.
         title: How text matching works
+      punishment_control:
+        ban: Ban
+        ban_warning: A ban is permanent until a mod lifts it, and shrkbot can't undo
+          it. Pick this only if you're confident your thresholds never catch real
+          members.
+        duration_help: Applies on top of the purge.
+        duration_label: Duration
+        kick: Kick
+        none: None
+        timeout: Time out
+      spam_protection_form:
+        detection:
+          match_strictness:
+            help: How similar two messages must be to count as the same message. 100%
+              only catches exact copies; lower values also catch spam with small edits
+              - swapped words, extra characters - but can mistake similar real messages
+              for spam. Case, punctuation, digits and disguised characters are ignored
+              either way.
+            label: Match strictness
+            recommended: 'Recommended default: 100%'
+          symbol_only:
+            help: Messages with no matchable text - only emoji, punctuation or digits
+              - are ignored by default. When on, they all count as the same message,
+              so blasting any symbol noise across channels triggers.
+            label: Also match symbol-only messages
+            recommended: 'Recommended default: Off'
+          trigger_threshold:
+            channels_unit: channels
+            help: Triggers when the same message appears in 4 different channels within
+              15 seconds.
+            label: Trigger threshold
+            seconds_unit: seconds
+            within: within
+        response:
+          action:
+            help: Notify only is a dry run - staff get the alert, nothing is deleted.
+            label: When spam is detected
+            notify_only: Notify only
+            purge: Purge the messages
+          punishment:
+            label: Also punish the sender
       staff_role_card:
         help: Shared by every Moderation sub-plugin. Pinged on every alert, and exempt
           from spam detection. Pick one before enabling any sub-plugin.
@@ -295,6 +386,22 @@ en:
           description: Reads the text inside posted images and checks it against known
             scam patterns and previously confirmed scam images. Staff confirm or dismiss
             every catch, and the bot remembers.
+          group_locked_reason: Enable the Server Shield group first - its master switch
+            is off.
+          no_role_callout_body: Every Moderation sub-plugin needs the shared staff
+            role - it's pinged on every alert. Set it on the
+          no_role_callout_lead: Pick a staff role first.
+          no_role_callout_link: Moderation overview
+          no_role_callout_suffix: ", then enable image scanning here."
+          prereq_gate_cta: Open Server Shield overview
+          prereq_gate_message: Image scanning is part of the Moderation group. Enable
+            the group on its overview to configure this page.
+          prereq_gate_title: Server Shield group is disabled
+          role_locked_reason: Pick a staff role first.
+          subline_link: Moderation overview
+          subline_prefix: 'Part of Moderation. Shared settings - staff role and alerts
+            - live on the '
+          subline_suffix: "."
           title: Scam Image Detection
       index:
         empty_body: You need Manage Server permissions and shrkbot must be present.
@@ -364,6 +471,22 @@ en:
           description: Detects the same message blasted across multiple channels within
             seconds and purges it before it spreads. Matching is fingerprint-based
             — message content is never stored.
+          group_locked_reason: Enable the Server Shield group first - its master switch
+            is off.
+          no_role_callout_body: Every Moderation sub-plugin needs the shared staff
+            role - it's pinged on every alert. Set it on the
+          no_role_callout_lead: Pick a staff role first.
+          no_role_callout_link: Moderation overview
+          no_role_callout_suffix: ", then enable spam protection here."
+          prereq_gate_cta: Open Server Shield overview
+          prereq_gate_message: Cross-Channel Spam Guard is part of the Server Shield
+            group. Enable the group on its overview to configure this page.
+          prereq_gate_title: Server Shield group is disabled
+          role_locked_reason: Pick a staff role first.
+          subline_link: Moderation overview
+          subline_prefix: 'Part of Moderation. Shared settings - staff role and alerts
+            - live on the '
+          subline_suffix: "."
           title: Cross-Channel Spam Guard
       welcomes:
         show:

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -208,6 +208,10 @@ en:
         logging:
           description: Record moderation events to a channel of your choice.
           name: Logging
+        moderation:
+          description: 'Your server''s aegis: automated moderation beyond Discord''s
+            AutoMod.'
+          name: Server Shield
         reminders:
           description: Members set their own reminders with /remind.
           locked: This plugin is always enabled to preserve DM functionality.

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -222,6 +222,7 @@ en:
       toggle: Toggle %{plugin}
     plugin_sidebar:
       dashboard: Dashboard
+      overview: Overview
       plugins: Plugins
     public_shell:
       dashboard: Dashboard

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,9 @@ Rails.application.routes.draw do
       resource :logging, only: [:show, :update], controller: "logging"
       resource :roles, only: [:show, :update]
       resource :reminders, only: [:show, :update]
+      resource :moderation, only: [:show, :update], controller: "moderation"
+      resource :spam_protection, only: [:show, :update], controller: "spam_protection"
+      resource :image_scanning, only: [:show, :update], controller: "image_scanning"
       resources :role_sets, only: [] do
         resource :repost, only: :create, module: :role_sets
       end

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -142,6 +142,11 @@ with `PluginRow` so the two can't drift) — with a status dot, an active highli
 list automatically once they have config routes; Reminders isn't in the catalog
 (it has no activation to toggle) — `PluginStatus::ALWAYS_ON` appends it as a
 locked, always-enabled row, which both the dashboard and the sidebar render.
+With a plugin sidebar the footer renders inside the scrolling main pane, so a
+page never scrolls by just the footer height — that would rob the sticky sidebar
+of headroom and make it slide out of view. `<details>` disclosures only animate
+when their panel carries the `dropdown-menu` class and
+`data-dropdown-target="menu"` (see the dropdown Stimulus controller).
 
 `Components::SaveBar` is the commit affordance: a fixed bottom bar, hidden until
 the form differs from its initial state. The `save-bar` Stimulus controller (on

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -155,6 +155,22 @@ save — config controllers return **422** (not 200) when a save fails validatio
 which is both the correct status and the signal (`turbo:submit-end` reports
 `success: false`) that tells the bar to stay dirty.
 
+### Plugin groups (Server Shield)
+
+A plugin *group* (a parent plus sub-plugins) needs richer chrome than `ConfigPage`
+offers, so the moderation pages use **`Components::Moderation::ConfigShell`** instead:
+same breadcrumb + form + `SaveBar` wiring, but the header enable-toggle has three
+states (interactive, or locked-with-reason inside a `Tooltip`) and the body gate is
+either the standard `EnableGate` (master switch off) or **`Components::PrereqGate`** —
+a variant whose card names the blocking dependency and deep-links to where it's fixed
+(a missing log channel, a disabled parent) instead of offering an Enable button. In
+the sidebar the group renders as **`Components::SidebarGroup`**: a native `<details>`
+disclosure (persisted per user, auto-expanded on an active child) whose parent row is
+a chevron toggle and whose sub-items are plain nav links on an indent rail. A
+sub-plugin can't be enabled until its group prerequisite is met — that requirement
+lives in `PluginCatalog::Definition#prerequisite`, so every enable path (the generic
+toggle, the sidebar/row UI, and the Configure ops) agrees.
+
 ## Core components
 
 Reach for these before hand-rolling markup — more small components beats
@@ -176,6 +192,17 @@ duplicated class strings:
   `enabled:`, muted sand otherwise). `size:` (`:sm`/`:md`/`:lg`).
 - **`Components::Callout`** — tinted bordered notice. `variant:` (`:info`/
   `:neutral`/`:warning`/`:danger`/`:success`) sets colour + default icon.
+- **`Components::NumberStepper`** — integer field with −/+ buttons, `min:`-clamped,
+  a `unit:` label and a "Recommended default: n" subscript. No UI cap (`max:` is
+  optional, for the dynamic keyword-count limit); submits as a plain number field.
+- **`Components::RangeSlider`** — native `<input type="range">` styled with tokens;
+  shows a percent readout but submits a hidden `0.75`–`1.0` float (converted once).
+- **`Components::RadioCardGroup`** — stacked radio options as bordered cards with a
+  title + one-line description; native radios, so selection is reactive with no JS.
+- **`Components::PrereqGate`** / **`Components::SidebarGroup`** — see *Plugin groups*.
+
+`Components::Icon` wraps Phosphor; names not in Phosphor (the `megaphone-slash`
+sub-plugin glyph) are served from its `CUSTOM_GLYPHS` map of inline SVGs.
 
 ## Where it lives
 

--- a/docs/design/moderation-config.html
+++ b/docs/design/moderation-config.html
@@ -1,0 +1,837 @@
+<!-- @dsCard group="Dashboard" viewport="1200x900" name="Moderation config" subtitle="Moderation as a plugin group: sidebar treatment, overview + per-sub-plugin pages, every state stacked — light & dark, annotated, with new-component specs" -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>shrkbot — Moderation group config (stacked states)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" /><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Space+Grotesk:wght@500;600;700&family=Exo+2:wght@400;500;600;700&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="tokens/colors.css" />
+<link rel="stylesheet" href="tokens/spacing.css" />
+<link rel="stylesheet" href="tokens/motion.css" />
+<script src="https://unpkg.com/@phosphor-icons/web@2.1.1"></script>
+<script src="https://cdn.tailwindcss.com"></script>
+<script>
+/* Semantic-token Tailwind wiring — every color maps to a CSS var from
+   tokens/colors.css, so [data-theme="dark"] flips both panes for free.
+   Same wiring as ui_kits/notifications. */
+tailwind.config={theme:{extend:{
+  colors:{
+    'surface-page':'var(--surface-page)','surface-card':'var(--surface-card)','surface-raised':'var(--surface-raised)','surface-sunken':'var(--surface-sunken)',
+    'text-primary':'var(--text-primary)','text-secondary':'var(--text-secondary)','text-muted':'var(--text-muted)','text-link':'var(--text-link)',
+    'border-subtle':'var(--border-subtle)','border-default':'var(--border-default)','border-strong':'var(--border-strong)',
+    accent:'var(--accent)','accent-fill':'var(--accent-fill)','accent-soft':'var(--accent-soft)','accent-soft-bd':'var(--accent-soft-bd)','accent-soft-fg':'var(--accent-soft-fg)',
+    'accent-2-text':'var(--accent-2-text)','accent-2-soft':'var(--accent-2-soft)','accent-2-soft-bd':'var(--accent-2-soft-bd)',
+    success:'var(--success)','success-soft':'var(--success-soft-x)',
+    warning:'var(--warning)','warning-soft':'var(--warning-soft-x)','warning-soft-bd':'var(--warning-soft-bd)',
+    danger:'var(--danger)','danger-soft':'var(--danger-soft-x)','danger-soft-bd':'var(--danger-soft-bd)'
+  },
+  fontFamily:{display:['"Space Grotesk"','system-ui','sans-serif'],sans:['"Exo 2"','system-ui','sans-serif'],mono:['"IBM Plex Mono"','ui-monospace','monospace']},
+  borderRadius:{sm:'5px',md:'8px',lg:'12px',xl:'16px',control:'8px',card:'12px',chip:'5px'},
+  boxShadow:{sm:'0 1px 3px rgba(29,26,21,.08),0 1px 2px rgba(29,26,21,.04)',md:'0 4px 12px rgba(29,26,21,.08),0 2px 4px rgba(29,26,21,.04)',lg:'0 12px 32px rgba(29,26,21,.18),0 4px 8px rgba(29,26,21,.08)'}
+}}};
+</script>
+<style>
+/* ── Local semantic extensions (theme-aware, mirrors notifications kit) ── */
+:root{
+  --accent-soft-fg: var(--teal-700);
+  --success-soft-x: var(--green-50);
+  --warning-soft-x: var(--amber-50);
+  --warning-soft-bd:#ecd6a6;
+  --danger-soft-x:  var(--red-50);
+  --danger-soft-bd: #eec3b8;
+  --plugin-tile:    var(--accent-fill);   /* icon identity tiles: white-text-safe teal */
+  --switch-off:     #c5b8a1;
+  --gate-veil:      rgba(245,240,232,.7);
+}
+[data-theme="dark"]{
+  --accent-soft-fg: #6fb3aa;
+  --success-soft-x: rgba(47,175,107,.12);
+  --warning-soft-x: rgba(232,161,58,.12);
+  --warning-soft-bd:rgba(232,161,58,.25);
+  --danger-soft-x:  rgba(224,83,61,.12);
+  --danger-soft-bd: rgba(224,83,61,.28);
+  --plugin-tile:    var(--accent);
+  --switch-off:     #5e4a37;
+  --gate-veil:      rgba(26,19,13,.82);
+}
+
+body{font-family:"Exo 2",system-ui,sans-serif;background:#161310}
+a{color:var(--text-link)} a:hover{color:var(--teal-700)}
+.lbl{font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--text-muted)}
+
+/* ── Chamfer geometry — brand-forward surfaces only ── */
+.chamfer-tile{--cut:var(--chamfer,12px);clip-path:polygon(var(--cut) 0,calc(100% - var(--cut)) 0,100% var(--cut),100% calc(100% - var(--cut)),calc(100% - var(--cut)) 100%,var(--cut) 100%,0 calc(100% - var(--cut)),0 var(--cut))}
+.chamfer-cta{--cut:var(--chamfer-sm,6px);clip-path:polygon(var(--cut) 0,calc(100% - var(--cut)) 0,100% var(--cut),100% calc(100% - var(--cut)),calc(100% - var(--cut)) 100%,var(--cut) 100%,0 calc(100% - var(--cut)),0 var(--cut));border-radius:0 !important}
+
+/* ── Static switch (rendered states of .shrk-switch / Stimulus in production) ── */
+.sw{position:relative;width:46px;height:26px;border-radius:999px;flex:none;display:inline-block;border:none;padding:0}
+.sw::after{content:'';position:absolute;top:3px;left:3px;width:20px;height:20px;border-radius:50%;background:#fff;box-shadow:0 1px 3px rgba(0,0,0,.2)}
+.sw-on{background:var(--accent-fill)} .sw-on::after{transform:translateX(20px)}
+.sw-off{background:var(--switch-off)}
+.sw-disabled{opacity:.5;cursor:not-allowed}
+
+/* ── Gate overlay (enable-gate pattern) ── */
+.gate-overlay{position:absolute;inset:0;z-index:20;background:var(--gate-veil);backdrop-filter:blur(1px);border-radius:12px;display:grid;place-items:center}
+
+/* ── Static tooltip, rendered visible for review (hover-only in production) ── */
+.tip-static{position:absolute;bottom:calc(100% + 8px);right:0;width:230px;background:#2f2a23;color:#fff;font-size:12px;line-height:1.45;padding:7px 10px;border-radius:8px;text-align:center;z-index:30}
+.tip-static::after{content:'';position:absolute;top:100%;right:15px;border:5px solid transparent;border-top-color:#2f2a23}
+
+/* ── Sidebar nav (excerpted from the PluginShell) ── */
+.side-item{display:flex;align-items:center;gap:9px;padding:7px 10px;border-radius:8px;width:100%;text-align:left;border:none;background:transparent;cursor:pointer;font-size:13px;color:var(--text-secondary)}
+.side-item:hover{background:var(--surface-sunken)}
+.side-sub{display:flex;align-items:center;gap:8px;padding:6px 10px;border-radius:7px;width:100%;text-align:left;border:none;background:transparent;cursor:pointer;font-size:13px;color:var(--text-secondary)}
+.side-sub:hover{background:var(--surface-sunken)}
+.side-sub.active{background:var(--accent-soft);color:var(--nav-active);font-weight:600}
+
+/* ── Review-chrome annotation — NOT page content ── */
+.anno{border:1px dashed var(--accent-2-soft-bd);border-radius:8px;padding:10px 12px;display:flex;gap:10px;align-items:flex-start;font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:12px;line-height:1.6;color:var(--text-secondary)}
+.anno-tag{font-size:10px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:var(--accent-2-text);background:var(--accent-2-soft);border-radius:5px;padding:2px 7px;flex:none;margin-top:1px}
+
+/* ── Slash overlay: spam-protection icon = megaphone + slash (locked 2026-07-08).
+      Phosphor has no megaphone-slash; production = custom SVG asset with Phosphor's
+      slash geometry. --slash-bg must match the surface behind the icon (the casing
+      bar fakes the notch real Phosphor slash icons have). ── */
+.icon-slash{--slash-bg:var(--plugin-tile);position:relative;display:inline-flex}
+.icon-slash::before,.icon-slash::after{content:'';position:absolute;left:50%;top:50%;height:135%;border-radius:2px;transform:translate(-50%,-50%) rotate(45deg)}
+.icon-slash::before{width:5px;background:var(--slash-bg)}
+.icon-slash::after{width:2px;background:currentColor}
+
+/* ── Phosphor icon sizing ── */
+i[class*="ph-"]{display:inline-flex;align-items:center;justify-content:center;line-height:1;flex:none;font-style:normal;vertical-align:middle}
+i[class*="ph-"].w-3{font-size:12px;min-width:12px;height:12px}
+i[class*="ph-"].w-3\.5{font-size:14px;min-width:14px;height:14px}
+i[class*="ph-"].w-4{font-size:16px;min-width:16px;height:16px}
+i[class*="ph-"].w-5{font-size:20px;min-width:20px;height:20px}
+i[class*="ph-"].w-6{font-size:24px;min-width:24px;height:24px}
+i[class*="ph-"].w-\[18px\]{font-size:18px;min-width:18px;height:18px}
+
+@media(prefers-reduced-motion:reduce){
+  .transition-colors,.transition{transition:none !important}
+}
+</style>
+</head>
+<body class="antialiased">
+
+<!-- ════════════════════════════════════════════════════════════════
+     LIGHT PANE — authored source of truth.
+     The DARK pane at the bottom is a JS clone under [data-theme="dark"];
+     every color is a semantic token, so it flips automatically.
+     The page renders fully without JS (light pane only).
+     ════════════════════════════════════════════════════════════════ -->
+<section data-theme="light" data-pane-light class="bg-surface-page text-text-primary py-10 px-6">
+  <div class="max-w-[860px] mx-auto">
+    <p class="font-mono text-xs text-text-muted mb-3">shrkbot · Moderation group config — stacked states — LIGHT</p>
+
+    <div class="anno mb-10"><span class="anno-tag">note</span><span>Moderation is now a plugin GROUP: sub-plugins Spam protection and Image scanning today, more later (raid detection, verdict dashboard). Structure on this page: sidebar group treatment, then the group Overview page in 5 states, then one full page per sub-plugin with its blocked states, then shared states and New components. Pages render without the PluginShell (app bar + sidebar) except the sidebar excerpts. Moderation replaces the former OCR Moderation plugin; image scanning absorbs its OCR pipeline. Group icon: <span class="font-mono">shield</span>; sub-plugin icons: <span class="font-mono">megaphone</span> with a slash overlay (locked 2026-07-08; Phosphor has no megaphone-slash — production is a custom SVG asset combining Phosphor's megaphone with their standard slash geometry, registered in the icon component; the mockup fakes it with the .icon-slash CSS overlay, whose --slash-bg must match the surface behind the icon), <span class="font-mono">scan</span> (Phosphor, one weight).</span></div>
+
+    <div data-pane-content class="flex flex-col gap-14">
+
+      <!-- ═══════════════ SIDEBAR — GROUP TREATMENT ═══════════════ -->
+      <div id="sidebar" data-screen-label="Sidebar group">
+        <span class="lbl">Sidebar — Moderation as a group · expanded (Spam protection active) and collapsed</span>
+
+        <div class="mt-3 flex flex-wrap gap-5 items-start">
+
+          <!-- Expanded -->
+          <div class="w-56 bg-surface-sunken border border-border-default rounded-lg p-4">
+            <p class="text-[10px] font-semibold uppercase tracking-widest px-2 mb-2" style="color:var(--eyebrow)">Plugins</p>
+            <nav class="flex flex-col gap-0.5">
+              <button class="side-item"><span class="w-7 h-7 rounded-[7px] grid place-items-center text-white flex-none" style="background:var(--accent)"><i class="ph ph-users-three w-3.5 h-3.5"></i></span><span>Roles</span><span class="ml-auto w-[7px] h-[7px] rounded-full bg-success flex-none"></span></button>
+              <button class="side-item"><span class="w-7 h-7 rounded-[7px] bg-surface-raised text-text-muted grid place-items-center flex-none"><i class="ph ph-hand-waving w-3.5 h-3.5"></i></span><span>Welcomes</span><span class="ml-auto w-[7px] h-[7px] rounded-full bg-border-strong flex-none"></span></button>
+              <button class="side-item"><span class="w-7 h-7 rounded-[7px] grid place-items-center text-white flex-none" style="background:var(--accent)"><i class="ph ph-scroll w-3.5 h-3.5"></i></span><span>Logging</span><span class="ml-auto w-[7px] h-[7px] rounded-full bg-success flex-none"></span></button>
+              <!-- Group parent — chevron instead of status dot, rotated open -->
+              <button class="side-item" aria-expanded="true"><span class="w-7 h-7 rounded-[7px] grid place-items-center text-white flex-none" style="background:var(--accent)"><i class="ph ph-shield w-3.5 h-3.5"></i></span><span>Moderation</span><i class="ph ph-caret-down w-3 h-3 text-text-muted ml-auto"></i></button>
+              <!-- Sub-items on an indent rail -->
+              <div class="ml-[23px] pl-2.5 border-l border-border-default flex flex-col gap-0.5 py-0.5">
+                <button class="side-sub"><span>Overview</span></button>
+                <button class="side-sub active"><span>Spam protection</span><span class="ml-auto w-[7px] h-[7px] rounded-full bg-success flex-none"></span></button>
+                <button class="side-sub"><span>Image scanning</span><span class="ml-auto w-[7px] h-[7px] rounded-full bg-success flex-none"></span></button>
+              </div>
+              <button class="side-item"><span class="w-7 h-7 rounded-[7px] grid place-items-center text-white flex-none" style="background:var(--accent)"><i class="ph ph-bell-ringing w-3.5 h-3.5"></i></span><span>Reminders</span><span class="ml-auto text-[10px] font-semibold px-1.5 py-px rounded-full copper" style="color:var(--accent-2-text);background:var(--accent-2-soft)">Global</span></button>
+            </nav>
+          </div>
+
+          <!-- Collapsed -->
+          <div class="w-56 bg-surface-sunken border border-border-default rounded-lg p-4">
+            <p class="text-[10px] font-semibold uppercase tracking-widest px-2 mb-2" style="color:var(--eyebrow)">Plugins</p>
+            <nav class="flex flex-col gap-0.5">
+              <button class="side-item"><span class="w-7 h-7 rounded-[7px] grid place-items-center text-white flex-none" style="background:var(--accent)"><i class="ph ph-users-three w-3.5 h-3.5"></i></span><span>Roles</span><span class="ml-auto w-[7px] h-[7px] rounded-full bg-success flex-none"></span></button>
+              <button class="side-item"><span class="w-7 h-7 rounded-[7px] bg-surface-raised text-text-muted grid place-items-center flex-none"><i class="ph ph-hand-waving w-3.5 h-3.5"></i></span><span>Welcomes</span><span class="ml-auto w-[7px] h-[7px] rounded-full bg-border-strong flex-none"></span></button>
+              <button class="side-item"><span class="w-7 h-7 rounded-[7px] grid place-items-center text-white flex-none" style="background:var(--accent)"><i class="ph ph-scroll w-3.5 h-3.5"></i></span><span>Logging</span><span class="ml-auto w-[7px] h-[7px] rounded-full bg-success flex-none"></span></button>
+              <button class="side-item" aria-expanded="false"><span class="w-7 h-7 rounded-[7px] grid place-items-center text-white flex-none" style="background:var(--accent)"><i class="ph ph-shield w-3.5 h-3.5"></i></span><span>Moderation</span><i class="ph ph-caret-right w-3 h-3 text-text-muted ml-auto"></i></button>
+              <button class="side-item"><span class="w-7 h-7 rounded-[7px] grid place-items-center text-white flex-none" style="background:var(--accent)"><i class="ph ph-bell-ringing w-3.5 h-3.5"></i></span><span>Reminders</span><span class="ml-auto text-[10px] font-semibold px-1.5 py-px rounded-full" style="color:var(--accent-2-text);background:var(--accent-2-soft)">Global</span></button>
+            </nav>
+          </div>
+
+        </div>
+
+        <div class="anno mt-6"><span class="anno-tag">note</span><span>SidebarGroup (NEW COMPONENT, spec at the end). Flat entries are untouched plugin-nav-items. The group parent keeps the icon tile + label but swaps the status dot for a chevron (caret-right closed, rotates to caret-down over 200ms ease-standard). Sub-items sit on an indent rail aligned with the parent label, text-only, each with its own status dot; Overview has none. Clicking the parent toggles disclosure only - navigation happens on sub-items. Open/closed persists per user (localStorage); the group auto-expands when a sub-page is active. Active state (accent-soft wash, --nav-active text) can sit on any sub-item. New sub-plugins are new rows on the rail - no layout change at 6. Reduced motion: chevron and disclosure snap.</span></div>
+      </div>
+
+      <!-- ═══════════════ OVERVIEW · STATE 1 — NORMAL ═══════════════ -->
+      <div id="ov-normal" data-screen-label="Overview normal">
+        <span class="lbl">Overview — state 1 · group on · shared settings + sub-plugin directory</span>
+
+        <div class="mt-3">
+          <nav class="text-xs text-text-muted mb-4 flex items-center gap-1.5"><a href="#" class="hover:text-text-secondary no-underline" style="color:var(--text-muted)">Servers</a><i class="ph ph-caret-right w-3 h-3"></i><a href="#" class="hover:text-text-secondary no-underline" style="color:var(--text-muted)">Dev Refuge</a><i class="ph ph-caret-right w-3 h-3"></i><span class="text-text-secondary font-medium">Moderation</span></nav>
+
+          <!-- Group header — master switch -->
+          <div class="flex items-start gap-4 mb-2">
+            <span class="w-12 h-12 chamfer-tile text-white grid place-items-center flex-none" style="background:var(--plugin-tile)"><i class="ph-fill ph-shield w-6 h-6"></i></span>
+            <div class="flex-1"><h1 class="font-display text-2xl font-bold tracking-tight">Moderation</h1><p class="text-sm text-text-secondary mt-0.5">Protections against spam, scams and worse. Each one is its own sub-plugin - turn on what you need.</p></div>
+            <div class="flex items-center gap-2.5 pt-1"><span class="text-sm font-medium text-text-secondary">Enabled</span><button class="sw sw-on" role="switch" aria-checked="true" aria-label="Enable Moderation"></button></div>
+          </div>
+          <p class="text-xs text-text-muted mb-6 flex items-center gap-1.5 pl-16"><i class="ph ph-scroll w-4 h-4"></i><span>Alerts post to <span class="font-mono">#mod-log</span> through the Logging plugin.</span></p>
+
+          <div class="flex flex-col gap-5">
+
+            <!-- Shared setting: staff role -->
+            <div class="bg-surface-card border border-border-default rounded-card shadow-sm p-5">
+              <label class="block text-sm font-semibold mb-1.5">Staff role <span class="text-danger text-xs font-semibold">*</span></label>
+              <div class="h-10 px-3 rounded-control border-[1.5px] border-border-strong bg-surface-card flex items-center gap-2 text-sm max-w-sm cursor-pointer"><span class="w-2.5 h-2.5 rounded-full flex-none" style="background:#e0533d"></span><span class="flex-1">Moderator</span><i class="ph ph-caret-down w-4 h-4 text-text-muted"></i></div>
+              <p class="text-xs text-text-muted mt-1.5">Shared by every Moderation sub-plugin. Pinged on every alert, and exempt from spam detection. Pick one before enabling any sub-plugin.</p>
+            </div>
+
+            <!-- Sub-plugin directory -->
+            <div>
+              <p class="text-[11px] font-semibold uppercase tracking-widest mb-3" style="color:var(--eyebrow)">Sub-plugins</p>
+              <div class="flex flex-col gap-3">
+                <div class="bg-surface-card border border-accent-soft-bd rounded-lg shadow-sm p-5 flex items-center gap-4">
+                  <span class="w-11 h-11 chamfer-tile text-white grid place-items-center flex-none" style="background:var(--plugin-tile)"><span class="icon-slash"><i class="ph-fill ph-megaphone w-5 h-5"></i></span></span>
+                  <div class="flex-1 min-w-0"><div class="flex items-center gap-2 flex-wrap"><span class="font-display font-semibold">Spam protection</span><span class="inline-flex items-center gap-1.5 text-xs font-semibold text-success bg-success-soft px-2 py-0.5 rounded-full"><span class="w-1.5 h-1.5 rounded-full bg-success"></span>Enabled</span></div><p class="text-sm text-text-secondary mt-0.5">Purges the same message posted across several channels within seconds.</p></div>
+                  <button class="inline-flex items-center gap-1.5 h-9 px-3.5 rounded-md border border-border-default text-sm font-semibold hover:bg-surface-sunken transition-colors"><span>Configure</span><i class="ph ph-arrow-right w-4 h-4"></i></button>
+                  <button class="sw sw-on" role="switch" aria-checked="true" aria-label="Enable spam protection"></button>
+                </div>
+                <div class="bg-surface-card border border-accent-soft-bd rounded-lg shadow-sm p-5 flex items-center gap-4">
+                  <span class="w-11 h-11 chamfer-tile text-white grid place-items-center flex-none" style="background:var(--plugin-tile)"><i class="ph-fill ph-scan w-5 h-5"></i></span>
+                  <div class="flex-1 min-w-0"><div class="flex items-center gap-2 flex-wrap"><span class="font-display font-semibold">Image scanning</span><span class="inline-flex items-center gap-1.5 text-xs font-semibold text-success bg-success-soft px-2 py-0.5 rounded-full"><span class="w-1.5 h-1.5 rounded-full bg-success"></span>Enabled</span></div><p class="text-sm text-text-secondary mt-0.5">Reads the text in images and fingerprints known scam images.</p></div>
+                  <button class="inline-flex items-center gap-1.5 h-9 px-3.5 rounded-md border border-border-default text-sm font-semibold hover:bg-surface-sunken transition-colors"><span>Configure</span><i class="ph ph-arrow-right w-4 h-4"></i></button>
+                  <button class="sw sw-on" role="switch" aria-checked="true" aria-label="Enable image scanning"></button>
+                </div>
+              </div>
+            </div>
+
+            <!-- Matching explainer — collapsible, rendered expanded -->
+            <div id="matching" class="bg-surface-card border border-border-default rounded-card shadow-sm overflow-hidden">
+              <div class="flex items-center gap-3 px-5 py-3.5 bg-surface-sunken border-b border-border-subtle cursor-pointer select-none">
+                <i class="ph ph-caret-down w-4 h-4 text-text-muted" style="transform:rotate(180deg)"></i>
+                <span class="text-sm font-semibold flex-1">How text matching works</span>
+              </div>
+              <div class="px-5 py-4 grid gap-3">
+                <p class="text-sm text-text-secondary flex items-start gap-2.5"><i class="ph ph-text-aa w-4 h-4 mt-0.5 text-text-muted"></i><span>Before comparing any text, shrkbot normalizes it: case, punctuation, extra spacing and invisible characters are ignored - <span class="font-mono">FREE N-I-T-R-O!!</span> and <span class="font-mono">free nitro</span> are the same text.</span></p>
+                <p class="text-sm text-text-secondary flex items-start gap-2.5"><i class="ph ph-mask-happy w-4 h-4 mt-0.5 text-text-muted"></i><span>Stylized and lookalike characters are folded to their plain form (<span class="font-mono">ⓕⓡⓔⓔ</span>, <span class="font-mono">ｆｒｅｅ</span> → <span class="font-mono">free</span>), so disguises don't help.</span></p>
+                <p class="text-sm text-text-secondary flex items-start gap-2.5"><span class="icon-slash mt-0.5 text-text-muted" style="--slash-bg:var(--surface-card)"><i class="ph ph-megaphone w-4 h-4"></i></span><span>Spam protection also ignores digits - <span class="font-mono">message 1</span>, <span class="font-mono">message 2</span>, <span class="font-mono">message 3</span> count as the same message.</span></p>
+                <p class="text-sm text-text-secondary flex items-start gap-2.5"><i class="ph ph-scan w-4 h-4 mt-0.5 text-text-muted"></i><span>Custom scam keywords keep digits, so entries like <span class="font-mono">50 giveaway</span> match.</span></p>
+              </div>
+            </div>
+
+          </div>
+
+          <p class="mt-6 text-xs text-text-muted flex items-center gap-1.5"><i class="ph ph-terminal-window w-4 h-4"></i><span>No slash commands - every sub-plugin runs automatically once enabled.</span></p>
+        </div>
+
+        <div class="anno mt-6"><span class="anno-tag">note</span><span>"How text matching works" is the same collapsible-card pattern as the image-scanning explainer, rendered expanded here (collapsed by default in production - reference material, not a setting). It lives ONLY on the overview; the strictness and custom-keywords help texts on the sub-pages link to it. Sub-plugin rows are the dashboard's plugin-row pattern verbatim (tile + name + status badge + one-liner + Configure + switch): six sub-plugins is six rows, no layout change. The row switch and the enable toggle on the sub-plugin's own page are the same value. Master switch off = state 3; it does NOT overwrite per-sub-plugin switches - they keep their values and come back as saved. The <span class="font-mono">#mod-log</span> name is read live from the Logging plugin. Edits here raise the shared SaveBar (final state below).</span></div>
+      </div>
+
+      <!-- ═══════════════ OVERVIEW · STATE 2 — LOGGING MISSING · BLOCKED ═══════════════ -->
+      <div id="ov-blocked" data-screen-label="Overview blocked (Logging)">
+        <span class="lbl">Overview — state 2 · blocked · Logging plugin disabled · group cannot be enabled</span>
+
+        <div class="mt-3 pt-16">
+          <div class="flex items-start gap-4 mb-6">
+            <span class="w-12 h-12 chamfer-tile bg-surface-raised text-text-muted grid place-items-center flex-none"><i class="ph ph-shield w-6 h-6"></i></span>
+            <div class="flex-1"><h1 class="font-display text-2xl font-bold tracking-tight">Moderation</h1><p class="text-sm text-text-secondary mt-0.5">Protections against spam, scams and worse. Each one is its own sub-plugin - turn on what you need.</p></div>
+            <div class="flex items-center gap-2.5 pt-1">
+              <span class="text-sm font-medium text-text-secondary">Disabled</span>
+              <span class="relative inline-flex">
+                <span class="tip-static">Enable the Logging plugin first - alerts are delivered through your log channel.</span>
+                <button class="sw sw-off sw-disabled" role="switch" aria-checked="false" aria-disabled="true" aria-label="Enable Moderation (blocked: Logging plugin is disabled)"></button>
+              </span>
+            </div>
+          </div>
+
+          <div class="relative">
+            <div class="gate-overlay">
+              <div class="text-center bg-surface-card border border-border-default rounded-lg shadow-md px-6 py-5 max-w-sm">
+                <i class="ph ph-scroll w-5 h-5 text-text-muted mx-auto block"></i>
+                <p class="text-sm font-semibold mt-2">Moderation needs the Logging plugin</p>
+                <p class="text-xs text-text-secondary mt-1 mb-3">Every alert, staff ping and one-click review lands in your log channel. Enable Logging and pick a log channel, then come back.</p>
+                <button class="inline-flex items-center gap-1.5 h-9 px-4 rounded-control border border-border-strong bg-surface-card text-sm font-semibold hover:bg-surface-sunken transition-colors"><span>Set up Logging</span><i class="ph ph-arrow-right w-4 h-4"></i></button>
+              </div>
+            </div>
+            <div class="flex flex-col gap-5" style="opacity:.45;pointer-events:none" aria-hidden="true">
+              <div class="bg-surface-card border border-border-default rounded-card shadow-sm p-5">
+                <label class="block text-sm font-semibold mb-1.5">Staff role <span class="text-danger text-xs font-semibold">*</span></label>
+                <div class="h-10 px-3 rounded-control border-[1.5px] border-border-strong bg-surface-card flex items-center gap-2 text-sm max-w-sm"><span class="flex-1 text-text-muted">Pick a role…</span><i class="ph ph-caret-down w-4 h-4 text-text-muted"></i></div>
+              </div>
+              <div class="bg-surface-card border border-border-default rounded-lg shadow-sm p-5 flex items-center gap-4">
+                <span class="w-11 h-11 chamfer-tile bg-surface-raised text-text-muted grid place-items-center flex-none"><span class="icon-slash" style="--slash-bg:var(--surface-raised)"><i class="ph ph-megaphone w-5 h-5"></i></span></span>
+                <div class="flex-1 min-w-0"><span class="font-display font-semibold">Spam protection</span><p class="text-sm text-text-secondary mt-0.5">Purges the same message posted across several channels within seconds.</p></div>
+                <button class="sw sw-off" role="switch" aria-checked="false" aria-label="Enable spam protection"></button>
+              </div>
+              <div class="bg-surface-card border border-border-default rounded-lg shadow-sm p-5 flex items-center gap-4">
+                <span class="w-11 h-11 chamfer-tile bg-surface-raised text-text-muted grid place-items-center flex-none"><i class="ph ph-scan w-5 h-5"></i></span>
+                <div class="flex-1 min-w-0"><span class="font-display font-semibold">Image scanning</span><p class="text-sm text-text-secondary mt-0.5">Reads the text in images and fingerprints known scam images.</p></div>
+                <button class="sw sw-off" role="switch" aria-checked="false" aria-label="Enable image scanning"></button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="anno mt-6"><span class="anno-tag">note</span><span>Trigger: Logging plugin disabled (hard prerequisite - alerts have nowhere to go). Master toggle is disabled-with-reason: 50% opacity, not-allowed cursor, tooltip rendered visible here but hover/focus-only in production. PrereqGate variant of the enable-gate: blocking reason + secondary CTA deep-linking to the Logging page instead of lock copy + Enable. The check is live - enabling Logging unblocks without a reload. Sub-plugin pages get the same treatment through their own group-disabled state.</span></div>
+      </div>
+
+      <!-- ═══════════════ OVERVIEW · STATE 3 — GROUP DISABLED · ENABLE-GATE ═══════════════ -->
+      <div id="ov-disabled" data-screen-label="Overview group disabled">
+        <span class="lbl">Overview — state 3 · group disabled · enable-gate over inert settings</span>
+
+        <div class="mt-3">
+          <div class="flex items-start gap-4 mb-6">
+            <span class="w-12 h-12 chamfer-tile bg-surface-raised text-text-muted grid place-items-center flex-none"><i class="ph ph-shield w-6 h-6"></i></span>
+            <div class="flex-1"><h1 class="font-display text-2xl font-bold tracking-tight">Moderation</h1><p class="text-sm text-text-secondary mt-0.5">Protections against spam, scams and worse. Each one is its own sub-plugin - turn on what you need.</p></div>
+            <div class="flex items-center gap-2.5 pt-1"><span class="text-sm font-medium text-text-secondary">Disabled</span><button class="sw sw-off" role="switch" aria-checked="false" aria-label="Enable Moderation"></button></div>
+          </div>
+
+          <div class="relative">
+            <div class="gate-overlay">
+              <div class="text-center bg-surface-card border border-border-default rounded-lg shadow-md px-6 py-5">
+                <i class="ph ph-lock w-5 h-5 text-text-muted mx-auto block"></i>
+                <p class="text-sm font-semibold mt-2">Moderation is disabled</p>
+                <p class="text-xs text-text-secondary mt-1 mb-3 max-w-xs">Enable the group to configure its sub-plugins and shared settings.</p>
+                <button class="inline-flex items-center gap-1.5 h-9 px-4 chamfer-cta bg-accent-fill text-white text-sm font-semibold">Enable Moderation</button>
+              </div>
+            </div>
+            <div class="flex flex-col gap-5" style="opacity:.45;pointer-events:none" aria-hidden="true">
+              <div class="bg-surface-card border border-border-default rounded-card shadow-sm p-5">
+                <label class="block text-sm font-semibold mb-1.5">Staff role <span class="text-danger text-xs font-semibold">*</span></label>
+                <div class="h-10 px-3 rounded-control border-[1.5px] border-border-strong bg-surface-card flex items-center gap-2 text-sm max-w-sm"><span class="w-2.5 h-2.5 rounded-full flex-none" style="background:#e0533d"></span><span class="flex-1">Moderator</span><i class="ph ph-caret-down w-4 h-4 text-text-muted"></i></div>
+              </div>
+              <div class="bg-surface-card border border-border-default rounded-lg shadow-sm p-5 flex items-center gap-4">
+                <span class="w-11 h-11 chamfer-tile bg-surface-raised text-text-muted grid place-items-center flex-none"><span class="icon-slash" style="--slash-bg:var(--surface-raised)"><i class="ph ph-megaphone w-5 h-5"></i></span></span>
+                <div class="flex-1 min-w-0"><span class="font-display font-semibold">Spam protection</span><p class="text-sm text-text-secondary mt-0.5">Purges the same message posted across several channels within seconds.</p></div>
+                <button class="sw sw-on" role="switch" aria-checked="true" aria-label="Enable spam protection"></button>
+              </div>
+              <div class="bg-surface-card border border-border-default rounded-lg shadow-sm p-5 flex items-center gap-4">
+                <span class="w-11 h-11 chamfer-tile bg-surface-raised text-text-muted grid place-items-center flex-none"><i class="ph ph-scan w-5 h-5"></i></span>
+                <div class="flex-1 min-w-0"><span class="font-display font-semibold">Image scanning</span><p class="text-sm text-text-secondary mt-0.5">Reads the text in images and fingerprints known scam images.</p></div>
+                <button class="sw sw-on" role="switch" aria-checked="true" aria-label="Enable image scanning"></button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="anno mt-6"><span class="anno-tag">note</span><span>Trigger: master toggle off (with Logging on - otherwise state 2 wins). Standard enable-gate: everything below the header goes inert (opacity .45, pointer-events none) under the veil (1px blur, fades in 250ms). Sub-plugin switches keep their saved values under the veil - dimmed ON here - and every sub-plugin page shows its own group-disabled state. Tiles drop to the neutral treatment while the group is off. Reduced motion: no fade.</span></div>
+      </div>
+
+      <!-- ═══════════════ OVERVIEW · STATE 4 — STAFF ROLE MISSING ═══════════════ -->
+      <div id="ov-no-role" data-screen-label="Overview staff role missing">
+        <span class="lbl">Overview — state 4 · group on · no staff role · sub-plugin toggles disabled-with-reason</span>
+
+        <div class="mt-3 flex flex-col gap-5">
+          <div class="bg-surface-card border border-border-default rounded-card shadow-sm p-5">
+            <label class="block text-sm font-semibold mb-1.5">Staff role <span class="text-danger text-xs font-semibold">*</span></label>
+            <div class="h-10 px-3 rounded-control border-[1.5px] border-border-strong bg-surface-card flex items-center gap-2 text-sm max-w-sm cursor-pointer"><span class="flex-1 text-text-muted">Pick a role…</span><i class="ph ph-caret-down w-4 h-4 text-text-muted"></i></div>
+            <p class="text-xs mt-1.5 flex items-center gap-1 font-medium text-warning"><i class="ph ph-warning w-3.5 h-3.5"></i><span>Required. Every sub-plugin stays off until a staff role is picked.</span></p>
+          </div>
+          <div>
+            <p class="text-[11px] font-semibold uppercase tracking-widest mb-3" style="color:var(--eyebrow)">Sub-plugins</p>
+            <div class="flex flex-col gap-3">
+              <div class="bg-surface-card border border-border-default rounded-lg shadow-sm p-5 flex items-center gap-4">
+                <span class="w-11 h-11 chamfer-tile bg-surface-raised text-text-muted grid place-items-center flex-none"><span class="icon-slash" style="--slash-bg:var(--surface-raised)"><i class="ph ph-megaphone w-5 h-5"></i></span></span>
+                <div class="flex-1 min-w-0"><div class="flex items-center gap-2 flex-wrap"><span class="font-display font-semibold">Spam protection</span><span class="inline-flex items-center gap-1.5 text-xs font-semibold text-warning bg-warning-soft px-2 py-0.5 rounded-full"><span class="w-1.5 h-1.5 rounded-full bg-warning"></span>Needs setup</span></div><p class="text-sm text-text-secondary mt-0.5">Purges the same message posted across several channels within seconds.</p><p class="flex items-center gap-1 text-xs font-medium mt-1 text-warning"><i class="ph ph-warning w-3.5 h-3.5"></i><span>Pick a staff role first.</span></p></div>
+                <button class="inline-flex items-center gap-1.5 h-9 px-3.5 rounded-md border border-border-default text-sm font-semibold hover:bg-surface-sunken transition-colors"><span>Configure</span><i class="ph ph-arrow-right w-4 h-4"></i></button>
+                <button class="sw sw-off sw-disabled" role="switch" aria-checked="false" aria-disabled="true" aria-label="Enable spam protection (blocked: no staff role)"></button>
+              </div>
+              <div class="bg-surface-card border border-border-default rounded-lg shadow-sm p-5 flex items-center gap-4">
+                <span class="w-11 h-11 chamfer-tile bg-surface-raised text-text-muted grid place-items-center flex-none"><i class="ph ph-scan w-5 h-5"></i></span>
+                <div class="flex-1 min-w-0"><div class="flex items-center gap-2 flex-wrap"><span class="font-display font-semibold">Image scanning</span><span class="inline-flex items-center gap-1.5 text-xs font-semibold text-warning bg-warning-soft px-2 py-0.5 rounded-full"><span class="w-1.5 h-1.5 rounded-full bg-warning"></span>Needs setup</span></div><p class="text-sm text-text-secondary mt-0.5">Reads the text in images and fingerprints known scam images.</p><p class="flex items-center gap-1 text-xs font-medium mt-1 text-warning"><i class="ph ph-warning w-3.5 h-3.5"></i><span>Pick a staff role first.</span></p></div>
+                <button class="inline-flex items-center gap-1.5 h-9 px-3.5 rounded-md border border-border-default text-sm font-semibold hover:bg-surface-sunken transition-colors"><span>Configure</span><i class="ph ph-arrow-right w-4 h-4"></i></button>
+                <button class="sw sw-off sw-disabled" role="switch" aria-checked="false" aria-disabled="true" aria-label="Enable image scanning (blocked: no staff role)"></button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="anno mt-6"><span class="anno-tag">note</span><span>Trigger: group enabled, no staff role saved. Header + breadcrumb unchanged from state 1 (cropped here). Sub-plugin toggles use disabled-with-reason with the reason always visible (inline warning note, not tooltip-only) and rows show the Needs-setup badge. Configure stays clickable - each page remains reachable so setup can continue; its enable toggle is blocked there too (sub-plugin state 3 below). Saving a role re-enables every toggle instantly, no reload.</span></div>
+      </div>
+
+      <!-- ═══════════════ OVERVIEW · STATE 5 — PERMISSION WARNING ═══════════════ -->
+      <div id="ov-permission" data-screen-label="Overview permission warning">
+        <span class="lbl">Overview — state 5 · "Mention All Roles" permission missing · warning visible</span>
+
+        <div class="mt-3">
+          <div class="bg-surface-card border border-border-default rounded-card shadow-sm p-5">
+            <label class="block text-sm font-semibold mb-1.5">Staff role <span class="text-danger text-xs font-semibold">*</span></label>
+            <div class="h-10 px-3 rounded-control border-[1.5px] border-border-strong bg-surface-card flex items-center gap-2 text-sm max-w-sm cursor-pointer"><span class="w-2.5 h-2.5 rounded-full flex-none" style="background:#e0533d"></span><span class="flex-1">Moderator</span><i class="ph ph-caret-down w-4 h-4 text-text-muted"></i></div>
+            <p class="text-xs text-text-muted mt-1.5">Shared by every Moderation sub-plugin. Pinged on every alert, and exempt from spam detection. Pick one before enabling any sub-plugin.</p>
+            <div class="mt-3 flex items-start gap-2.5 bg-warning-soft border border-warning-soft-bd rounded-md px-3 py-2.5">
+              <i class="ph ph-warning w-[18px] h-[18px] text-warning flex-none mt-0.5"></i>
+              <p class="text-sm leading-relaxed"><b class="text-warning">Staff pings will fail.</b> shrkbot is missing the <span class="font-medium">Mention All Roles</span> permission in this server. Alerts still post to <span class="font-mono">#mod-log</span>, but nobody gets pinged until it's restored.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="anno mt-6"><span class="anno-tag">note</span><span>Trigger: the bot's permission check (on page load and after every save) finds Mention All Roles missing. Shown ONLY then, attached to the staff role card on the overview - the shared setting it breaks; sub-plugin pages don't repeat it. Not dismissable by hand; it removes itself when the permission is restored. Standard inline-warning callout, same markup as the Logging kit's @everyone warning.</span></div>
+      </div>
+
+      <!-- ═══════════════ SPAM PROTECTION · STATE 1 — NORMAL · FULL PAGE ═══════════════ -->
+      <div id="spam-normal" data-screen-label="Spam protection normal">
+        <span class="lbl">Spam protection — state 1 · full page · configured</span>
+
+        <div class="mt-3">
+          <nav class="text-xs text-text-muted mb-4 flex items-center gap-1.5"><a href="#" class="hover:text-text-secondary no-underline" style="color:var(--text-muted)">Servers</a><i class="ph ph-caret-right w-3 h-3"></i><a href="#" class="hover:text-text-secondary no-underline" style="color:var(--text-muted)">Dev Refuge</a><i class="ph ph-caret-right w-3 h-3"></i><a href="#ov-normal" class="hover:text-text-secondary no-underline" style="color:var(--text-muted)">Moderation</a><i class="ph ph-caret-right w-3 h-3"></i><span class="text-text-secondary font-medium">Spam protection</span></nav>
+
+          <div class="flex items-start gap-4 mb-2">
+            <span class="w-12 h-12 chamfer-tile text-white grid place-items-center flex-none" style="background:var(--plugin-tile)"><span class="icon-slash"><i class="ph-fill ph-megaphone w-6 h-6"></i></span></span>
+            <div class="flex-1"><h1 class="font-display text-2xl font-bold tracking-tight">Spam protection</h1><p class="text-sm text-text-secondary mt-0.5">Purges the same message when it's posted across several channels within seconds.</p></div>
+            <div class="flex items-center gap-2.5 pt-1"><span class="text-sm font-medium text-text-secondary">Enabled</span><button class="sw sw-on" role="switch" aria-checked="true" aria-label="Enable spam protection"></button></div>
+          </div>
+          <p class="text-xs text-text-muted mb-6 flex items-center gap-1.5 pl-16"><i class="ph ph-shield w-4 h-4"></i><span>Part of Moderation. Shared settings - staff role and alerts - live on the <a href="#ov-normal">Moderation overview</a>.</span></p>
+
+          <div class="flex flex-col gap-5">
+
+            <!-- Detection -->
+            <div class="bg-surface-card border border-border-default rounded-card shadow-sm p-5 grid gap-5">
+              <div>
+                <label class="block text-sm font-semibold mb-1.5">Trigger threshold</label>
+                <div class="flex items-start gap-2.5 flex-wrap">
+                  <div class="flex flex-col gap-1">
+                    <div class="inline-flex items-stretch h-10 rounded-control border-[1.5px] border-border-strong bg-surface-card overflow-hidden">
+                      <button class="w-9 grid place-items-center text-text-secondary hover:bg-surface-sunken transition-colors border-r border-border-subtle" aria-label="Fewer channels"><i class="ph ph-minus w-3.5 h-3.5"></i></button>
+                      <span class="w-11 grid place-items-center font-mono text-sm" aria-label="4 channels">4</span>
+                      <button class="w-9 grid place-items-center text-text-secondary hover:bg-surface-sunken transition-colors border-l border-border-subtle" aria-label="More channels"><i class="ph ph-plus w-3.5 h-3.5"></i></button>
+                    </div>
+                    <span class="text-[11px] text-text-muted">Recommended default: 4</span>
+                  </div>
+                  <span class="text-sm text-text-secondary h-10 inline-flex items-center">channels within</span>
+                  <div class="flex flex-col gap-1">
+                    <div class="inline-flex items-stretch h-10 rounded-control border-[1.5px] border-border-strong bg-surface-card overflow-hidden">
+                      <button class="w-9 grid place-items-center text-text-secondary hover:bg-surface-sunken transition-colors border-r border-border-subtle" aria-label="Shorter window"><i class="ph ph-minus w-3.5 h-3.5"></i></button>
+                      <span class="w-11 grid place-items-center font-mono text-sm" aria-label="15 seconds">15</span>
+                      <button class="w-9 grid place-items-center text-text-secondary hover:bg-surface-sunken transition-colors border-l border-border-subtle" aria-label="Longer window"><i class="ph ph-plus w-3.5 h-3.5"></i></button>
+                    </div>
+                    <span class="text-[11px] text-text-muted">Recommended default: 15</span>
+                  </div>
+                  <span class="text-sm text-text-secondary h-10 inline-flex items-center">seconds</span>
+                </div>
+                <p class="text-xs text-text-muted mt-1.5">Triggers when the same message appears in 4 different channels within 15 seconds.</p>
+              </div>
+              <div>
+                <div class="flex items-baseline justify-between max-w-sm mb-1.5">
+                  <label class="text-sm font-semibold">Match strictness</label>
+                  <span class="text-sm"><span class="font-mono font-medium">100%</span> <span class="text-xs text-text-muted">only identical messages</span></span>
+                </div>
+                <div class="relative max-w-sm h-5 flex items-center" role="slider" aria-valuemin="75" aria-valuemax="100" aria-valuenow="100" aria-valuetext="100% - only identical messages" aria-label="Match strictness">
+                  <div class="h-1.5 w-full rounded-full bg-border-subtle overflow-hidden"><div class="h-full rounded-full bg-accent" style="width:100%"></div></div>
+                  <span class="absolute right-0 w-[18px] h-[18px] rounded-full bg-white border-2 border-accent shadow-sm"></span>
+                </div>
+                <div class="flex justify-between max-w-sm mt-1"><span class="text-[11px] font-mono text-text-muted">75% · loosely similar</span><span class="text-[11px] font-mono text-text-muted">100% · identical</span></div>
+                <p class="text-xs text-text-muted mt-1.5">How similar two messages must be to count as the same message. 100% only catches exact copies; lower values also catch spam with small edits - swapped words, extra characters - but can mistake similar real messages for spam. Case, punctuation, digits and disguised characters are ignored either way - see <a href="#matching">How text matching works</a>.</p>
+                <p class="text-[11px] text-text-muted mt-1">Recommended default: 100%</p>
+              </div>
+              <div>
+                <div class="flex items-center justify-between max-w-md gap-4">
+                  <label class="text-sm font-semibold">Also match symbol-only messages</label>
+                  <button class="sw sw-off" role="switch" aria-checked="false" aria-label="Also match symbol-only messages"></button>
+                </div>
+                <p class="text-xs text-text-muted mt-1.5 max-w-md">Messages with no matchable text - only emoji, punctuation or digits - are ignored by default. When on, they all count as the same message, so blasting any symbol noise across channels triggers.</p>
+                <p class="text-[11px] text-text-muted mt-1">Recommended default: Off</p>
+              </div>
+            </div>
+
+            <!-- Response -->
+            <div class="bg-surface-card border border-border-default rounded-card shadow-sm p-5 grid gap-5">
+              <div>
+                <label class="block text-sm font-semibold mb-1.5">When spam is detected</label>
+                <div class="flex gap-2 max-w-md" role="group" aria-label="Spam action">
+                  <button class="flex-1 h-10 rounded-md border-[1.5px] border-accent bg-accent-soft text-sm font-semibold text-accent-soft-fg">Purge the messages</button>
+                  <button class="flex-1 h-10 rounded-md border-[1.5px] border-border-default text-sm font-medium text-text-secondary">Notify only</button>
+                </div>
+                <p class="text-xs text-text-muted mt-1.5">Notify only is a dry run - staff get the alert, nothing is deleted.</p>
+              </div>
+              <div>
+                <label class="block text-sm font-semibold mb-1.5">Also punish the sender</label>
+                <div class="flex gap-2 max-w-md" role="group" aria-label="Spam punishment">
+                  <button class="flex-1 h-10 rounded-md border-[1.5px] border-border-default text-sm font-medium text-text-secondary">None</button>
+                  <button class="flex-1 h-10 rounded-md border-[1.5px] border-accent bg-accent-soft text-sm font-semibold text-accent-soft-fg">Time out</button>
+                  <button class="flex-1 h-10 rounded-md border-[1.5px] border-border-default text-sm font-medium text-text-secondary">Kick</button>
+                  <button class="flex-1 h-10 rounded-md border-[1.5px] border-border-default text-sm font-medium text-text-secondary">Ban</button>
+                </div>
+                <div class="mt-3">
+                  <label class="block text-xs font-semibold mb-1.5">Duration</label>
+                  <div class="h-10 px-3 rounded-control border-[1.5px] border-border-strong bg-surface-card flex items-center gap-2 text-sm max-w-[200px] cursor-pointer"><span class="flex-1">1 hour</span><i class="ph ph-caret-down w-4 h-4 text-text-muted"></i></div>
+                  <p class="text-xs text-text-muted mt-1.5">Applies on top of the purge.</p>
+                </div>
+              </div>
+            </div>
+
+          </div>
+
+          <p class="mt-6 text-xs text-text-muted flex items-center gap-1.5"><i class="ph ph-terminal-window w-4 h-4"></i><span>No slash commands - spam protection runs automatically once enabled.</span></p>
+        </div>
+
+        <div class="anno mt-6"><span class="anno-tag">note</span><span>Standard ConfigPage; the header toggle is the same value as this sub-plugin's switch on the overview. Controls reflowed into two cards: Detection (threshold + strictness + symbol-only toggle, default off) and Response (action + punishment). Time out shows the Duration select; None and Kick show nothing extra; Ban shows the danger warning (shared state below). Edits raise the shared SaveBar. Collapse/expand: none on this page.</span></div>
+      </div>
+
+      <!-- ═══════════════ SPAM PROTECTION · STATE 2 — GROUP DISABLED ═══════════════ -->
+      <div id="spam-group-off" data-screen-label="Spam protection group disabled">
+        <span class="lbl">Spam protection — state 2 · blocked · Moderation group is disabled</span>
+
+        <div class="mt-3 pt-16">
+          <div class="flex items-start gap-4 mb-6">
+            <span class="w-12 h-12 chamfer-tile bg-surface-raised text-text-muted grid place-items-center flex-none"><span class="icon-slash" style="--slash-bg:var(--surface-raised)"><i class="ph ph-megaphone w-6 h-6"></i></span></span>
+            <div class="flex-1"><h1 class="font-display text-2xl font-bold tracking-tight">Spam protection</h1><p class="text-sm text-text-secondary mt-0.5">Purges the same message when it's posted across several channels within seconds.</p></div>
+            <div class="flex items-center gap-2.5 pt-1">
+              <span class="text-sm font-medium text-text-secondary">Disabled</span>
+              <span class="relative inline-flex">
+                <span class="tip-static">Enable the Moderation group first - its master switch is off.</span>
+                <button class="sw sw-off sw-disabled" role="switch" aria-checked="false" aria-disabled="true" aria-label="Enable spam protection (blocked: Moderation group is disabled)"></button>
+              </span>
+            </div>
+          </div>
+
+          <div class="relative">
+            <div class="gate-overlay">
+              <div class="text-center bg-surface-card border border-border-default rounded-lg shadow-md px-6 py-5 max-w-sm">
+                <i class="ph ph-shield w-5 h-5 text-text-muted mx-auto block"></i>
+                <p class="text-sm font-semibold mt-2">Moderation is disabled</p>
+                <p class="text-xs text-text-secondary mt-1 mb-3">Spam protection is part of the Moderation group. Enable the group on its overview to configure this page.</p>
+                <button class="inline-flex items-center gap-1.5 h-9 px-4 rounded-control border border-border-strong bg-surface-card text-sm font-semibold hover:bg-surface-sunken transition-colors"><span>Open Moderation overview</span><i class="ph ph-arrow-right w-4 h-4"></i></button>
+              </div>
+            </div>
+            <div class="flex flex-col gap-5" style="opacity:.45;pointer-events:none" aria-hidden="true">
+              <div class="bg-surface-card border border-border-default rounded-card shadow-sm p-5">
+                <label class="block text-sm font-semibold mb-1.5">Trigger threshold</label>
+                <div class="flex items-center gap-2.5 flex-wrap">
+                  <div class="inline-flex items-stretch h-10 rounded-control border-[1.5px] border-border-strong bg-surface-card overflow-hidden">
+                    <span class="w-9 grid place-items-center text-text-secondary border-r border-border-subtle"><i class="ph ph-minus w-3.5 h-3.5"></i></span>
+                    <span class="w-11 grid place-items-center font-mono text-sm">4</span>
+                    <span class="w-9 grid place-items-center text-text-secondary border-l border-border-subtle"><i class="ph ph-plus w-3.5 h-3.5"></i></span>
+                  </div>
+                  <span class="text-sm text-text-secondary">channels within</span>
+                  <div class="inline-flex items-stretch h-10 rounded-control border-[1.5px] border-border-strong bg-surface-card overflow-hidden">
+                    <span class="w-9 grid place-items-center text-text-secondary border-r border-border-subtle"><i class="ph ph-minus w-3.5 h-3.5"></i></span>
+                    <span class="w-11 grid place-items-center font-mono text-sm">15</span>
+                    <span class="w-9 grid place-items-center text-text-secondary border-l border-border-subtle"><i class="ph ph-plus w-3.5 h-3.5"></i></span>
+                  </div>
+                  <span class="text-sm text-text-secondary">seconds</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="anno mt-6"><span class="anno-tag">note</span><span>Trigger: the group's master switch is off. Same PrereqGate treatment as the overview's Logging block: header toggle disabled-with-reason (tooltip rendered visible here), gate card names the blocker and deep-links to the overview. Settings render inert beneath (cropped to the first card here). Flipping the master switch on the overview unblocks this page live.</span></div>
+      </div>
+
+      <!-- ═══════════════ SPAM PROTECTION · STATE 3 — NO STAFF ROLE ═══════════════ -->
+      <div id="spam-no-role" data-screen-label="Spam protection no staff role">
+        <span class="lbl">Spam protection — state 3 · blocked · no staff role set · settings stay editable</span>
+
+        <div class="mt-3">
+          <div class="flex items-start gap-4 mb-4">
+            <span class="w-12 h-12 chamfer-tile bg-surface-raised text-text-muted grid place-items-center flex-none"><span class="icon-slash" style="--slash-bg:var(--surface-raised)"><i class="ph ph-megaphone w-6 h-6"></i></span></span>
+            <div class="flex-1"><h1 class="font-display text-2xl font-bold tracking-tight">Spam protection</h1><p class="text-sm text-text-secondary mt-0.5">Purges the same message when it's posted across several channels within seconds.</p></div>
+            <div class="flex items-center gap-2.5 pt-1"><span class="text-sm font-medium text-text-secondary">Disabled</span><button class="sw sw-off sw-disabled" role="switch" aria-checked="false" aria-disabled="true" aria-label="Enable spam protection (blocked: no staff role)"></button></div>
+          </div>
+          <div class="flex items-start gap-2.5 bg-warning-soft border border-warning-soft-bd rounded-md px-4 py-3">
+            <i class="ph ph-warning w-[18px] h-[18px] text-warning flex-none mt-0.5"></i>
+            <p class="text-sm leading-relaxed"><b class="text-warning">Pick a staff role first.</b> Every Moderation sub-plugin needs the shared staff role - it's pinged on every alert. Set it on the <a href="#ov-no-role">Moderation overview</a>, then enable spam protection here.</p>
+          </div>
+        </div>
+
+        <div class="anno mt-6"><span class="anno-tag">note</span><span>Trigger: group on, no staff role saved. NOT a gate - all settings below stay visible and editable so setup can continue (cropped here); only the enable toggle is locked, disabled-with-reason. The warning callout is always visible and links to the overview. Identical markup on the Image scanning page. Saving a role flips the toggle back to interactive without a reload.</span></div>
+      </div>
+
+      <!-- ═══════════════ IMAGE SCANNING · STATE 1 — NORMAL · FULL PAGE ═══════════════ -->
+      <div id="img-normal" data-screen-label="Image scanning normal">
+        <span class="lbl">Image scanning — state 1 · full page · configured · explainer expanded</span>
+
+        <div class="mt-3">
+          <nav class="text-xs text-text-muted mb-4 flex items-center gap-1.5"><a href="#" class="hover:text-text-secondary no-underline" style="color:var(--text-muted)">Servers</a><i class="ph ph-caret-right w-3 h-3"></i><a href="#" class="hover:text-text-secondary no-underline" style="color:var(--text-muted)">Dev Refuge</a><i class="ph ph-caret-right w-3 h-3"></i><a href="#ov-normal" class="hover:text-text-secondary no-underline" style="color:var(--text-muted)">Moderation</a><i class="ph ph-caret-right w-3 h-3"></i><span class="text-text-secondary font-medium">Image scanning</span></nav>
+
+          <div class="flex items-start gap-4 mb-2">
+            <span class="w-12 h-12 chamfer-tile text-white grid place-items-center flex-none" style="background:var(--plugin-tile)"><i class="ph-fill ph-scan w-6 h-6"></i></span>
+            <div class="flex-1"><h1 class="font-display text-2xl font-bold tracking-tight">Image scanning</h1><p class="text-sm text-text-secondary mt-0.5">Reads the text in images and fingerprints known scam images.</p></div>
+            <div class="flex items-center gap-2.5 pt-1"><span class="text-sm font-medium text-text-secondary">Enabled</span><button class="sw sw-on" role="switch" aria-checked="true" aria-label="Enable image scanning"></button></div>
+          </div>
+          <p class="text-xs text-text-muted mb-6 flex items-center gap-1.5 pl-16"><i class="ph ph-shield w-4 h-4"></i><span>Part of Moderation. Shared settings - staff role and alerts - live on the <a href="#ov-normal">Moderation overview</a>.</span></p>
+
+          <div class="flex flex-col gap-5">
+
+            <!-- Consent — REQUIRED informed-consent block, always visible while the sub-plugin is on -->
+            <div class="flex gap-3 bg-warning-soft border border-warning-soft-bd rounded-md px-4 py-3">
+              <i class="ph ph-warning w-[18px] h-[18px] text-warning flex-none mt-0.5"></i>
+              <div class="text-sm leading-relaxed">
+                <p class="font-semibold">Before you turn this on</p>
+                <p class="mt-1">Deletion is on by default, and detection is automated and imperfect. Screenshots of scams - the kind well-meaning members post as warnings - can be detected and deleted too, so tell your community not to post scam screenshots. Staff are pinged on every action and can mark a decision as wrong with one click in Discord.</p>
+              </div>
+            </div>
+
+            <!-- Detection -->
+            <div class="bg-surface-card border border-border-default rounded-card shadow-sm p-5">
+              <label class="block text-sm font-semibold mb-1.5">Sensitivity</label>
+              <div class="flex flex-col gap-2 max-w-md" role="radiogroup" aria-label="Image scanning sensitivity">
+                <button class="flex items-start gap-3 rounded-md border-[1.5px] border-border-default px-4 py-3 text-left hover:bg-surface-sunken transition-colors" role="radio" aria-checked="false">
+                  <span class="w-4 h-4 rounded-full border-[1.5px] border-border-strong flex-none mt-0.5"></span>
+                  <span><span class="block text-sm font-semibold">Relaxed</span><span class="block text-xs text-text-secondary mt-0.5">Acts only on unmistakable scams. Fewest false positives; more scams slip through.</span></span>
+                </button>
+                <button class="flex items-start gap-3 rounded-md border-[1.5px] border-accent bg-accent-soft px-4 py-3 text-left" role="radio" aria-checked="true">
+                  <span class="w-4 h-4 rounded-full border-[5px] border-accent bg-white flex-none mt-0.5"></span>
+                  <span><span class="block text-sm font-semibold text-accent-soft-fg">Standard</span><span class="block text-xs text-text-secondary mt-0.5">Catches most scam images with occasional false positives. Recommended.</span></span>
+                </button>
+                <button class="flex items-start gap-3 rounded-md border-[1.5px] border-border-default px-4 py-3 text-left hover:bg-surface-sunken transition-colors" role="radio" aria-checked="false">
+                  <span class="w-4 h-4 rounded-full border-[1.5px] border-border-strong flex-none mt-0.5"></span>
+                  <span><span class="block text-sm font-semibold">Strict</span><span class="block text-xs text-text-secondary mt-0.5">Also acts on borderline matches. Expect false positives - best with an active staff team.</span></span>
+                </button>
+              </div>
+            </div>
+
+            <!-- Custom keywords -->
+            <div class="bg-surface-card border border-border-default rounded-card shadow-sm p-5 grid gap-5">
+              <div>
+                <label class="block text-sm font-semibold mb-1.5">Custom keywords</label>
+                <div class="min-h-10 px-2 py-1.5 rounded-control border-[1.5px] border-border-strong bg-surface-card flex items-center gap-1.5 flex-wrap max-w-md cursor-text">
+                  <span class="inline-flex items-center gap-1 text-xs font-medium bg-accent-soft text-accent-soft-fg rounded-chip px-2 py-1">free nitro<i class="ph ph-x w-3 h-3"></i></span>
+                  <span class="inline-flex items-center gap-1 text-xs font-medium bg-accent-soft text-accent-soft-fg rounded-chip px-2 py-1">steam gift<i class="ph ph-x w-3 h-3"></i></span>
+                  <span class="inline-flex items-center gap-1 text-xs font-medium bg-accent-soft text-accent-soft-fg rounded-chip px-2 py-1">$50 giveaway<i class="ph ph-x w-3 h-3"></i></span>
+                  <span class="text-sm text-text-muted px-1">Add a word or phrase…</span>
+                </div>
+                <p class="text-xs text-text-muted mt-1.5">Words or phrases that mark an image as a scam when they show up in its text - on top of shrkbot's built-in scam rules. Close misspellings count too, so one entry covers its variations. Short, common words trigger easily; longer phrases make more precise rules. Keywords are matched like all other text - case, punctuation and disguised characters ignored, digits kept - see <a href="#matching">How text matching works</a>.</p>
+              </div>
+              <div>
+                <label class="block text-sm font-semibold mb-1.5">Require at least</label>
+                <div class="flex items-start gap-2.5">
+                  <div class="flex flex-col gap-1">
+                    <div class="inline-flex items-stretch h-10 rounded-control border-[1.5px] border-border-strong bg-surface-card overflow-hidden">
+                      <button class="w-9 grid place-items-center text-text-secondary hover:bg-surface-sunken transition-colors border-r border-border-subtle" aria-label="Fewer matches"><i class="ph ph-minus w-3.5 h-3.5"></i></button>
+                      <span class="w-11 grid place-items-center font-mono text-sm" aria-label="2 matches">2</span>
+                      <button class="w-9 grid place-items-center text-text-secondary hover:bg-surface-sunken transition-colors border-l border-border-subtle" aria-label="More matches"><i class="ph ph-plus w-3.5 h-3.5"></i></button>
+                    </div>
+                    <span class="text-[11px] text-text-muted">Recommended default: 2</span>
+                  </div>
+                  <span class="text-sm text-text-secondary h-10 inline-flex items-center">matching keywords before shrkbot acts</span>
+                </div>
+                <p class="text-xs text-text-muted mt-1.5">1 is aggressive - a single matched word can delete an image. 2 or more keeps one stray word from triggering. Up to as many keywords as you've set.</p>
+              </div>
+            </div>
+
+            <!-- Response -->
+            <div class="bg-surface-card border border-border-default rounded-card shadow-sm p-5 grid gap-5">
+              <div>
+                <label class="block text-sm font-semibold mb-1.5">When a scam is detected</label>
+                <div class="flex gap-2 max-w-md" role="group" aria-label="Scam action">
+                  <button class="flex-1 h-10 rounded-md border-[1.5px] border-accent bg-accent-soft text-sm font-semibold text-accent-soft-fg">Delete the image</button>
+                  <button class="flex-1 h-10 rounded-md border-[1.5px] border-border-default text-sm font-medium text-text-secondary">Flag only</button>
+                </div>
+                <p class="text-xs text-text-muted mt-1.5">Flag only leaves the image up and pings staff to review it.</p>
+              </div>
+              <div>
+                <label class="block text-sm font-semibold mb-1.5">Also punish the sender</label>
+                <div class="flex gap-2 max-w-md" role="group" aria-label="Image scanning punishment">
+                  <button class="flex-1 h-10 rounded-md border-[1.5px] border-accent bg-accent-soft text-sm font-semibold text-accent-soft-fg">None</button>
+                  <button class="flex-1 h-10 rounded-md border-[1.5px] border-border-default text-sm font-medium text-text-secondary">Time out</button>
+                  <button class="flex-1 h-10 rounded-md border-[1.5px] border-border-default text-sm font-medium text-text-secondary">Kick</button>
+                  <button class="flex-1 h-10 rounded-md border-[1.5px] border-border-default text-sm font-medium text-text-secondary">Ban</button>
+                </div>
+              </div>
+            </div>
+
+            <!-- Explainer — collapsible, rendered expanded -->
+            <div class="bg-surface-card border border-border-default rounded-card shadow-sm overflow-hidden">
+              <div class="flex items-center gap-3 px-5 py-3.5 bg-surface-sunken border-b border-border-subtle cursor-pointer select-none">
+                <i class="ph ph-caret-down w-4 h-4 text-text-muted" style="transform:rotate(180deg)"></i>
+                <span class="text-sm font-semibold flex-1">How image scanning works</span>
+              </div>
+              <div class="px-5 py-4 grid gap-3">
+                <p class="text-sm text-text-secondary flex items-start gap-2.5"><i class="ph ph-cpu w-4 h-4 mt-0.5 text-text-muted"></i><span>shrkbot reads image text in memory. Nothing is stored.</span></p>
+                <p class="text-sm text-text-secondary flex items-start gap-2.5"><i class="ph ph-check-square w-4 h-4 mt-0.5 text-text-muted"></i><span>Staff confirm or dismiss every flag with buttons in your log channel.</span></p>
+                <p class="text-sm text-text-secondary flex items-start gap-2.5"><i class="ph ph-fingerprint w-4 h-4 mt-0.5 text-text-muted"></i><span>Confirmed scams are remembered by image fingerprint, across every server shrkbot is in.</span></p>
+              </div>
+            </div>
+
+          </div>
+
+          <p class="mt-6 text-xs text-text-muted flex items-center gap-1.5"><i class="ph ph-terminal-window w-4 h-4"></i><span>No slash commands - image scanning runs automatically once enabled.</span></p>
+        </div>
+
+        <div class="anno mt-6"><span class="anno-tag">note</span><span>Consent callout leads the page (informed consent before settings, required), then Detection (sensitivity as a RadioCardGroup - new component, options carry their own descriptions), Custom keywords (TomSelect in free-tag mode - chips are words or whole phrases, no quote syntax; plus a NumberStepper for the minimum-matches gate), Response, and the collapsible explainer (standard collapsible card, logExpand 180ms / logCollapse 150ms, chevron rotates; rendered expanded per review spec). The consent callout is part of the page whenever the sub-plugin is on - not dismissable. Edits raise the shared SaveBar. Reduced motion: expand/collapse snaps.</span></div>
+      </div>
+
+      <!-- ═══════════════ IMAGE SCANNING · STATE 2 — GROUP DISABLED ═══════════════ -->
+      <div id="img-group-off" data-screen-label="Image scanning group disabled">
+        <span class="lbl">Image scanning — state 2 · blocked · Moderation group is disabled</span>
+
+        <div class="mt-3 pt-16">
+          <div class="flex items-start gap-4 mb-6">
+            <span class="w-12 h-12 chamfer-tile bg-surface-raised text-text-muted grid place-items-center flex-none"><i class="ph ph-scan w-6 h-6"></i></span>
+            <div class="flex-1"><h1 class="font-display text-2xl font-bold tracking-tight">Image scanning</h1><p class="text-sm text-text-secondary mt-0.5">Reads the text in images and fingerprints known scam images.</p></div>
+            <div class="flex items-center gap-2.5 pt-1">
+              <span class="text-sm font-medium text-text-secondary">Disabled</span>
+              <span class="relative inline-flex">
+                <span class="tip-static">Enable the Moderation group first - its master switch is off.</span>
+                <button class="sw sw-off sw-disabled" role="switch" aria-checked="false" aria-disabled="true" aria-label="Enable image scanning (blocked: Moderation group is disabled)"></button>
+              </span>
+            </div>
+          </div>
+
+          <div class="relative">
+            <div class="gate-overlay">
+              <div class="text-center bg-surface-card border border-border-default rounded-lg shadow-md px-6 py-5 max-w-sm">
+                <i class="ph ph-shield w-5 h-5 text-text-muted mx-auto block"></i>
+                <p class="text-sm font-semibold mt-2">Moderation is disabled</p>
+                <p class="text-xs text-text-secondary mt-1 mb-3">Image scanning is part of the Moderation group. Enable the group on its overview to configure this page.</p>
+                <button class="inline-flex items-center gap-1.5 h-9 px-4 rounded-control border border-border-strong bg-surface-card text-sm font-semibold hover:bg-surface-sunken transition-colors"><span>Open Moderation overview</span><i class="ph ph-arrow-right w-4 h-4"></i></button>
+              </div>
+            </div>
+            <div class="flex flex-col gap-5" style="opacity:.45;pointer-events:none" aria-hidden="true">
+              <div class="bg-surface-card border border-border-default rounded-card shadow-sm p-5">
+                <label class="block text-sm font-semibold mb-1.5">Sensitivity</label>
+                <div class="flex flex-col gap-2 max-w-md">
+                  <span class="flex items-start gap-3 rounded-md border-[1.5px] border-accent bg-accent-soft px-4 py-3"><span class="w-4 h-4 rounded-full border-[5px] border-accent bg-white flex-none mt-0.5"></span><span><span class="block text-sm font-semibold text-accent-soft-fg">Standard</span><span class="block text-xs text-text-secondary mt-0.5">Catches most scam images with occasional false positives. Recommended.</span></span></span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="anno mt-6"><span class="anno-tag">note</span><span>Identical treatment to Spam protection state 2 - one PrereqGate pattern serves every sub-plugin. Settings render inert beneath (cropped to the first card here).</span></div>
+      </div>
+
+      <!-- ═══════════════ IMAGE SCANNING · STATE 3 — NO STAFF ROLE ═══════════════ -->
+      <div id="img-no-role" data-screen-label="Image scanning no staff role">
+        <span class="lbl">Image scanning — state 3 · blocked · no staff role set · settings stay editable</span>
+
+        <div class="mt-3">
+          <div class="flex items-start gap-4 mb-4">
+            <span class="w-12 h-12 chamfer-tile bg-surface-raised text-text-muted grid place-items-center flex-none"><i class="ph ph-scan w-6 h-6"></i></span>
+            <div class="flex-1"><h1 class="font-display text-2xl font-bold tracking-tight">Image scanning</h1><p class="text-sm text-text-secondary mt-0.5">Reads the text in images and fingerprints known scam images.</p></div>
+            <div class="flex items-center gap-2.5 pt-1"><span class="text-sm font-medium text-text-secondary">Disabled</span><button class="sw sw-off sw-disabled" role="switch" aria-checked="false" aria-disabled="true" aria-label="Enable image scanning (blocked: no staff role)"></button></div>
+          </div>
+          <div class="flex items-start gap-2.5 bg-warning-soft border border-warning-soft-bd rounded-md px-4 py-3">
+            <i class="ph ph-warning w-[18px] h-[18px] text-warning flex-none mt-0.5"></i>
+            <p class="text-sm leading-relaxed"><b class="text-warning">Pick a staff role first.</b> Every Moderation sub-plugin needs the shared staff role - it's pinged on every alert. Set it on the <a href="#ov-no-role">Moderation overview</a>, then enable image scanning here.</p>
+          </div>
+        </div>
+
+        <div class="anno mt-6"><span class="anno-tag">note</span><span>Identical treatment to Spam protection state 3: no gate, settings below stay editable (cropped here), only the enable toggle is locked with the always-visible reason.</span></div>
+      </div>
+
+      <!-- ═══════════════ SHARED STATE — BAN PUNISHMENT SELECTED ═══════════════ -->
+      <div id="ban" data-screen-label="Ban selected">
+        <span class="lbl">Shared state — Ban punishment selected · inline danger warning (both sub-plugin pages)</span>
+
+        <div class="mt-3">
+          <div class="bg-surface-card border border-border-default rounded-card shadow-sm p-5">
+            <label class="block text-sm font-semibold mb-1.5">Also punish the sender</label>
+            <div class="flex gap-2 max-w-md" role="group" aria-label="Spam punishment">
+              <button class="flex-1 h-10 rounded-md border-[1.5px] border-border-default text-sm font-medium text-text-secondary">None</button>
+              <button class="flex-1 h-10 rounded-md border-[1.5px] border-border-default text-sm font-medium text-text-secondary">Time out</button>
+              <button class="flex-1 h-10 rounded-md border-[1.5px] border-border-default text-sm font-medium text-text-secondary">Kick</button>
+              <button class="flex-1 h-10 rounded-md border-[1.5px] border-danger bg-danger-soft text-sm font-semibold text-danger">Ban</button>
+            </div>
+            <div class="mt-3 flex items-start gap-2.5 bg-danger-soft border border-danger-soft-bd rounded-md px-3 py-2.5">
+              <i class="ph ph-warning w-[18px] h-[18px] text-danger flex-none mt-0.5"></i>
+              <p class="text-sm leading-relaxed">A ban is permanent until a mod lifts it, and shrkbot can't undo it. Pick this only if you're confident your thresholds never catch real members.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="anno mt-6"><span class="anno-tag">note</span><span>Trigger: Ban selected in the punishment control on either sub-plugin page (identical markup on both; cropped to the Response card's punishment block). The active Ban segment uses the danger treatment (danger border + soft wash), same as the OCR kit's punish tiers. The warning expands in with the standard 180ms ease; picking any other option removes it. Time out shows the Duration select instead; None and Kick show nothing extra.</span></div>
+      </div>
+
+      <!-- ═══════════════ SHARED STATE — DIRTY FORM · SAVEBAR ═══════════════ -->
+      <div id="savebar" data-screen-label="Dirty form">
+        <span class="lbl">Shared state — unsaved changes · SaveBar visible (overview + both sub-plugin pages)</span>
+
+        <div class="mt-3 grid place-items-center py-4">
+          <div class="bg-surface-card border border-border-default rounded-xl shadow-lg px-5 py-3 flex items-center justify-between gap-6 whitespace-nowrap w-[480px] max-w-full">
+            <p class="text-sm text-text-secondary flex items-center gap-2">
+              <span class="w-2 h-2 rounded-full bg-warning inline-block flex-none"></span>
+              Unsaved changes
+            </p>
+            <div class="flex items-center gap-2">
+              <button class="h-8 px-3.5 rounded-lg border border-border-default text-sm font-semibold hover:bg-surface-sunken transition-colors">Discard</button>
+              <button class="h-8 px-4 rounded-lg bg-accent-fill text-white text-sm font-semibold inline-flex items-center gap-1.5"><i class="ph ph-check w-4 h-4"></i><span>Save</span></button>
+            </div>
+          </div>
+        </div>
+
+        <div class="anno mt-6"><span class="anno-tag">note</span><span>Standard SaveBar, rendered inline here - in production it's fixed bottom-center (bottom-6, z-40) over whichever Moderation page is open. Appears on the first edit with the saveBarIn spring (420ms); navigating away while dirty - including between sub-plugins in the sidebar group - shakes it with a copper ring (600ms + 1.6s ring fade) and blocks the navigation. Save validates that the shared staff role is set whenever any sub-plugin is on - failing that, it navigates to the overview and the staff role card gets the field-error shake + red ring with "A staff role is required while a sub-plugin is enabled." Discard reverts every control on the current page. Reduced motion: the bar appears and leaves without animation.</span></div>
+      </div>
+
+      <!-- ═══════════════ NEW COMPONENTS ═══════════════ -->
+      <div id="new-components">
+        <p class="text-[11px] font-semibold uppercase tracking-widest mb-1" style="color:var(--eyebrow)">New components</p>
+        <p class="text-sm text-text-secondary mb-4 max-w-2xl">Everything else on these pages maps to existing components (ConfigPage header + enable toggle, enable-gate, plugin row, setting row, inline warning callouts, segmented control, punish tiers, TomSelect role/duration selects, switch, SaveBar, collapsible card, disabled-with-reason). These five don't exist yet - each ships with a fallback so we can skip building it.</p>
+
+        <div class="flex flex-col gap-4">
+
+          <div class="bg-surface-card border border-border-default rounded-card shadow-sm p-5">
+            <p class="font-mono text-sm font-medium">SidebarGroup</p>
+            <p class="text-sm text-text-secondary mt-2 leading-relaxed">A plugin-nav entry that expands into sub-items. The parent row keeps the flat entry's icon tile + label but swaps the status dot for a chevron (caret-right closed, rotating to caret-down, 200ms ease-standard); clicking it toggles disclosure only. Sub-items are text-only rows on an indent rail (1px left border aligned under the parent label), each with its own status dot; Overview has none. Disclosure state persists per user and the group auto-expands when one of its pages is active. Active styling reuses plugin-nav-item.active (accent-soft wash, --nav-active text). One Stimulus disclosure controller; sub-items are plain Turbo links.</p>
+            <p class="text-sm mt-3 leading-relaxed"><span class="font-semibold">Fallback:</span> <span class="text-text-secondary">No disclosure: a section eyebrow reading "Moderation" above permanently-indented flat plugin-nav-items (Overview, Spam protection, Image scanning) using only existing nav markup. Loses collapse, keeps the grouping legible.</span></p>
+          </div>
+
+          <div class="bg-surface-card border border-border-default rounded-card shadow-sm p-5">
+            <p class="font-mono text-sm font-medium">NumberStepper</p>
+            <p class="text-sm text-text-secondary mt-2 leading-relaxed">An integer field with minus / plus buttons around a mono value, min clamping (no UI upper cap - sanity caps live in the DB), a unit label ("channels", "seconds") and a "Recommended default: n" subscript. Arrow keys step, Home jumps to the minimum; held buttons repeat; the value is directly editable as a plain number field. Used for the spam trigger threshold (channels, min 2, default 4; window, min 1 second, default 15) and the custom-keyword minimum-matches gate (min 1, default 2, max = the number of keywords currently set - the one stepper with a dynamic UI max). DB-side sanity caps are not advertised, but an out-of-range save is rejected with the standard inline field error naming the bound ("Must be between 2 and 500"). One small Stimulus controller; submits as a plain number field.</p>
+            <p class="text-sm mt-3 leading-relaxed"><span class="font-semibold">Fallback:</span> <span class="text-text-secondary">A plain number input in the standard field shell with the same subscript. Loses the stepper buttons, keeps free entry.</span></p>
+          </div>
+
+          <div class="bg-surface-card border border-border-default rounded-card shadow-sm p-5">
+            <p class="font-mono text-sm font-medium">RangeSlider</p>
+            <p class="text-sm text-text-secondary mt-2 leading-relaxed">A labelled slider with a filled accent track, endpoint captions ("75% · loosely similar" / "100% · identical") and a live mono readout that doubles as the accessible value text ("100% - only identical messages"). Steps of 1 between 75% and 100%, default 100%; displayed as a percentage, stored as a 0.75-1.00 float. Used for spam match strictness, where the whole point is feeling the trade-off as a continuum. Native <span class="font-mono">&lt;input type="range"&gt;</span> under the hood, restyled with tokens.</p>
+            <p class="text-sm mt-3 leading-relaxed"><span class="font-semibold">Fallback:</span> <span class="text-text-secondary">TomSelect with curated presets: Identical (100%), Very close (95%), Close (90%), Loose (85%), Looser (80%), Loosest (75%) - each option carrying its one-line risk note in the dropdown.</span></p>
+          </div>
+
+          <div class="bg-surface-card border border-border-default rounded-card shadow-sm p-5">
+            <p class="font-mono text-sm font-medium">RadioCardGroup</p>
+            <p class="text-sm text-text-secondary mt-2 leading-relaxed">Stacked radio options, each a full-width bordered card with a radio dot, a bold title and a one-line description - for choices whose options need explaining, where a segmented control's bare words are meaningless. The selected card gets the accent border, accent-soft wash and a filled radio dot; unselected cards hover with the surface-sunken wash. Keyboard: arrow keys move selection per the radiogroup pattern. Used for image-scanning sensitivity (Relaxed / Standard / Strict).</p>
+            <p class="text-sm mt-3 leading-relaxed"><span class="font-semibold">Fallback:</span> <span class="text-text-secondary">The existing SegmentedControl with a single help line below that swaps to the selected option's description. Keeps the meaning, loses the at-a-glance comparison.</span></p>
+          </div>
+
+          <div class="bg-surface-card border border-border-default rounded-card shadow-sm p-5">
+            <p class="font-mono text-sm font-medium">PrereqGate</p>
+            <p class="text-sm text-text-secondary mt-2 leading-relaxed">A variant of the existing enable-gate overlay card for hard dependencies, used twice here: Logging missing (overview) and group disabled (sub-plugin pages). It swaps the lock icon + "is disabled" copy for the blocking reason, and the primary Enable CTA for a secondary button that deep-links to wherever the blocker is fixed. Pairs with the disabled-with-reason header toggle. Copy and CTA are slots; the veil, blur and fade are unchanged.</p>
+            <p class="text-sm mt-3 leading-relaxed"><span class="font-semibold">Fallback:</span> <span class="text-text-secondary">The existing GateOverlay with a warning Callout + secondary Button composed into its card slot - visually near-identical, just less reusable.</span></p>
+          </div>
+
+        </div>
+      </div>
+
+    </div><!-- /pane-content -->
+  </div>
+</section>
+
+<!-- ════════════════════════════════════════════════════════════════
+     DARK PANE — same markup cloned under [data-theme="dark"];
+     semantic tokens flip everything (espresso surfaces, patina teal,
+     copper annotation chrome, translucent warning washes).
+     ════════════════════════════════════════════════════════════════ -->
+<section data-theme="dark" data-pane-dark class="bg-surface-page text-text-primary py-10 px-6">
+  <div class="max-w-[860px] mx-auto">
+    <p class="font-mono text-xs text-text-muted mb-3">shrkbot · Moderation group config — stacked states — DARK</p>
+    <div data-pane-slot></div>
+  </div>
+</section>
+
+<script>
+// Clone the light pane's content into the dark pane so both stay identical.
+(function(){
+  var src = document.querySelector('[data-pane-content]');
+  var slot = document.querySelector('[data-pane-slot]');
+  if(!src || !slot) return;
+  var clone = src.cloneNode(true);
+  clone.removeAttribute('data-pane-content');
+  // de-duplicate anchor ids and re-point in-page links in the clone
+  clone.querySelectorAll('[id]').forEach(function(el){ el.id = el.id + '-dark'; });
+  clone.querySelectorAll('a[href^="#"]').forEach(function(a){ var h = a.getAttribute('href'); if(h.length > 1) a.setAttribute('href', h + '-dark'); });
+  slot.appendChild(clone);
+})();
+</script>
+</body>
+</html>

--- a/docs/web-debug-harness.md
+++ b/docs/web-debug-harness.md
@@ -1,0 +1,76 @@
+# Web debug harness
+
+Boots the website with **stubbed Discord auth** and a **seeded fixture guild**, so the
+UI can be driven by a real browser (manually or via Playwright) without OAuth or a live
+bot. Built for debugging client-side behaviour — Turbo submissions, Stimulus
+controllers, dialogs — that request specs can't see.
+
+## Boot
+
+```sh
+bin/web-debug          # serves on 127.0.0.1:3123 (PORT overrides)
+```
+
+Everything is gated behind `WEB_DEBUG=1` **and** `Rails.env.development?`
+(`config/initializers/web_debug.rb`) — the initializer is inert in test and
+production. On boot it:
+
+- puts OmniAuth in test mode with a mock Discord identity (uid `12345`),
+- stubs `Discord::UserGuilds.call` to return one fixture guild
+  (`Dev Refuge`, id `900000001`, owner),
+- idempotently seeds that guild: server configuration, the four plugin rows +
+  activations (all disabled), settings rows, a `Moderator` role (id 500) and a
+  `#mod-log` channel (id 111).
+
+The seed never toggles state back — flip things in the UI or via `bin/rails runner`.
+
+## Log in inside the browser
+
+Visit `/auth/discord/callback` once (OmniAuth test mode completes the session), then
+`/servers/900000001` to authorize the guild for the session. From there every page
+works as a signed-in owner.
+
+## Driving with Playwright
+
+Playwright is not a project dependency — install it in a scratch directory:
+
+```sh
+mkdir -p /tmp/pw && cd /tmp/pw
+npm install playwright
+npx playwright install chromium
+```
+
+Minimal script (`node drive.mjs`):
+
+```js
+import { chromium } from "playwright"
+
+const BASE = "http://127.0.0.1:3123"
+const browser = await chromium.launch()
+const page = await browser.newPage()
+page.on("dialog", async (d) => { console.log("DIALOG", d.type(), d.message()); await d.accept() })
+page.on("pageerror", (e) => console.log("PAGEERROR", e.message))
+page.on("response", (r) => { if (r.status() >= 400) console.log(r.status(), r.url()) })
+
+await page.goto(`${BASE}/auth/discord/callback`)
+await page.goto(`${BASE}/servers/900000001`)
+await page.goto(`${BASE}/servers/900000001/moderation`)
+// interact + assert…
+await browser.close()
+```
+
+Useful listeners when hunting Turbo/Stimulus bugs: `dialog` (beforeunload prompts mean
+a NATIVE form submission slipped past Turbo), `pageerror` (a Stimulus controller
+exception often degrades silently), and `response` for 4xx/5xx that Turbo swallows.
+
+Toggles use `sr-only` checkboxes — click them with `{ force: true }` or click the
+wrapping label.
+
+## Resetting state
+
+```sh
+WEB_DEBUG=1 bin/rails runner 'ServerConfiguration.find_by(discord_id: 900_000_001)&.destroy!'
+```
+
+Next boot reseeds from scratch (the guild purge cascade removes everything hanging off
+the configuration).

--- a/spec/components/icon_spec.rb
+++ b/spec/components/icon_spec.rb
@@ -45,4 +45,30 @@ RSpec.describe Components::Icon do
       expect { svg }.to raise_error(PhosphorIcons::IconNotFoundError)
     end
   end
+
+  context "with a custom glyph name" do
+    let(:name) { "megaphone-slash" }
+
+    it "renders an svg without raising IconNotFoundError" do
+      expect { svg }.not_to raise_error
+      expect(svg).to include("<svg").and include("viewBox=\"0 0 256 256\"")
+    end
+
+    it "applies the default size class" do
+      expect(svg).to include("size-5")
+    end
+
+    context "with a provided class" do
+      let(:options) { {class: "size-8 text-danger"} }
+
+      it "spreads options onto the svg tag" do
+        expect(svg).to include("size-8").and include("text-danger")
+      end
+    end
+
+    it "delegates real Phosphor names normally" do
+      real_svg = described_class.new("sun").call
+      expect(real_svg).to eq(PhosphorIcons::Icon.new("sun", style: :regular, class: "size-5").to_svg)
+    end
+  end
 end

--- a/spec/components/moderation/config_shell_spec.rb
+++ b/spec/components/moderation/config_shell_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::Moderation::ConfigShell do
+  include_context "component view context"
+
+  let(:config) { create(:server_configuration, discord_id: 900_000_001, name: "Dev Refuge") }
+  let(:header) do
+    Components::ConfigPageHeader.new(
+      icon: "shield",
+      title: "Server Shield",
+      description: "Your server's aegis."
+    )
+  end
+  let(:base_toggle) { {field: "moderation[enabled]", enabled: true, locked: false} }
+
+  subject(:html) do
+    described_class.new(
+      header:,
+      server_configuration: config,
+      url: "/servers/900000001/moderation",
+      toggle: base_toggle
+    ).render_in(view_context) { "" }
+  end
+
+  it "renders the page header with the title" do
+    expect(html).to include("Server Shield")
+  end
+
+  it "renders the form with PATCH method and save-bar wiring" do
+    expect(html).to include("save-bar")
+    expect(html).to include("input-&gt;save-bar#check").or include("input->save-bar#check")
+    expect(html).to include("turbo:submit-end-&gt;save-bar#saved").or include("turbo:submit-end->save-bar#saved")
+  end
+
+  it "renders the breadcrumb with the server name" do
+    expect(html).to include("Dev Refuge")
+    expect(html).to include("Server Shield")
+  end
+
+  context "when gate is nil" do
+    it "yields the body without any gate overlay" do
+      html = described_class.new(
+        header:,
+        server_configuration: config,
+        url: "/servers/900000001/moderation",
+        toggle: base_toggle
+      ).render_in(view_context) { "<p>body content</p>" }
+      expect(html).to include("body content")
+      expect(html).not_to include("enable-gate")
+    end
+  end
+
+  context "when gate type is :prereq" do
+    subject(:html) do
+      described_class.new(
+        header:,
+        server_configuration: config,
+        url: "/servers/900000001/moderation",
+        toggle: {field: "moderation[enabled]", enabled: false, locked: true, reason: "Enable Logging first."},
+        gate: {
+          type: :prereq,
+          icon: "scroll",
+          title: "Needs Logging",
+          message: "Set up Logging first.",
+          cta_label: "Set up Logging",
+          cta_href: "/servers/900000001/logging"
+        }
+      ).render_in(view_context) { "" }
+    end
+
+    it "renders the PrereqGate with the CTA link" do
+      expect(html).to include("Needs Logging")
+      expect(html).to include("Set up Logging")
+      expect(html).to include("/servers/900000001/logging")
+    end
+  end
+
+  context "when gate type is :enable" do
+    subject(:html) do
+      described_class.new(
+        header:,
+        server_configuration: config,
+        url: "/servers/900000001/moderation",
+        toggle: {field: "moderation[enabled]", enabled: false, locked: false},
+        gate: {
+          type: :enable,
+          message: "Enable the group to configure sub-plugins."
+        }
+      ).render_in(view_context) { "" }
+    end
+
+    it "renders the EnableGate overlay" do
+      expect(html).to include("Enable Server Shield")
+    end
+
+    it "wires the form to enable-gate" do
+      expect(html).to include("enable-gate")
+    end
+  end
+
+  context "when toggle is locked" do
+    subject(:html) do
+      described_class.new(
+        header:,
+        server_configuration: config,
+        url: "/servers/900000001/moderation",
+        toggle: {
+          field: "moderation[enabled]",
+          enabled: false,
+          locked: true,
+          reason: "Enable the Logging plugin first."
+        }
+      ).render_in(view_context) { "" }
+    end
+
+    it "renders the toggle as disabled" do
+      expect(html).to include("disabled")
+    end
+
+    it "wraps the toggle in a Tooltip with the reason" do
+      expect(html).to include("Enable the Logging plugin first.")
+    end
+  end
+end

--- a/spec/components/moderation/config_shell_spec.rb
+++ b/spec/components/moderation/config_shell_spec.rb
@@ -123,4 +123,69 @@ RSpec.describe Components::Moderation::ConfigShell do
       expect(html).to include("Enable the Logging plugin first.")
     end
   end
+
+  context "when toggle is locked and currently enabled" do
+    subject(:html) do
+      described_class.new(
+        header:,
+        server_configuration: config,
+        url: "/servers/900000001/moderation",
+        toggle: {
+          field: "moderation[enabled]",
+          enabled: true,
+          locked: true,
+          reason: "Cannot disable while sub-plugins are active."
+        }
+      ).render_in(view_context) { "" }
+    end
+
+    it "shows the enabled label text" do
+      expect(html).to include("Enabled")
+    end
+
+    it "renders the toggle as disabled" do
+      expect(html).to include("disabled")
+    end
+  end
+
+  context "when header has a badge" do
+    subject(:html) do
+      header_with_badge = Components::ConfigPageHeader.new(
+        icon: "shield",
+        title: "Server Shield",
+        description: "Your server's aegis.",
+        badge: "Beta"
+      )
+      described_class.new(
+        header: header_with_badge,
+        server_configuration: config,
+        url: "/servers/900000001/moderation",
+        toggle: base_toggle
+      ).render_in(view_context) { "" }
+    end
+
+    it "renders the badge text" do
+      expect(html).to include("Beta")
+    end
+  end
+
+  context "with a breadcrumb_extra" do
+    subject(:html) do
+      described_class.new(
+        header:,
+        server_configuration: config,
+        url: "/servers/900000001/moderation",
+        toggle: base_toggle,
+        breadcrumb_extra: "Spam Protection"
+      ).render_in(view_context) { "" }
+    end
+
+    it "renders the extra breadcrumb label" do
+      expect(html).to include("Spam Protection")
+    end
+
+    it "links the Server Shield breadcrumb to the moderation overview path" do
+      expect(html).to include("/servers/900000001/moderation")
+    end
+  end
 end

--- a/spec/components/moderation/image_scanning_form_spec.rb
+++ b/spec/components/moderation/image_scanning_form_spec.rb
@@ -75,6 +75,11 @@ RSpec.describe Components::Moderation::ImageScanningForm do
     expect(html).to include("Nothing is stored.")
   end
 
+  it "renders the explainer with dropdown-menu class and menu target" do
+    expect(html).to include("dropdown-menu")
+    expect(html).to include('data-dropdown-target="menu"')
+  end
+
   it "renders the report-as-scam hint" do
     expect(html).to include("Report as scam")
   end

--- a/spec/components/moderation/image_scanning_form_spec.rb
+++ b/spec/components/moderation/image_scanning_form_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe Components::Moderation::ImageScanningForm do
 
   subject(:html) do
     described_class.new(
-      server_configuration: config,
       context:
     ).render_in(view_context)
   end
@@ -83,7 +82,6 @@ RSpec.describe Components::Moderation::ImageScanningForm do
   context "with an enable_error" do
     subject(:html) do
       described_class.new(
-        server_configuration: config,
         context:,
         enable_error: "A staff role is required."
       ).render_in(view_context)
@@ -105,7 +103,6 @@ RSpec.describe Components::Moderation::ImageScanningForm do
 
     subject(:html) do
       described_class.new(
-        server_configuration: config,
         context:
       ).render_in(view_context)
     end

--- a/spec/components/moderation/image_scanning_form_spec.rb
+++ b/spec/components/moderation/image_scanning_form_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::Moderation::ImageScanningForm do
+  include_context "component view context"
+
+  let(:config) { create(:server_configuration, discord_id: 900_000_001) }
+  let(:settings) { create(:image_scanning_settings, server_configuration: config) }
+  let(:context) do
+    instance_double(
+      Moderation::SubPluginContext,
+      settings:,
+      plugin_enabled?: true,
+      group_enabled?: true,
+      staff_role_present?: true
+    )
+  end
+
+  subject(:html) do
+    described_class.new(
+      server_configuration: config,
+      context:
+    ).render_in(view_context)
+  end
+
+  it "renders the wrapping div with the correct id" do
+    expect(html).to include('id="image_scanning-config"')
+  end
+
+  it "renders the consent callout" do
+    expect(html).to include("Before you turn this on")
+  end
+
+  it "renders the sensitivity radio card group with correct field name" do
+    expect(html).to include('name="image_scanning[sensitivity]"')
+  end
+
+  it "renders all three sensitivity options" do
+    expect(html).to include("Relaxed")
+    expect(html).to include("Standard")
+    expect(html).to include("Strict")
+  end
+
+  it "renders the custom keywords select with correct field name" do
+    expect(html).to include('name="image_scanning[custom_keywords][]"')
+  end
+
+  it "wires the custom keywords select for free-tag creation" do
+    expect(html).to include("tom-select-create-value")
+  end
+
+  it "renders the min_hits stepper with correct field name" do
+    expect(html).to include('name="image_scanning[custom_keyword_min_hits]"')
+  end
+
+  it "renders the action segmented control with correct field name" do
+    expect(html).to include('name="image_scanning[action]"')
+  end
+
+  it "renders Delete the image and Flag only options" do
+    expect(html).to include("Delete the image")
+    expect(html).to include("Flag only")
+  end
+
+  it "renders the punishment control with correct field name" do
+    expect(html).to include('name="image_scanning[punishment]"')
+  end
+
+  it "renders the timeout_seconds duration select" do
+    expect(html).to include('name="image_scanning[timeout_seconds]"')
+  end
+
+  it "renders the image scanning explainer" do
+    expect(html).to include("How image scanning works")
+    expect(html).to include("Nothing is stored.")
+  end
+
+  it "renders the report-as-scam hint" do
+    expect(html).to include("Report as scam")
+  end
+
+  context "with an enable_error" do
+    subject(:html) do
+      described_class.new(
+        server_configuration: config,
+        context:,
+        enable_error: "A staff role is required."
+      ).render_in(view_context)
+    end
+
+    it "renders the error callout" do
+      expect(html).to include("A staff role is required.")
+    end
+  end
+end

--- a/spec/components/moderation/image_scanning_form_spec.rb
+++ b/spec/components/moderation/image_scanning_form_spec.rb
@@ -93,4 +93,31 @@ RSpec.describe Components::Moderation::ImageScanningForm do
       expect(html).to include("A staff role is required.")
     end
   end
+
+  context "when the settings have custom keywords" do
+    let(:settings) do
+      create(
+        :image_scanning_settings,
+        server_configuration: config,
+        custom_keywords: ["free nitro", "click link"]
+      )
+    end
+
+    subject(:html) do
+      described_class.new(
+        server_configuration: config,
+        context:
+      ).render_in(view_context)
+    end
+
+    it "renders the keywords as option values in the select" do
+      expect(html).to include("free nitro")
+      expect(html).to include("click link")
+    end
+
+    it "caps the min_hits stepper at the keyword count" do
+      expect(html).to include('name="image_scanning[custom_keyword_min_hits]"')
+      expect(html).to include('max="2"')
+    end
+  end
 end

--- a/spec/components/moderation/overview_form_spec.rb
+++ b/spec/components/moderation/overview_form_spec.rb
@@ -31,6 +31,11 @@ RSpec.describe Components::Moderation::OverviewForm do
     expect(html).not_to include("Something went wrong enabling.")
   end
 
+  it "renders the matching explainer with dropdown-menu class and menu target" do
+    expect(html).to include("dropdown-menu")
+    expect(html).to include('data-dropdown-target="menu"')
+  end
+
   context "with an enable_error" do
     subject(:html) do
       described_class.new(

--- a/spec/components/moderation/overview_form_spec.rb
+++ b/spec/components/moderation/overview_form_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::Moderation::OverviewForm do
+  include_context "component view context"
+
+  let(:config) { create(:server_configuration, discord_id: 900_000_001) }
+  let(:context) do
+    instance_double(
+      Moderation::OverviewContext,
+      staff_role_id: nil,
+      staff_role_present?: false,
+      permission_warning?: false,
+      sub_plugin_rows: []
+    )
+  end
+
+  subject(:html) do
+    described_class.new(
+      server_configuration: config,
+      context:
+    ).render_in(view_context)
+  end
+
+  it "renders the staff role card" do
+    expect(html).to include("moderation[staff_role_id]")
+  end
+
+  it "renders no enable_error callout by default" do
+    expect(html).not_to include("Something went wrong enabling.")
+  end
+
+  context "with an enable_error" do
+    subject(:html) do
+      described_class.new(
+        server_configuration: config,
+        context:,
+        enable_error: "Something went wrong enabling."
+      ).render_in(view_context)
+    end
+
+    it "renders the error callout" do
+      expect(html).to include("Something went wrong enabling.")
+    end
+  end
+end

--- a/spec/components/moderation/punishment_control_spec.rb
+++ b/spec/components/moderation/punishment_control_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::Moderation::PunishmentControl do
+  include_context "component view context"
+
+  subject(:html) do
+    described_class.new(
+      name: "spam_protection[punishment]",
+      value: "none",
+      timeout_seconds: 3600
+    ).render_in(view_context)
+  end
+
+  it "renders the punishment segmented control with None/Time out/Kick/Ban options" do
+    expect(html).to include("None")
+    expect(html).to include("Time out")
+    expect(html).to include("Kick")
+    expect(html).to include("Ban")
+  end
+
+  it "renders the hidden punishment input with the correct name" do
+    expect(html).to include('name="spam_protection[punishment]"')
+  end
+
+  it "wires the Stimulus punishment controller" do
+    expect(html).to include('data-controller="punishment"')
+  end
+
+  it "renders the duration select with the derived timeout_seconds field name" do
+    expect(html).to include('name="spam_protection[timeout_seconds]"')
+  end
+
+  it "renders the duration block hidden when value is not timeout" do
+    expect(html).to include('data-punishment-target="duration"')
+    expect(html).to include("hidden")
+  end
+
+  it "renders the ban warning block hidden when value is not ban" do
+    expect(html).to include('data-punishment-target="banWarning"')
+  end
+
+  it "renders the ban warning copy" do
+    expect(html).to include("A ban is permanent")
+  end
+
+  context "when value is timeout" do
+    subject(:html) do
+      described_class.new(
+        name: "spam_protection[punishment]",
+        value: "timeout",
+        timeout_seconds: 3600
+      ).render_in(view_context)
+    end
+
+    it "does not hide the duration block" do
+      expect(html).not_to include('data-punishment-target="duration" hidden')
+    end
+  end
+
+  context "when used for image scanning" do
+    subject(:html) do
+      described_class.new(
+        name: "image_scanning[punishment]",
+        value: "none",
+        timeout_seconds: 3600
+      ).render_in(view_context)
+    end
+
+    it "uses the correct timeout field name for the sub-plugin" do
+      expect(html).to include('name="image_scanning[timeout_seconds]"')
+    end
+  end
+end

--- a/spec/components/moderation/spam_protection_form_spec.rb
+++ b/spec/components/moderation/spam_protection_form_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::Moderation::SpamProtectionForm do
+  include_context "component view context"
+
+  let(:config) { create(:server_configuration, discord_id: 900_000_001) }
+  let(:settings) { create(:spam_protection_settings, server_configuration: config) }
+  let(:context) do
+    instance_double(
+      Moderation::SubPluginContext,
+      settings:,
+      plugin_enabled?: true,
+      group_enabled?: true,
+      staff_role_present?: true
+    )
+  end
+
+  subject(:html) do
+    described_class.new(
+      server_configuration: config,
+      context:
+    ).render_in(view_context)
+  end
+
+  it "renders the wrapping div with the correct id" do
+    expect(html).to include('id="spam_protection-config"')
+  end
+
+  it "renders the channel threshold stepper with correct field name" do
+    expect(html).to include('name="spam_protection[channel_threshold]"')
+  end
+
+  it "renders the window seconds stepper with correct field name" do
+    expect(html).to include('name="spam_protection[window_seconds]"')
+  end
+
+  it "renders the similarity range slider with correct field name" do
+    expect(html).to include('name="spam_protection[similarity]"')
+  end
+
+  it "renders the symbol-only toggle with correct field name" do
+    expect(html).to include('name="spam_protection[match_symbol_only_messages]"')
+  end
+
+  it "renders the action segmented control with correct field name" do
+    expect(html).to include('name="spam_protection[action]"')
+  end
+
+  it "renders the purge and notify-only options" do
+    expect(html).to include("Purge the messages")
+    expect(html).to include("Notify only")
+  end
+
+  it "renders the punishment control with correct field name" do
+    expect(html).to include('name="spam_protection[punishment]"')
+  end
+
+  it "renders the timeout_seconds duration select" do
+    expect(html).to include('name="spam_protection[timeout_seconds]"')
+  end
+
+  it "renders the ban warning block" do
+    expect(html).to include("A ban is permanent")
+  end
+
+  it "renders no enable_error callout by default" do
+    expect(html).not_to include("A staff role is required.")
+  end
+
+  context "with an enable_error" do
+    subject(:html) do
+      described_class.new(
+        server_configuration: config,
+        context:,
+        enable_error: "A staff role is required."
+      ).render_in(view_context)
+    end
+
+    it "renders the error callout" do
+      expect(html).to include("A staff role is required.")
+    end
+  end
+end

--- a/spec/components/moderation/spam_protection_form_spec.rb
+++ b/spec/components/moderation/spam_protection_form_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe Components::Moderation::SpamProtectionForm do
 
   subject(:html) do
     described_class.new(
-      server_configuration: config,
       context:
     ).render_in(view_context)
   end
@@ -72,7 +71,6 @@ RSpec.describe Components::Moderation::SpamProtectionForm do
   context "with an enable_error" do
     subject(:html) do
       described_class.new(
-        server_configuration: config,
         context:,
         enable_error: "A staff role is required."
       ).render_in(view_context)

--- a/spec/components/moderation/staff_role_card_spec.rb
+++ b/spec/components/moderation/staff_role_card_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::Moderation::StaffRoleCard do
+  include_context "component view context"
+
+  let(:config) { create(:server_configuration, discord_id: 900_000_001) }
+  let(:role) { create(:server_role, server_configuration: config, discord_id: 501, name: "Moderators", color: 0) }
+
+  before { role }
+
+  subject(:html) do
+    described_class.new(
+      server_configuration: config,
+      staff_role_id: nil,
+      missing: false,
+      permission_warning: false
+    ).render_in(view_context)
+  end
+
+  it "renders the staff role select with correct field name" do
+    expect(html).to include('name="moderation[staff_role_id]"')
+  end
+
+  it "renders the role name as an option" do
+    expect(html).to include("Moderators")
+  end
+
+  it "uses the default colour for a zero-colour role" do
+    expect(html).to include("#99aab5")
+  end
+
+  context "when the role has a colour" do
+    let(:role) { create(:server_role, server_configuration: config, discord_id: 501, name: "Moderators", color: 0xE67E22) }
+
+    it "renders the role colour as a hex dot" do
+      expect(html).to include("#e67e22")
+    end
+  end
+
+  context "when the role is missing" do
+    subject(:html) do
+      described_class.new(
+        server_configuration: config,
+        staff_role_id: 999,
+        missing: true,
+        permission_warning: false
+      ).render_in(view_context)
+    end
+
+    it "renders the missing warning" do
+      expect(html).to include("Required. Every sub-plugin stays off")
+    end
+
+    it "does not render the normal help text" do
+      expect(html).not_to include("Shared by every Moderation sub-plugin")
+    end
+  end
+
+  context "when there is a permission warning" do
+    subject(:html) do
+      described_class.new(
+        server_configuration: config,
+        staff_role_id: 501,
+        missing: false,
+        permission_warning: true
+      ).render_in(view_context)
+    end
+
+    it "renders the permission warning bold text" do
+      expect(html).to include("Staff pings will fail.")
+    end
+
+    it "renders the permission warning body" do
+      expect(html).to include("Mention All Roles")
+    end
+  end
+end

--- a/spec/components/moderation/sub_plugin_row_spec.rb
+++ b/spec/components/moderation/sub_plugin_row_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::Moderation::SubPluginRow do
+  include_context "component view context"
+
+  let(:config) { create(:server_configuration, discord_id: 900_000_001) }
+  let(:spam_settings) { create(:spam_protection_settings, server_configuration: config) }
+
+  let(:base_attrs) do
+    {
+      server_id: config.discord_id,
+      key: :spam_protection,
+      name: "Cross-Channel Spam Guard",
+      description: "Purges the same message posted across several channels within seconds.",
+      enabled: true,
+      configured: true,
+      settings: spam_settings,
+      group_enabled: true
+    }
+  end
+
+  subject(:html) { described_class.new(**base_attrs).render_in(view_context) }
+
+  context "when enabled and configured" do
+    it "renders the Enabled badge" do
+      expect(html).to include("Enabled")
+    end
+
+    it "renders the Configure link to the sub-plugin path" do
+      expect(html).to include("spam_protection")
+      expect(html).to include("Configure")
+    end
+
+    it "renders a mini-form posting to the sub-plugin path" do
+      expect(html).to include("spam_protection")
+      expect(html).to include("method")
+    end
+
+    it "includes hidden settings fields to preserve current values" do
+      expect(html).to include('name="spam_protection[channel_threshold]"')
+      expect(html).to include('name="spam_protection[window_seconds]"')
+      expect(html).to include('name="spam_protection[similarity]"')
+      expect(html).to include('name="spam_protection[action]"')
+      expect(html).to include('name="spam_protection[punishment]"')
+      expect(html).to include('name="spam_protection[timeout_seconds]"')
+    end
+  end
+
+  context "when needs setup (not configured, group enabled)" do
+    subject(:html) do
+      described_class.new(**base_attrs.merge(enabled: false, configured: false)).render_in(view_context)
+    end
+
+    it "renders the Needs setup badge" do
+      expect(html).to include("Needs setup")
+    end
+
+    it "renders an inline warning hint" do
+      expect(html).to include("Pick a staff role first.")
+    end
+
+    it "renders the toggle as disabled" do
+      expect(html).to include("disabled")
+    end
+
+    it "still renders the Configure link" do
+      expect(html).to include("Configure")
+    end
+  end
+
+  context "for image_scanning with custom keywords" do
+    let(:image_settings) { create(:image_scanning_settings, server_configuration: config) }
+
+    subject(:html) do
+      described_class.new(
+        server_id: config.discord_id,
+        key: :image_scanning,
+        name: "Scam Image Detection",
+        description: "Reads the text in images and fingerprints known scam images.",
+        enabled: true,
+        configured: true,
+        settings: image_settings,
+        group_enabled: true
+      ).render_in(view_context)
+    end
+
+    it "includes hidden fields for image scanning settings" do
+      expect(html).to include('name="image_scanning[sensitivity]"')
+      expect(html).to include('name="image_scanning[action]"')
+      expect(html).to include('name="image_scanning[punishment]"')
+    end
+  end
+end

--- a/spec/components/moderation/sub_plugin_row_spec.rb
+++ b/spec/components/moderation/sub_plugin_row_spec.rb
@@ -33,9 +33,16 @@ RSpec.describe Components::Moderation::SubPluginRow do
       expect(html).to include("Configure")
     end
 
-    it "renders a mini-form posting to the sub-plugin path" do
-      expect(html).to include("spam_protection")
-      expect(html).to include("method")
+    it "does not render an inline form tag" do
+      expect(html).not_to include("<form")
+    end
+
+    it "hidden fields carry the stub form id" do
+      expect(html).to include('form="spam_protection-overview-toggle-form"')
+    end
+
+    it "includes a from_overview hidden field" do
+      expect(html).to include('name="from_overview"')
     end
 
     it "includes hidden settings fields to preserve current values" do
@@ -97,6 +104,18 @@ RSpec.describe Components::Moderation::SubPluginRow do
     it "links the Configure button to the image_scanning path" do
       expect(html).to include("image_scanning")
       expect(html).to include("Configure")
+    end
+
+    it "does not render an inline form tag" do
+      expect(html).not_to include("<form")
+    end
+
+    it "hidden fields carry the image_scanning stub form id" do
+      expect(html).to include('form="image_scanning-overview-toggle-form"')
+    end
+
+    it "includes a from_overview hidden field" do
+      expect(html).to include('name="from_overview"')
     end
   end
 
@@ -163,7 +182,7 @@ RSpec.describe Components::Moderation::SubPluginRow do
       expect(html).to include("Disabled")
     end
 
-    it "renders a form with hidden settings fields (not locked)" do
+    it "renders hidden settings fields (not locked)" do
       expect(html).to include('name="spam_protection[channel_threshold]"')
     end
 

--- a/spec/components/moderation/sub_plugin_row_spec.rb
+++ b/spec/components/moderation/sub_plugin_row_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Components::Moderation::SubPluginRow do
     end
   end
 
-  context "for image_scanning with custom keywords" do
+  context "for image_scanning when enabled and configured" do
     let(:image_settings) { create(:image_scanning_settings, server_configuration: config) }
 
     subject(:html) do
@@ -90,6 +90,106 @@ RSpec.describe Components::Moderation::SubPluginRow do
       expect(html).to include('name="image_scanning[sensitivity]"')
       expect(html).to include('name="image_scanning[action]"')
       expect(html).to include('name="image_scanning[punishment]"')
+      expect(html).to include('name="image_scanning[timeout_seconds]"')
+      expect(html).to include('name="image_scanning[custom_keyword_min_hits]"')
+    end
+
+    it "links the Configure button to the image_scanning path" do
+      expect(html).to include("image_scanning")
+      expect(html).to include("Configure")
+    end
+  end
+
+  context "for image_scanning with custom keywords" do
+    let(:image_settings) do
+      create(:image_scanning_settings, server_configuration: config, custom_keywords: ["free nitro", "click here"])
+    end
+
+    subject(:html) do
+      described_class.new(
+        server_id: config.discord_id,
+        key: :image_scanning,
+        name: "Scam Image Detection",
+        description: "Reads the text in images and fingerprints known scam images.",
+        enabled: true,
+        configured: true,
+        settings: image_settings,
+        group_enabled: true
+      ).render_in(view_context)
+    end
+
+    it "renders each keyword as a hidden field" do
+      expect(html).to include('name="image_scanning[custom_keywords][]"')
+      expect(html).to include('value="free nitro"')
+      expect(html).to include('value="click here"')
+    end
+  end
+
+  context "for image_scanning when needs setup (not configured, group enabled)" do
+    let(:image_settings) { create(:image_scanning_settings, server_configuration: config) }
+
+    subject(:html) do
+      described_class.new(
+        server_id: config.discord_id,
+        key: :image_scanning,
+        name: "Scam Image Detection",
+        description: "Reads the text in images and fingerprints known scam images.",
+        enabled: false,
+        configured: false,
+        settings: image_settings,
+        group_enabled: true
+      ).render_in(view_context)
+    end
+
+    it "renders the Needs setup badge" do
+      expect(html).to include("Needs setup")
+    end
+
+    it "renders the inline warning hint" do
+      expect(html).to include("Pick a staff role first.")
+    end
+
+    it "renders the toggle as disabled" do
+      expect(html).to include("disabled")
+    end
+  end
+
+  context "for spam_protection when disabled but configured" do
+    subject(:html) do
+      described_class.new(**base_attrs.merge(enabled: false, configured: true)).render_in(view_context)
+    end
+
+    it "renders the Disabled badge" do
+      expect(html).to include("Disabled")
+    end
+
+    it "renders a form with hidden settings fields (not locked)" do
+      expect(html).to include('name="spam_protection[channel_threshold]"')
+    end
+
+    it "does not render the needs-setup warning" do
+      expect(html).not_to include("Pick a staff role first.")
+    end
+  end
+
+  context "when settings is nil (no settings record yet)" do
+    subject(:html) do
+      described_class.new(**base_attrs.merge(enabled: false, configured: true, settings: nil)).render_in(view_context)
+    end
+
+    it "renders without hidden fields" do
+      expect(html).not_to include('name="spam_protection[channel_threshold]"')
+    end
+  end
+
+  context "when spam_protection settings have match_symbol_only_messages true" do
+    before { spam_settings.update!(match_symbol_only_messages: true) }
+
+    subject(:html) { described_class.new(**base_attrs).render_in(view_context) }
+
+    it "renders the match_symbol_only_messages field with value 1" do
+      expect(html).to include('name="spam_protection[match_symbol_only_messages]"')
+      expect(html).to include('value="1"')
     end
   end
 end

--- a/spec/components/number_stepper_spec.rb
+++ b/spec/components/number_stepper_spec.rb
@@ -3,7 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Components::NumberStepper do
-  subject(:html) { described_class.new(**options).call }
+  include_context "component view context"
+
+  subject(:html) { described_class.new(**options).render_in(view_context) }
 
   let(:options) { {name: "spam_protection[channel_threshold]", value: 4, min: 2, default: 4, unit: "channels"} }
 

--- a/spec/components/number_stepper_spec.rb
+++ b/spec/components/number_stepper_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::NumberStepper do
+  subject(:html) { described_class.new(**options).call }
+
+  let(:options) { {name: "spam_protection[channel_threshold]", value: 4, min: 2, default: 4, unit: "channels"} }
+
+  it "renders a number input with the correct name and value" do
+    expect(html).to include('name="spam_protection[channel_threshold]"')
+    expect(html).to include('value="4"')
+    expect(html).to include('type="number"')
+  end
+
+  it "sets the min attribute on the input" do
+    expect(html).to include('min="2"')
+  end
+
+  it "renders minus and plus buttons wired to the controller" do
+    expect(html).to include("click->number-stepper#decrement")
+    expect(html).to include("click->number-stepper#increment")
+  end
+
+  it "marks the input as the controller target" do
+    expect(html).to include('data-number-stepper-target="input"')
+  end
+
+  it "shows the recommended default subscript" do
+    expect(html).to include("Recommended default: 4")
+  end
+
+  it "renders the unit label when provided" do
+    expect(html).to include("channels")
+  end
+
+  context "when max is provided" do
+    let(:options) { {name: "image_scanning[custom_keyword_min_hits]", value: 1, min: 1, default: 2, max: 5} }
+
+    it "sets the max attribute and data value on the controller wrapper" do
+      expect(html).to include('max="5"')
+      expect(html).to include("data-number-stepper-max-value")
+    end
+  end
+
+  context "when max is omitted" do
+    it "omits the max attribute and max data value" do
+      expect(html).not_to include("max=")
+      expect(html).not_to include("data-number-stepper-max-value")
+    end
+  end
+end

--- a/spec/components/plugin_sidebar_spec.rb
+++ b/spec/components/plugin_sidebar_spec.rb
@@ -26,4 +26,82 @@ RSpec.describe Components::PluginSidebar do
       expect(html).to include("Dashboard")
     end
   end
+
+  context "with the moderation group" do
+    let(:name) { "Dev Refuge" }
+
+    it "renders Server Shield as a disclosure group with its sub-plugin links" do
+      expect(html).to include("Server Shield")
+      expect(html).to include("Overview")
+      expect(html).to include("Cross-Channel Spam Guard")
+      expect(html).to include("Scam Image Detection")
+      expect(html).to include("/servers/900000001/spam_protection")
+      expect(html).to include("/servers/900000001/image_scanning")
+    end
+
+    context "when a sub-plugin page is active" do
+      subject(:html) do
+        described_class.new(server_configuration: config, active_key: :image_scanning).render_in(view_context)
+      end
+
+      it "auto-expands the group" do
+        expect(html).to include("<details open")
+      end
+    end
+
+    context "when a sub-plugin is configured but disabled (disabled status)" do
+      let!(:spam_plugin) { create(:plugin, key: "spam_protection", name: "Cross-Channel Spam Guard") }
+      let!(:moderation_plugin) { create(:plugin, key: "moderation", name: "Server Shield") }
+      let!(:logging_plugin) { create(:plugin, key: "logging", name: "Logging") }
+
+      before do
+        config.create_logging_setting!(channel_id: 111)
+        config.create_moderation_settings!(staff_role_id: 555)
+        config.create_spam_protection_settings!
+        config.create_image_scanning_settings!
+        # logging enabled so moderation prereqs pass; spam_protection activation NOT enabled
+        create(:plugin_activation, server_configuration: config, plugin: logging_plugin, enabled: false)
+          .update_column(:enabled, true)
+        create(:plugin_activation, server_configuration: config, plugin: moderation_plugin, enabled: false)
+          .update_column(:enabled, true)
+        # spam_protection activation exists and is disabled — configured but not enabled
+        create(:plugin_activation, server_configuration: config, plugin: spam_plugin, enabled: false)
+      end
+
+      subject(:html) do
+        described_class.new(server_configuration: config, active_key: :moderation).render_in(view_context)
+      end
+
+      it "renders the sidebar without raising" do
+        expect(html).to include("Cross-Channel Spam Guard")
+      end
+    end
+
+    context "when a sub-plugin is enabled (enabled status)" do
+      let!(:spam_plugin) { create(:plugin, key: "spam_protection", name: "Cross-Channel Spam Guard") }
+      let!(:moderation_plugin) { create(:plugin, key: "moderation", name: "Server Shield") }
+      let!(:logging_plugin) { create(:plugin, key: "logging", name: "Logging") }
+
+      before do
+        config.create_logging_setting!(channel_id: 111)
+        config.create_moderation_settings!(staff_role_id: 555)
+        config.create_spam_protection_settings!
+        config.create_image_scanning_settings!
+        create(:plugin_activation, server_configuration: config, plugin: logging_plugin, enabled: false)
+          .update_column(:enabled, true)
+        create(:plugin_activation, server_configuration: config, plugin: moderation_plugin, enabled: false)
+          .update_column(:enabled, true)
+        create(:plugin_activation, server_configuration: config, plugin: spam_plugin, enabled: false)
+          .update_column(:enabled, true)
+      end
+
+      subject(:html) do
+        described_class.new(server_configuration: config, active_key: :moderation).render_in(view_context)
+      end
+
+      it "renders the sidebar with the enabled sub-plugin" do
+        expect(html).to include("Cross-Channel Spam Guard")
+      end
+    end
+  end
 end

--- a/spec/components/prereq_gate_spec.rb
+++ b/spec/components/prereq_gate_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::PrereqGate do
+  subject(:html) do
+    described_class.new(**options).call { "body-content" }
+  end
+
+  let(:options) do
+    {
+      title: "Logging required",
+      message: "Set up Logging before enabling this.",
+      cta_label: "Set up Logging",
+      cta_href: "/servers/123/logging"
+    }
+  end
+
+  it "renders the reason title and message" do
+    expect(html).to include("Logging required").and include("Set up Logging before enabling this.")
+  end
+
+  it "renders a CTA linking to cta_href" do
+    expect(html).to include("/servers/123/logging").and include("Set up Logging")
+  end
+
+  it "renders the CTA as a secondary button with a trailing arrow icon" do
+    arrow_svg = PhosphorIcons::Icon.new("arrow-right", style: :regular, class: "size-4").to_svg
+    expect(html).to include(arrow_svg)
+  end
+
+  it "renders the body content as inert" do
+    expect(html).to include("body-content").and include("inert")
+  end
+
+  it "renders the body at reduced opacity" do
+    expect(html).to include("opacity-45")
+  end
+
+  it "renders no enable button" do
+    expect(html).not_to include("enable-gate#enable")
+  end
+
+  context "with a custom icon" do
+    let(:options) do
+      {
+        title: "Shield required",
+        message: "Enable Server Shield first.",
+        cta_label: "Open Server Shield",
+        cta_href: "/servers/123/moderation",
+        icon: "shield"
+      }
+    end
+
+    it "uses the specified icon" do
+      shield_svg = PhosphorIcons::Icon.new("shield", style: :regular, class: "mx-auto block size-5 text-text-muted").to_svg
+      expect(html).to include(shield_svg)
+    end
+  end
+end

--- a/spec/components/radio_card_group_spec.rb
+++ b/spec/components/radio_card_group_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::RadioCardGroup do
+  subject(:html) { described_class.new(**options).call }
+
+  let(:options) do
+    {
+      name: "image_scanning[sensitivity]",
+      value: "standard",
+      options: [
+        {value: "relaxed", title: "Relaxed", description: "Catches only the most obvious scams."},
+        {value: "standard", title: "Standard", description: "Balanced detection for most servers."},
+        {value: "strict", title: "Strict", description: "Maximises catch rate; more false positives."}
+      ]
+    }
+  end
+
+  it "renders all option titles and descriptions" do
+    expect(html).to include("Relaxed").and include("Standard").and include("Strict")
+    expect(html).to include("Catches only the most obvious scams.")
+    expect(html).to include("Balanced detection for most servers.")
+    expect(html).to include("Maximises catch rate; more false positives.")
+  end
+
+  it "marks the selected option checked" do
+    expect(html).to include('value="standard"').and include("checked")
+  end
+
+  it "does not mark unselected options checked" do
+    doc = Nokogiri::HTML5.fragment(html)
+    checked_inputs = doc.css("input[type=radio][checked]")
+    expect(checked_inputs.size).to eq(1)
+    expect(checked_inputs.first["value"]).to eq("standard")
+  end
+
+  it "gives all inputs the same name" do
+    doc = Nokogiri::HTML5.fragment(html)
+    names = doc.css("input[type=radio]").map { |i| i["name"] }.uniq
+    expect(names).to eq(["image_scanning[sensitivity]"])
+  end
+
+  it "renders a radiogroup wrapper" do
+    expect(html).to include('role="radiogroup"')
+  end
+
+  context "with a label" do
+    let(:options) do
+      super().merge(label: "Detection sensitivity")
+    end
+
+    it "sets aria-label on the wrapper" do
+      expect(html).to include("Detection sensitivity")
+    end
+  end
+
+  context "with the first option selected" do
+    let(:options) { super().merge(value: "relaxed") }
+
+    it "checks the first option only" do
+      doc = Nokogiri::HTML5.fragment(html)
+      checked = doc.css("input[type=radio][checked]")
+      expect(checked.size).to eq(1)
+      expect(checked.first["value"]).to eq("relaxed")
+    end
+  end
+end

--- a/spec/components/range_slider_spec.rb
+++ b/spec/components/range_slider_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::RangeSlider do
+  subject(:html) { described_class.new(**options).call }
+
+  let(:options) { {name: "spam_protection[similarity]", value: 0.85} }
+
+  it "renders a hidden input with the stored float value and correct name" do
+    expect(html).to include('type="hidden"')
+    expect(html).to include('name="spam_protection[similarity]"')
+    expect(html).to include('value="0.85"')
+  end
+
+  it "marks the hidden input as a controller target" do
+    expect(html).to include('data-range-slider-target="hidden"')
+  end
+
+  it "renders a range input without a name (display only)" do
+    expect(html).to include('type="range"')
+    range_input = html[/<input[^>]*type="range"[^>]*>/, 0]
+    expect(range_input).not_to include("name=")
+  end
+
+  it "converts the stored float to a percent value on the range input" do
+    expect(html).to include('value="85"')
+  end
+
+  it "marks the range input as a controller target and wires the update action" do
+    expect(html).to include('data-range-slider-target="range"')
+    expect(html).to include("input->range-slider#update")
+  end
+
+  it "renders the readout target showing the initial percent" do
+    expect(html).to include('data-range-slider-target="readout"')
+    expect(html).to include("85%")
+  end
+
+  it "renders endpoint captions" do
+    expect(html).to include("loosely similar")
+    expect(html).to include("identical")
+  end
+
+  context "with value 0.75 (minimum)" do
+    let(:options) { {name: "spam_protection[similarity]", value: 0.75} }
+
+    it "shows 75 on the range and 0.75 on the hidden field" do
+      expect(html).to include('value="75"')
+      expect(html).to include('value="0.75"')
+    end
+  end
+
+  context "with value 1.0 (maximum)" do
+    let(:options) { {name: "spam_protection[similarity]", value: 1.0} }
+
+    it "shows 100 on the range and 1.0 on the hidden field" do
+      expect(html).to include('value="100"')
+      expect(html).to include('value="1.0"')
+    end
+  end
+end

--- a/spec/components/range_slider_spec.rb
+++ b/spec/components/range_slider_spec.rb
@@ -5,7 +5,15 @@ require "rails_helper"
 RSpec.describe Components::RangeSlider do
   subject(:html) { described_class.new(**options).call }
 
-  let(:options) { {name: "spam_protection[similarity]", value: 0.85} }
+  let(:base_options) do
+    {
+      name: "spam_protection[similarity]",
+      label: "Match strictness",
+      min_caption: "loosely similar",
+      max_caption: "identical"
+    }
+  end
+  let(:options) { base_options.merge(value: 0.85) }
 
   it "renders a hidden input with the stored float value and correct name" do
     expect(html).to include('type="hidden"')
@@ -37,13 +45,14 @@ RSpec.describe Components::RangeSlider do
     expect(html).to include("85%")
   end
 
-  it "renders endpoint captions" do
+  it "renders the endpoint captions and aria label it was given" do
     expect(html).to include("loosely similar")
     expect(html).to include("identical")
+    expect(html).to include('aria-label="Match strictness"')
   end
 
   context "with value 0.75 (minimum)" do
-    let(:options) { {name: "spam_protection[similarity]", value: 0.75} }
+    let(:options) { base_options.merge(value: 0.75) }
 
     it "shows 75 on the range and 0.75 on the hidden field" do
       expect(html).to include('value="75"')
@@ -52,7 +61,7 @@ RSpec.describe Components::RangeSlider do
   end
 
   context "with value 1.0 (maximum)" do
-    let(:options) { {name: "spam_protection[similarity]", value: 1.0} }
+    let(:options) { base_options.merge(value: 1.0) }
 
     it "shows 100 on the range and 1.0 on the hidden field" do
       expect(html).to include('value="100"')

--- a/spec/components/sidebar_group_spec.rb
+++ b/spec/components/sidebar_group_spec.rb
@@ -74,4 +74,36 @@ RSpec.describe Components::SidebarGroup do
       expect(details_tag).not_to include(" open")
     end
   end
+
+  describe "parent tile tinting" do
+    let(:inactive_items) do
+      items.map { |item| item.merge(active: false) }
+    end
+
+    context "when the group plugin is enabled" do
+      let(:options) do
+        {label: "Server Shield", icon: "shield", open: false, items: inactive_items, storage_key: "k", enabled: true}
+      end
+
+      it "renders the accent tile" do
+        expect(html).to include("bg-accent-fill")
+      end
+    end
+
+    context "when disabled with no active child" do
+      let(:options) do
+        {label: "Server Shield", icon: "shield", open: false, items: inactive_items, storage_key: "k"}
+      end
+
+      it "renders the muted tile" do
+        expect(html).not_to include("bg-accent-fill")
+      end
+    end
+
+    context "when disabled but a child page is active" do
+      it "renders the accent tile" do
+        expect(html).to include("bg-accent-fill")
+      end
+    end
+  end
 end

--- a/spec/components/sidebar_group_spec.rb
+++ b/spec/components/sidebar_group_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::SidebarGroup do
+  include_context "component view context"
+
+  subject(:html) do
+    described_class.new(**options).render_in(view_context)
+  end
+
+  let(:items) do
+    [
+      {label: "Overview", href: "/servers/1/moderation", active: false, status: nil},
+      {label: "Cross-Channel Spam Guard", href: "/servers/1/spam_protection", active: true, status: :enabled},
+      {label: "Scam Image Detection", href: "/servers/1/image_scanning", active: false, status: :needs_setup}
+    ]
+  end
+
+  let(:options) do
+    {label: "Server Shield", icon: "shield", open: false, items:, storage_key: "sidebar-group-moderation"}
+  end
+
+  it "renders the group parent label" do
+    expect(html).to include("Server Shield")
+  end
+
+  it "renders a chevron that rotates when the group is open" do
+    expect(html).to include("group-open/details:rotate-90")
+  end
+
+  it "wires the disclosure controller with the storage key" do
+    expect(html).to include('data-controller="disclosure"')
+    expect(html).to include('data-disclosure-key-value="sidebar-group-moderation"')
+  end
+
+  it "renders sub-items as links with their hrefs" do
+    expect(html).to include('href="/servers/1/moderation"')
+    expect(html).to include('href="/servers/1/spam_protection"')
+    expect(html).to include('href="/servers/1/image_scanning"')
+  end
+
+  it "marks the active sub-item with aria-current" do
+    expect(html).to include('aria-current="page"')
+    expect(html).to include("Cross-Channel Spam Guard")
+  end
+
+  it "applies the active wash class to the active sub-item link" do
+    expect(html).to include("bg-accent-soft")
+  end
+
+  it "renders status dots for items that have a status" do
+    expect(html).to include("bg-success")
+    expect(html).to include("bg-warning")
+  end
+
+  it "does not render a status dot for the Overview item (status nil)" do
+    overview_section = html[%r{href="/servers/1/moderation"[^>]*>.*?</a>}m, 0]
+    expect(overview_section).not_to include("rounded-full") if overview_section
+  end
+
+  context "when open is true (active child)" do
+    let(:options) { {label: "Server Shield", icon: "shield", open: true, items:, storage_key: "sidebar-group-moderation"} }
+
+    it "renders the details element as open" do
+      expect(html).to include("<details")
+      expect(html).to include("open")
+    end
+  end
+
+  context "when open is false" do
+    it "renders the details element without the open attribute" do
+      details_tag = html[/<details[^>]*>/, 0]
+      expect(details_tag).not_to include(" open")
+    end
+  end
+end

--- a/spec/components/toggle_spec.rb
+++ b/spec/components/toggle_spec.rb
@@ -44,4 +44,21 @@ RSpec.describe Components::Toggle do
       expect(html).not_to include("w-11")
     end
   end
+
+  context "with a form: attribute set" do
+    subject(:html) { Components::Toggle.new(name: "foo[enabled]", checked: false, label: "Toggle foo", form: "some-form").call }
+
+    it "renders form=\"some-form\" on both the hidden input and the checkbox" do
+      expect(html).to include('type="hidden"').and include('form="some-form"')
+      expect(html).to include('type="checkbox"').and include('form="some-form"')
+    end
+  end
+
+  context "without a form: attribute" do
+    subject(:html) { Components::Toggle.new(name: "foo[enabled]", checked: false, label: "Toggle foo").call }
+
+    it "renders no form attribute" do
+      expect(html).not_to include("form=")
+    end
+  end
 end

--- a/spec/models/plugin_catalog_spec.rb
+++ b/spec/models/plugin_catalog_spec.rb
@@ -25,6 +25,30 @@ RSpec.describe PluginCatalog do
     end
   end
 
+  describe ".sub_plugin?" do
+    it "returns true for :spam_protection" do
+      expect(described_class.sub_plugin?(:spam_protection)).to be(true)
+    end
+
+    it "returns true for :image_scanning" do
+      expect(described_class.sub_plugin?(:image_scanning)).to be(true)
+    end
+
+    it "returns false for :moderation" do
+      expect(described_class.sub_plugin?(:moderation)).to be(false)
+    end
+
+    it "returns false for :roles" do
+      expect(described_class.sub_plugin?(:roles)).to be(false)
+    end
+  end
+
+  describe ".sub_plugin_keys" do
+    it "returns [:spam_protection, :image_scanning] for :moderation" do
+      expect(described_class.sub_plugin_keys(:moderation)).to eq([:spam_protection, :image_scanning])
+    end
+  end
+
   describe "moderation group wiring" do
     it "spam_protection has parent :moderation" do
       expect(described_class.find(:spam_protection).parent).to eq(:moderation)

--- a/spec/models/plugin_catalog_spec.rb
+++ b/spec/models/plugin_catalog_spec.rb
@@ -115,5 +115,113 @@ RSpec.describe PluginCatalog do
         it { is_expected.to be(true) }
       end
     end
+
+    context "when a prerequisite predicate is set" do
+      def definition_with_predicate(predicate)
+        described_class.new(key: :x, name: "X", description: "", prerequisite: predicate)
+      end
+
+      subject(:check) { definition_with_predicate(predicate).prerequisites_met?(config) }
+
+      context "when predicate returns false" do
+        let(:predicate) { ->(_c) { false } }
+        let(:config) { double }
+
+        it { is_expected.to be(false) }
+      end
+
+      context "when predicate returns true" do
+        let(:predicate) { ->(_c) { true } }
+        let(:config) { double }
+
+        it { is_expected.to be(true) }
+      end
+    end
+  end
+
+  describe "moderation prerequisite predicates" do
+    let(:enabled_scope) { double }
+
+    before do
+      allow(enabled_scope).to receive(:exists?).and_return(true)
+    end
+
+    describe ":moderation prerequisite" do
+      subject(:check) { PluginCatalog.find(:moderation).prerequisites_met?(config) }
+
+      context "when logging enabled but no logging channel" do
+        let(:config) do
+          double(
+            plugins: double(enabled: enabled_scope),
+            logging_setting: double(channel_id: nil)
+          )
+        end
+
+        it { is_expected.to be(false) }
+      end
+
+      context "when logging enabled with a logging channel" do
+        let(:config) do
+          double(
+            plugins: double(enabled: enabled_scope),
+            logging_setting: double(channel_id: 999)
+          )
+        end
+
+        it { is_expected.to be(true) }
+      end
+    end
+
+    describe ":spam_protection prerequisite" do
+      subject(:check) { PluginCatalog.find(:spam_protection).prerequisites_met?(config) }
+
+      context "when group enabled but no staff role" do
+        let(:config) do
+          double(
+            plugins: double(enabled: enabled_scope),
+            moderation_settings: double(staff_role_id: nil)
+          )
+        end
+
+        it { is_expected.to be(false) }
+      end
+
+      context "when group enabled with staff role" do
+        let(:config) do
+          double(
+            plugins: double(enabled: enabled_scope),
+            moderation_settings: double(staff_role_id: 123)
+          )
+        end
+
+        it { is_expected.to be(true) }
+      end
+    end
+
+    describe ":image_scanning prerequisite" do
+      subject(:check) { PluginCatalog.find(:image_scanning).prerequisites_met?(config) }
+
+      context "when group enabled but no staff role" do
+        let(:config) do
+          double(
+            plugins: double(enabled: enabled_scope),
+            moderation_settings: double(staff_role_id: nil)
+          )
+        end
+
+        it { is_expected.to be(false) }
+      end
+
+      context "when group enabled with staff role" do
+        let(:config) do
+          double(
+            plugins: double(enabled: enabled_scope),
+            moderation_settings: double(staff_role_id: 456)
+          )
+        end
+
+        it { is_expected.to be(true) }
+      end
+    end
   end
 end

--- a/spec/models/plugin_catalog_spec.rb
+++ b/spec/models/plugin_catalog_spec.rb
@@ -139,6 +139,124 @@ RSpec.describe PluginCatalog do
     end
   end
 
+  describe "moderation prerequisite lambdas with real ServerConfiguration" do
+    let(:config) { create(:server_configuration, discord_id: 900_000_001) }
+    let!(:logging_plugin) { create(:plugin, key: "logging", name: "Logging") }
+    let!(:moderation_plugin) { create(:plugin, key: "moderation", name: "Server Shield") }
+
+    before do
+      config.create_logging_setting!
+      config.create_moderation_settings!
+      config.create_spam_protection_settings!
+      config.create_image_scanning_settings!
+    end
+
+    describe ":moderation prerequisite lambda" do
+      subject(:check) { PluginCatalog.find(:moderation).prerequisites_met?(config) }
+
+      context "when logging is enabled and channel is set" do
+        before do
+          config.logging_setting.update!(channel_id: 111)
+          create(:plugin_activation, server_configuration: config, plugin: logging_plugin, enabled: false)
+            .update_column(:enabled, true)
+        end
+
+        it { is_expected.to be(true) }
+      end
+
+      context "when logging is enabled but no channel is set" do
+        before do
+          create(:plugin_activation, server_configuration: config, plugin: logging_plugin, enabled: false)
+            .update_column(:enabled, true)
+        end
+
+        it { is_expected.to be(false) }
+      end
+
+      context "when logging is enabled but logging_setting is absent" do
+        before do
+          config.logging_setting.destroy!
+          create(:plugin_activation, server_configuration: config, plugin: logging_plugin, enabled: false)
+            .update_column(:enabled, true)
+        end
+
+        subject(:check) { PluginCatalog.find(:moderation).prerequisites_met?(config.reload) }
+
+        it { is_expected.to be(false) }
+      end
+    end
+
+    describe ":spam_protection prerequisite lambda" do
+      subject(:check) { PluginCatalog.find(:spam_protection).prerequisites_met?(config) }
+
+      context "when moderation is enabled and staff_role_id is set" do
+        before do
+          create(:plugin_activation, server_configuration: config, plugin: moderation_plugin, enabled: false)
+            .update_column(:enabled, true)
+          config.moderation_settings.update!(staff_role_id: 500)
+        end
+
+        it { is_expected.to be(true) }
+      end
+
+      context "when moderation is enabled but no staff_role_id" do
+        before do
+          create(:plugin_activation, server_configuration: config, plugin: moderation_plugin, enabled: false)
+            .update_column(:enabled, true)
+        end
+
+        it { is_expected.to be(false) }
+      end
+
+      context "when moderation is enabled but moderation_settings is absent" do
+        before do
+          config.moderation_settings.destroy!
+          create(:plugin_activation, server_configuration: config, plugin: moderation_plugin, enabled: false)
+            .update_column(:enabled, true)
+        end
+
+        subject(:check) { PluginCatalog.find(:spam_protection).prerequisites_met?(config.reload) }
+
+        it { is_expected.to be(false) }
+      end
+    end
+
+    describe ":image_scanning prerequisite lambda" do
+      subject(:check) { PluginCatalog.find(:image_scanning).prerequisites_met?(config) }
+
+      context "when moderation is enabled and staff_role_id is set" do
+        before do
+          create(:plugin_activation, server_configuration: config, plugin: moderation_plugin, enabled: false)
+            .update_column(:enabled, true)
+          config.moderation_settings.update!(staff_role_id: 501)
+        end
+
+        it { is_expected.to be(true) }
+      end
+
+      context "when moderation is enabled but no staff_role_id" do
+        before do
+          create(:plugin_activation, server_configuration: config, plugin: moderation_plugin, enabled: false)
+            .update_column(:enabled, true)
+        end
+
+        it { is_expected.to be(false) }
+      end
+
+      context "when moderation is enabled but moderation_settings is absent" do
+        before do
+          config.moderation_settings.destroy!
+          create(:plugin_activation, server_configuration: config, plugin: moderation_plugin, enabled: false)
+            .update_column(:enabled, true)
+        end
+
+        subject(:check) { PluginCatalog.find(:image_scanning).prerequisites_met?(config.reload) }
+
+        it { is_expected.to be(false) }
+      end
+    end
+  end
+
   describe "moderation prerequisite predicates" do
     let(:enabled_scope) { double }
 

--- a/spec/operations/moderation/configure_spec.rb
+++ b/spec/operations/moderation/configure_spec.rb
@@ -96,4 +96,58 @@ RSpec.describe Ops::Moderation::Configure do
       expect(config.plugin_activations.find_by(plugin:)&.enabled).to be_falsey
     end
   end
+
+  context "when clearing staff_role_id while a sub-plugin is enabled" do
+    let(:staff_role_id) { nil }
+    let(:enabled) { "0" }
+    let!(:spam_plugin) { create(:plugin, key: "spam_protection", name: "Cross-Channel Spam Guard") }
+
+    before do
+      create(:plugin_activation, server_configuration: config, plugin: spam_plugin, enabled: false).update_column(:enabled, true)
+    end
+
+    it "fails with an error on staff_role_id" do
+      expect(result).to be_failure
+      expect(result.value.errors[:staff_role_id]).to be_present
+    end
+
+    it "does not save the cleared staff_role_id" do
+      settings.update!(staff_role_id: 111_222_333)
+      result
+      expect(config.moderation_settings.reload.staff_role_id).to eq(111_222_333)
+    end
+  end
+
+  context "when clearing staff_role_id with no sub-plugin enabled" do
+    let(:staff_role_id) { nil }
+    let(:enabled) { "0" }
+
+    it "succeeds" do
+      expect(result).to be_success
+    end
+
+    it "clears the staff_role_id" do
+      settings.update!(staff_role_id: 111_222_333)
+      result
+      expect(config.moderation_settings.reload.staff_role_id).to be_nil
+    end
+  end
+
+  context "when setting a staff_role_id while a sub-plugin is enabled" do
+    let(:enabled) { "0" }
+    let!(:spam_plugin) { create(:plugin, key: "spam_protection", name: "Cross-Channel Spam Guard") }
+
+    before do
+      create(:plugin_activation, server_configuration: config, plugin: spam_plugin, enabled: false).update_column(:enabled, true)
+    end
+
+    it "succeeds" do
+      expect(result).to be_success
+    end
+
+    it "saves the staff_role_id" do
+      result
+      expect(config.moderation_settings.reload.staff_role_id).to eq(111_222_333)
+    end
+  end
 end

--- a/spec/operations/moderation/image_scanning/configure_spec.rb
+++ b/spec/operations/moderation/image_scanning/configure_spec.rb
@@ -102,6 +102,18 @@ RSpec.describe Ops::Moderation::ImageScanning::Configure do
     end
   end
 
+  context "with a blank custom keyword entry from an empty multiselect" do
+    let(:enabled) { "0" }
+    let(:custom_keywords) { [""] }
+
+    before { setup_moderation_group_enabled }
+
+    it "normalizes the blank entry away and succeeds" do
+      expect(result).to be_success
+      expect(config.image_scanning_settings.reload.custom_keywords).to eq([])
+    end
+  end
+
   context "when saving settings without enabling" do
     let(:enabled) { "0" }
     let(:custom_keywords) { %w[scam free] }

--- a/spec/plugins/moderation/events/spam_guard_spec.rb
+++ b/spec/plugins/moderation/events/spam_guard_spec.rb
@@ -275,11 +275,11 @@ RSpec.describe Moderation::SpamGuard do
       allow(Discord::Components).to receive(:send_to)
     end
 
-    it "notifies without a staff-role ping" do
+    it "notifies with nil in the roles array (seam guard prevents this in production)" do
       expect(Discord::Components).to receive(:send_to).with(
         log_channel,
         anything,
-        allowed_mentions: {parse: [], roles: []}
+        allowed_mentions: {parse: [], roles: [nil]}
       )
 
       simulate_message(channel_id: 1, message_id: 1)

--- a/spec/plugins/moderation/image_scanning/settings_spec.rb
+++ b/spec/plugins/moderation/image_scanning/settings_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe Moderation::ImageScanning::Settings do
         server.create_logging_setting!(channel_id: 999)
         create(:plugin_activation, server_configuration: server, plugin: logging_plugin, enabled: true)
         create(:plugin_activation, server_configuration: server, plugin: moderation_plugin, enabled: true)
-        create(:plugin_activation, server_configuration: server, plugin: scan_plugin, enabled: true)
+        create(:plugin_activation, server_configuration: server, plugin: scan_plugin, enabled: false).update_column(:enabled, true)
       end
 
       it "returns the image scanning settings" do

--- a/spec/plugins/moderation/spam_protection/settings_spec.rb
+++ b/spec/plugins/moderation/spam_protection/settings_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Moderation::SpamProtection::Settings do
         server.create_logging_setting!(channel_id: 999)
         create(:plugin_activation, server_configuration: server, plugin: logging_plugin, enabled: true)
         create(:plugin_activation, server_configuration: server, plugin: moderation_plugin, enabled: true)
-        create(:plugin_activation, server_configuration: server, plugin: spam_plugin, enabled: true)
+        create(:plugin_activation, server_configuration: server, plugin: spam_plugin, enabled: false).update_column(:enabled, true)
       end
 
       it "returns the spam protection settings" do

--- a/spec/plugins/moderation/staff_ping_spec.rb
+++ b/spec/plugins/moderation/staff_ping_spec.rb
@@ -12,12 +12,4 @@ RSpec.describe Moderation::StaffPing do
       expect(prefix).to eq("<@&123> ")
     end
   end
-
-  context "without a staff role id" do
-    let(:staff_role_id) { nil }
-
-    it "renders an empty string" do
-      expect(prefix).to eq("")
-    end
-  end
 end

--- a/spec/presenters/moderation/overview_context_spec.rb
+++ b/spec/presenters/moderation/overview_context_spec.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Moderation::OverviewContext do
+  let(:config) { create(:server_configuration, discord_id: 900_000_001) }
+  let!(:logging_plugin) { create(:plugin, key: "logging", name: "Logging") }
+  let!(:moderation_plugin) { create(:plugin, key: "moderation", name: "Server Shield") }
+
+  before do
+    config.create_logging_setting!
+    config.create_moderation_settings!
+    config.create_spam_protection_settings!
+    config.create_image_scanning_settings!
+  end
+
+  subject(:context) { described_class.new(config) }
+
+  describe "#logging_ready?" do
+    context "when logging plugin is enabled and channel is set" do
+      before do
+        config.logging_setting.update!(channel_id: 111)
+        create(:plugin_activation, server_configuration: config, plugin: logging_plugin, enabled: false)
+          .update_column(:enabled, true)
+      end
+
+      it { expect(context.logging_ready?).to be(true) }
+    end
+
+    context "when logging plugin is enabled but no channel" do
+      before do
+        create(:plugin_activation, server_configuration: config, plugin: logging_plugin, enabled: false)
+          .update_column(:enabled, true)
+      end
+
+      it { expect(context.logging_ready?).to be(false) }
+    end
+
+    context "when logging plugin is not enabled" do
+      it { expect(context.logging_ready?).to be(false) }
+    end
+
+    context "when logging plugin is enabled but logging_setting has no channel_id" do
+      before do
+        config.logging_setting.update!(channel_id: nil)
+        create(:plugin_activation, server_configuration: config, plugin: logging_plugin, enabled: false)
+          .update_column(:enabled, true)
+      end
+
+      it { expect(context.logging_ready?).to be(false) }
+    end
+
+    context "when logging plugin is enabled but logging_setting is absent" do
+      before do
+        config.logging_setting.destroy!
+        create(:plugin_activation, server_configuration: config, plugin: logging_plugin, enabled: false)
+          .update_column(:enabled, true)
+      end
+
+      it { expect(described_class.new(config.reload).logging_ready?).to be(false) }
+    end
+  end
+
+  describe "#staff_role_id" do
+    context "when staff_role_id is set" do
+      before { config.moderation_settings.update!(staff_role_id: 555) }
+
+      it "returns the staff role id" do
+        expect(context.staff_role_id).to eq(555)
+      end
+    end
+
+    context "when no staff_role_id is set" do
+      it "returns nil" do
+        expect(context.staff_role_id).to be_nil
+      end
+    end
+
+    context "when moderation_settings does not exist" do
+      before { config.moderation_settings.destroy! }
+
+      it "returns nil" do
+        expect(described_class.new(config.reload).staff_role_id).to be_nil
+      end
+    end
+  end
+
+  describe "#staff_role_present?" do
+    context "when staff_role_id is set" do
+      before { config.moderation_settings.update!(staff_role_id: 555) }
+
+      it { expect(context.staff_role_present?).to be(true) }
+    end
+
+    context "when no staff_role_id" do
+      it { expect(context.staff_role_present?).to be(false) }
+    end
+  end
+
+  describe "#group_enabled?" do
+    context "when moderation plugin activation is enabled" do
+      before do
+        create(:plugin_activation, server_configuration: config, plugin: moderation_plugin, enabled: false)
+          .update_column(:enabled, true)
+      end
+
+      it { expect(context.group_enabled?).to be(true) }
+    end
+
+    context "when moderation plugin is not activated" do
+      it { expect(context.group_enabled?).to be(false) }
+    end
+  end
+
+  describe "#logging_channel_name" do
+    context "when logging_setting is absent" do
+      before { config.logging_setting.destroy! }
+
+      it "returns nil" do
+        expect(described_class.new(config.reload).logging_channel_name).to be_nil
+      end
+    end
+
+    context "when logging_setting has no channel_id" do
+      it "returns nil" do
+        expect(context.logging_channel_name).to be_nil
+      end
+    end
+
+    context "when logging_setting has a channel_id but no matching server_channel" do
+      before { config.logging_setting.update!(channel_id: 777) }
+
+      it "returns nil" do
+        expect(context.logging_channel_name).to be_nil
+      end
+    end
+
+    context "when logging_setting has a channel_id with a matching server_channel" do
+      before do
+        config.logging_setting.update!(channel_id: 888)
+        create(:server_channel, server_configuration: config, discord_id: 888, name: "mod-log")
+      end
+
+      it "returns the channel name" do
+        expect(context.logging_channel_name).to eq("mod-log")
+      end
+    end
+  end
+
+  describe "#sub_plugin_rows" do
+    it "returns two rows for spam_protection and image_scanning" do
+      rows = context.sub_plugin_rows
+      expect(rows.map(&:key)).to contain_exactly(:spam_protection, :image_scanning)
+    end
+  end
+end

--- a/spec/presenters/moderation/sub_plugin_context_spec.rb
+++ b/spec/presenters/moderation/sub_plugin_context_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Moderation::SubPluginContext do
+  let(:config) { create(:server_configuration, discord_id: 900_000_001) }
+  let!(:moderation_plugin) { create(:plugin, key: "moderation", name: "Server Shield") }
+
+  before do
+    config.create_moderation_settings!
+    config.create_spam_protection_settings!
+    config.create_image_scanning_settings!
+  end
+
+  describe "#staff_role_present?" do
+    context "when staff_role_id is set" do
+      before { config.moderation_settings.update!(staff_role_id: 555) }
+
+      subject(:ctx) { described_class.new(config, :spam_protection) }
+
+      it { expect(ctx.staff_role_present?).to be(true) }
+    end
+
+    context "when no staff_role_id" do
+      subject(:ctx) { described_class.new(config, :spam_protection) }
+
+      it { expect(ctx.staff_role_present?).to be(false) }
+    end
+
+    context "when moderation_settings does not exist" do
+      before { config.moderation_settings.destroy! }
+
+      subject(:ctx) { described_class.new(config.reload, :spam_protection) }
+
+      it { expect(ctx.staff_role_present?).to be(false) }
+    end
+  end
+
+  describe "#settings" do
+    context "when plugin_key is :spam_protection" do
+      subject(:ctx) { described_class.new(config, :spam_protection) }
+
+      it "returns the spam_protection_settings" do
+        expect(ctx.settings).to eq(config.spam_protection_settings)
+      end
+    end
+
+    context "when plugin_key is :image_scanning" do
+      subject(:ctx) { described_class.new(config, :image_scanning) }
+
+      it "returns the image_scanning_settings" do
+        expect(ctx.settings).to eq(config.image_scanning_settings)
+      end
+    end
+  end
+
+  describe "#group_enabled?" do
+    subject(:ctx) { described_class.new(config, :spam_protection) }
+
+    context "when moderation plugin activation is enabled" do
+      before do
+        create(:plugin_activation, server_configuration: config, plugin: moderation_plugin, enabled: false)
+          .update_column(:enabled, true)
+      end
+
+      it { expect(ctx.group_enabled?).to be(true) }
+    end
+
+    context "when moderation plugin is not activated" do
+      it { expect(ctx.group_enabled?).to be(false) }
+    end
+  end
+
+  describe "#plugin_enabled?" do
+    let!(:spam_plugin) { create(:plugin, key: "spam_protection", name: "Cross-Channel Spam Guard") }
+
+    subject(:ctx) { described_class.new(config, :spam_protection) }
+
+    context "when the plugin activation is enabled" do
+      before do
+        create(:plugin_activation, server_configuration: config, plugin: spam_plugin, enabled: false)
+          .update_column(:enabled, true)
+      end
+
+      it { expect(ctx.plugin_enabled?).to be(true) }
+    end
+
+    context "when the plugin has no activation" do
+      it { expect(ctx.plugin_enabled?).to be(false) }
+    end
+  end
+end

--- a/spec/requests/image_scanning_config_spec.rb
+++ b/spec/requests/image_scanning_config_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Image scanning config", type: :request do
+  include_context "discord auth"
+
+  let(:guild) { Discord::Guild.new(id: 900_000_001, name: "Dev Refuge", owner: true, permissions: 0, icon: nil, member_count: 5) }
+  let(:config) { ServerConfiguration.find_by(discord_id: guild.id) }
+  let(:turbo) { {headers: {"Accept" => "text/vnd.turbo-stream.html"}} }
+
+  context "when signed out" do
+    it "redirects to the sign-in page" do
+      get server_image_scanning_path(900_000_001)
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  context "when signed in" do
+    let!(:moderation_plugin) { create(:plugin, key: "moderation", name: "Server Shield") }
+    let!(:image_plugin) { create(:plugin, key: "image_scanning", name: "Scam Image Detection") }
+
+    before do
+      post "/auth/discord/callback"
+      create(:server_configuration, discord_id: guild.id)
+      config.create_moderation_settings!
+      config.create_spam_protection_settings!
+      config.create_image_scanning_settings!
+      allow(Discord::UserGuilds).to receive(:call).and_return([guild])
+    end
+
+    context "without proving the server is manageable this session" do
+      it "redirects to the picker" do
+        get server_image_scanning_path(guild.id)
+        expect(response).to redirect_to(servers_path)
+      end
+    end
+
+    context "after loading the dashboard authorizes the server" do
+      before { get server_path(guild.id) }
+
+      describe "GET /servers/:server_id/image_scanning" do
+        context "when group is enabled and staff role is present" do
+          before do
+            create(:plugin_activation, server_configuration: config, plugin: moderation_plugin, enabled: false)
+              .update_column(:enabled, true)
+            config.moderation_settings.update!(staff_role_id: 500)
+            create(:server_role, server_configuration: config, discord_id: 500, name: "Moderator")
+          end
+
+          it "returns 200 and renders the page" do
+            get server_image_scanning_path(guild.id)
+            expect(response).to have_http_status(:ok)
+            expect(response.body).to include("Scam Image Detection")
+          end
+
+          it "renders the sensitivity options and consent callout" do
+            get server_image_scanning_path(guild.id)
+            expect(response.body).to include("Before you turn this on")
+            expect(response.body).to include("Relaxed")
+            expect(response.body).to include("Standard")
+            expect(response.body).to include("Strict")
+          end
+
+          it "renders the report-as-scam hint" do
+            get server_image_scanning_path(guild.id)
+            expect(response.body).to include("Report as scam")
+          end
+        end
+
+        context "when group is disabled" do
+          it "returns 200 and renders the prereq gate" do
+            get server_image_scanning_path(guild.id)
+            expect(response).to have_http_status(:ok)
+            expect(response.body).to include("Server Shield group is disabled")
+            expect(response.body).to include("Open Server Shield overview")
+          end
+        end
+
+        context "when group is enabled but no staff role set" do
+          before do
+            create(:plugin_activation, server_configuration: config, plugin: moderation_plugin, enabled: false)
+              .update_column(:enabled, true)
+          end
+
+          it "returns 200 with locked toggle and warning callout" do
+            get server_image_scanning_path(guild.id)
+            expect(response).to have_http_status(:ok)
+            expect(response.body).to include("Pick a staff role first.")
+            expect(response.body).not_to include("Server Shield group is disabled")
+          end
+        end
+      end
+
+      describe "PATCH /servers/:server_id/image_scanning" do
+        before do
+          create(:plugin_activation, server_configuration: config, plugin: moderation_plugin, enabled: false)
+            .update_column(:enabled, true)
+          config.moderation_settings.update!(staff_role_id: 500)
+        end
+
+        it "saves settings and returns turbo stream on success" do
+          patch server_image_scanning_path(guild.id),
+            params: {image_scanning: {sensitivity: "standard", action: "delete",
+                                      punishment: "none", timeout_seconds: 3600, custom_keyword_min_hits: 2,
+                                      custom_keywords: [], enabled: "0"}},
+            **turbo
+          expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+          expect(response.body).to include("image_scanning-config")
+          expect(response.body).to include("saved")
+        end
+
+        it "returns 422 when enabling with no staff role" do
+          config.moderation_settings.update!(staff_role_id: nil)
+          create(:plugin_activation, server_configuration: config, plugin: image_plugin, enabled: false)
+
+          patch server_image_scanning_path(guild.id),
+            params: {image_scanning: {sensitivity: "standard", action: "delete",
+                                      punishment: "none", timeout_seconds: 3600, custom_keyword_min_hits: 2,
+                                      custom_keywords: [], enabled: "1"}},
+            **turbo
+          expect(response).to have_http_status(:unprocessable_content)
+        end
+
+        it "falls back to a redirect without Turbo" do
+          patch server_image_scanning_path(guild.id),
+            params: {image_scanning: {sensitivity: "standard", action: "delete",
+                                      punishment: "none", timeout_seconds: 3600, custom_keyword_min_hits: 2,
+                                      custom_keywords: [], enabled: "0"}}
+          expect(response).to redirect_to(server_image_scanning_path(guild.id))
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/image_scanning_config_spec.rb
+++ b/spec/requests/image_scanning_config_spec.rb
@@ -129,6 +129,21 @@ RSpec.describe "Image scanning config", type: :request do
                                       custom_keywords: [], enabled: "0"}}
           expect(response).to redirect_to(server_image_scanning_path(guild.id))
         end
+
+        context "when toggled from the overview" do
+          subject(:patch_from_overview) do
+            patch server_image_scanning_path(guild.id),
+              params: {image_scanning: {sensitivity: "standard", action: "delete",
+                                        punishment: "none", timeout_seconds: 3600, custom_keyword_min_hits: 2,
+                                        custom_keywords: [], enabled: "0"},
+                       from_overview: "1"}
+          end
+
+          it "redirects to the moderation overview" do
+            patch_from_overview
+            expect(response).to redirect_to(server_moderation_path(guild.id))
+          end
+        end
       end
     end
   end

--- a/spec/requests/image_scanning_config_spec.rb
+++ b/spec/requests/image_scanning_config_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe "Image scanning config", type: :request do
                                       custom_keywords: [], enabled: "0"}},
             **turbo
           expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+          expect(response.body).to include('target="plugin-sidebar"')
           expect(response.body).to include("image_scanning-config")
           expect(response.body).to include("saved")
         end

--- a/spec/requests/moderation_config_spec.rb
+++ b/spec/requests/moderation_config_spec.rb
@@ -142,6 +142,7 @@ RSpec.describe "Moderation config", type: :request do
             **turbo
           expect(response).to have_http_status(:unprocessable_content)
           expect(config.moderation_settings.reload.staff_role_id).to eq(500)
+          expect(response.body).to include("A staff role is required while a sub-plugin is enabled.")
         end
 
         it "falls back to a redirect without Turbo" do

--- a/spec/requests/moderation_config_spec.rb
+++ b/spec/requests/moderation_config_spec.rb
@@ -71,6 +71,12 @@ RSpec.describe "Moderation config", type: :request do
             expect(response.body).to include("How text matching works")
           end
 
+          it "renders the stub toggle forms for sub-plugins" do
+            get server_moderation_path(guild.id)
+            expect(response.body).to include("spam_protection-overview-toggle-form")
+            expect(response.body).to include("image_scanning-overview-toggle-form")
+          end
+
           it "renders the save bar wired to the form" do
             get server_moderation_path(guild.id)
             expect(response.body).to include("save-bar").and include("Unsaved changes")

--- a/spec/requests/moderation_config_spec.rb
+++ b/spec/requests/moderation_config_spec.rb
@@ -136,6 +136,7 @@ RSpec.describe "Moderation config", type: :request do
           expect(config.moderation_settings.reload.staff_role_id).to eq(500)
           expect(response.body).to include("moderation-config")
           expect(response.body).to include("saved")
+          expect(response.body).to include('target="plugin-sidebar"')
         end
 
         it "returns 422 when clearing the staff role while a sub-plugin is enabled" do

--- a/spec/requests/moderation_config_spec.rb
+++ b/spec/requests/moderation_config_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Moderation config", type: :request do
+  include_context "discord auth"
+
+  let(:guild) { Discord::Guild.new(id: 900_000_001, name: "Dev Refuge", owner: true, permissions: 0, icon: nil, member_count: 5) }
+  let(:config) { ServerConfiguration.find_by(discord_id: guild.id) }
+  let(:turbo) { {headers: {"Accept" => "text/vnd.turbo-stream.html"}} }
+
+  context "when signed out" do
+    it "redirects to the sign-in page" do
+      get server_moderation_path(900_000_001)
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  context "when signed in" do
+    let!(:logging_plugin) { create(:plugin, key: "logging", name: "Logging") }
+    let!(:moderation_plugin) { create(:plugin, key: "moderation", name: "Server Shield") }
+    let!(:spam_plugin) { create(:plugin, key: "spam_protection", name: "Cross-Channel Spam Guard") }
+
+    before do
+      post "/auth/discord/callback"
+      create(:server_configuration, discord_id: guild.id)
+      config.create_moderation_settings!
+      config.create_logging_setting!
+      config.create_spam_protection_settings!
+      config.create_image_scanning_settings!
+      allow(Discord::UserGuilds).to receive(:call).and_return([guild])
+    end
+
+    context "without proving the server is manageable this session" do
+      it "redirects to the picker" do
+        get server_moderation_path(guild.id)
+        expect(response).to redirect_to(servers_path)
+      end
+    end
+
+    context "after loading the dashboard authorizes the server" do
+      before do
+        get server_path(guild.id)
+      end
+
+      describe "GET /servers/:server_id/moderation" do
+        context "when logging is ready and group is enabled" do
+          before do
+            config.logging_setting.update!(channel_id: 111)
+            create(:plugin_activation, server_configuration: config, plugin: logging_plugin, enabled: false)
+              .update_column(:enabled, true)
+            create(:plugin_activation, server_configuration: config, plugin: moderation_plugin, enabled: false)
+              .update_column(:enabled, true)
+          end
+
+          it "renders the overview page with the Server Shield title" do
+            get server_moderation_path(guild.id)
+            expect(response).to have_http_status(:ok)
+            expect(response.body).to include("Server Shield")
+          end
+
+          it "renders the sub-plugin directory" do
+            get server_moderation_path(guild.id)
+            expect(response.body).to include("Sub-plugins")
+            expect(response.body).to include("Cross-Channel Spam Guard")
+            expect(response.body).to include("Scam Image Detection")
+          end
+
+          it "renders the matching explainer" do
+            get server_moderation_path(guild.id)
+            expect(response.body).to include("How text matching works")
+          end
+
+          it "renders the save bar wired to the form" do
+            get server_moderation_path(guild.id)
+            expect(response.body).to include("save-bar").and include("Unsaved changes")
+          end
+        end
+
+        context "when group is disabled but logging is ready" do
+          before do
+            config.logging_setting.update!(channel_id: 111)
+            create(:plugin_activation, server_configuration: config, plugin: logging_plugin, enabled: false)
+              .update_column(:enabled, true)
+          end
+
+          it "renders the page with the enable gate" do
+            get server_moderation_path(guild.id)
+            expect(response).to have_http_status(:ok)
+            expect(response.body).to include("Server Shield")
+          end
+        end
+
+        context "when logging is not ready" do
+          it "renders the page with the prereq gate" do
+            get server_moderation_path(guild.id)
+            expect(response).to have_http_status(:ok)
+            expect(response.body).to include("Moderation needs the Logging plugin")
+            expect(response.body).to include("Set up Logging")
+          end
+        end
+      end
+
+      describe "PATCH /servers/:server_id/moderation" do
+        before do
+          config.logging_setting.update!(channel_id: 111)
+          create(:plugin_activation, server_configuration: config, plugin: logging_plugin, enabled: false)
+            .update_column(:enabled, true)
+          create(:plugin_activation, server_configuration: config, plugin: moderation_plugin, enabled: false)
+            .update_column(:enabled, true)
+          create(:server_role, server_configuration: config, discord_id: 500, name: "Moderator")
+        end
+
+        it "saves the staff role and returns turbo stream on success" do
+          patch server_moderation_path(guild.id),
+            params: {moderation: {staff_role_id: 500, enabled: "1"}},
+            **turbo
+          expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+          expect(config.moderation_settings.reload.staff_role_id).to eq(500)
+          expect(response.body).to include("moderation-config")
+          expect(response.body).to include("saved")
+        end
+
+        it "returns 422 when clearing the staff role while a sub-plugin is enabled" do
+          create(:plugin_activation, server_configuration: config, plugin: spam_plugin, enabled: false)
+            .update_column(:enabled, true)
+          config.moderation_settings.update!(staff_role_id: 500)
+
+          patch server_moderation_path(guild.id),
+            params: {moderation: {staff_role_id: "", enabled: "1"}},
+            **turbo
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(config.moderation_settings.reload.staff_role_id).to eq(500)
+        end
+
+        it "falls back to a redirect without Turbo" do
+          patch server_moderation_path(guild.id),
+            params: {moderation: {staff_role_id: 500, enabled: "1"}}
+          expect(response).to redirect_to(server_moderation_path(guild.id))
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/moderation_config_spec.rb
+++ b/spec/requests/moderation_config_spec.rb
@@ -75,6 +75,17 @@ RSpec.describe "Moderation config", type: :request do
             get server_moderation_path(guild.id)
             expect(response.body).to include("save-bar").and include("Unsaved changes")
           end
+
+          context "when the logging channel has a server_channel record with a name" do
+            before do
+              create(:server_channel, server_configuration: config, discord_id: 111, name: "mod-log")
+            end
+
+            it "renders the logging subline with the channel name" do
+              get server_moderation_path(guild.id)
+              expect(response.body).to include("#mod-log")
+            end
+          end
         end
 
         context "when group is disabled but logging is ready" do

--- a/spec/requests/server_dashboard_spec.rb
+++ b/spec/requests/server_dashboard_spec.rb
@@ -43,6 +43,16 @@ RSpec.describe "Server dashboard", type: :request do
         expect(response.body).to include("Roles").and include("Welcomes").and include("Logging")
       end
 
+      it "lists moderation but not its sub-plugins on the dashboard" do
+        create(:plugin, key: "moderation", name: "Server Shield")
+        create(:plugin, key: "spam_protection", name: "Cross-Channel Spam Guard")
+        create(:plugin, key: "image_scanning", name: "Scam Image Detection")
+        get_dashboard
+        expect(response.body).to include("plugin-moderation")
+        expect(response.body).not_to include("plugin-spam_protection")
+        expect(response.body).not_to include("plugin-image_scanning")
+      end
+
       context "with another configured server" do
         let(:other_guild) { Discord::Guild.new(id: 900_000_002, name: "Speedrun HQ", owner: true, permissions: 0, icon: nil, member_count: 80) }
 

--- a/spec/requests/spam_protection_config_spec.rb
+++ b/spec/requests/spam_protection_config_spec.rb
@@ -100,6 +100,7 @@ RSpec.describe "Spam protection config", type: :request do
                                        timeout_seconds: 3600, enabled: "0"}},
             **turbo
           expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+          expect(response.body).to include('target="plugin-sidebar"')
           expect(response.body).to include("spam_protection-config")
           expect(response.body).to include("saved")
         end

--- a/spec/requests/spam_protection_config_spec.rb
+++ b/spec/requests/spam_protection_config_spec.rb
@@ -123,6 +123,21 @@ RSpec.describe "Spam protection config", type: :request do
                                        timeout_seconds: 3600, enabled: "0"}}
           expect(response).to redirect_to(server_spam_protection_path(guild.id))
         end
+
+        context "when toggled from the overview" do
+          subject(:patch_from_overview) do
+            patch server_spam_protection_path(guild.id),
+              params: {spam_protection: {channel_threshold: 3, window_seconds: 10, similarity: 0.9,
+                                         match_symbol_only_messages: "0", action: "purge", punishment: "none",
+                                         timeout_seconds: 3600, enabled: "0"},
+                       from_overview: "1"}
+          end
+
+          it "redirects to the moderation overview" do
+            patch_from_overview
+            expect(response).to redirect_to(server_moderation_path(guild.id))
+          end
+        end
       end
     end
   end

--- a/spec/requests/spam_protection_config_spec.rb
+++ b/spec/requests/spam_protection_config_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Spam protection config", type: :request do
+  include_context "discord auth"
+
+  let(:guild) { Discord::Guild.new(id: 900_000_001, name: "Dev Refuge", owner: true, permissions: 0, icon: nil, member_count: 5) }
+  let(:config) { ServerConfiguration.find_by(discord_id: guild.id) }
+  let(:turbo) { {headers: {"Accept" => "text/vnd.turbo-stream.html"}} }
+
+  context "when signed out" do
+    it "redirects to the sign-in page" do
+      get server_spam_protection_path(900_000_001)
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  context "when signed in" do
+    let!(:moderation_plugin) { create(:plugin, key: "moderation", name: "Server Shield") }
+    let!(:spam_plugin) { create(:plugin, key: "spam_protection", name: "Cross-Channel Spam Guard") }
+
+    before do
+      post "/auth/discord/callback"
+      create(:server_configuration, discord_id: guild.id)
+      config.create_moderation_settings!
+      config.create_spam_protection_settings!
+      config.create_image_scanning_settings!
+      allow(Discord::UserGuilds).to receive(:call).and_return([guild])
+    end
+
+    context "without proving the server is manageable this session" do
+      it "redirects to the picker" do
+        get server_spam_protection_path(guild.id)
+        expect(response).to redirect_to(servers_path)
+      end
+    end
+
+    context "after loading the dashboard authorizes the server" do
+      before { get server_path(guild.id) }
+
+      describe "GET /servers/:server_id/spam_protection" do
+        context "when group is enabled and staff role is present" do
+          before do
+            create(:plugin_activation, server_configuration: config, plugin: moderation_plugin, enabled: false)
+              .update_column(:enabled, true)
+            config.moderation_settings.update!(staff_role_id: 500)
+            create(:server_role, server_configuration: config, discord_id: 500, name: "Moderator")
+          end
+
+          it "returns 200 and renders the page" do
+            get server_spam_protection_path(guild.id)
+            expect(response).to have_http_status(:ok)
+            expect(response.body).to include("Cross-Channel Spam Guard")
+          end
+
+          it "renders the detection and response controls" do
+            get server_spam_protection_path(guild.id)
+            expect(response.body).to include("Trigger threshold")
+            expect(response.body).to include("Match strictness")
+            expect(response.body).to include("When spam is detected")
+          end
+        end
+
+        context "when group is disabled" do
+          it "returns 200 and renders the prereq gate" do
+            get server_spam_protection_path(guild.id)
+            expect(response).to have_http_status(:ok)
+            expect(response.body).to include("Server Shield group is disabled")
+            expect(response.body).to include("Open Server Shield overview")
+          end
+        end
+
+        context "when group is enabled but no staff role set" do
+          before do
+            create(:plugin_activation, server_configuration: config, plugin: moderation_plugin, enabled: false)
+              .update_column(:enabled, true)
+          end
+
+          it "returns 200 with no gate but locked toggle and warning callout" do
+            get server_spam_protection_path(guild.id)
+            expect(response).to have_http_status(:ok)
+            expect(response.body).to include("Pick a staff role first.")
+            expect(response.body).not_to include("Server Shield group is disabled")
+          end
+        end
+      end
+
+      describe "PATCH /servers/:server_id/spam_protection" do
+        before do
+          create(:plugin_activation, server_configuration: config, plugin: moderation_plugin, enabled: false)
+            .update_column(:enabled, true)
+          config.moderation_settings.update!(staff_role_id: 500)
+        end
+
+        it "saves settings and returns turbo stream on success" do
+          patch server_spam_protection_path(guild.id),
+            params: {spam_protection: {channel_threshold: 3, window_seconds: 10, similarity: 0.9,
+                                       match_symbol_only_messages: "0", action: "purge", punishment: "none",
+                                       timeout_seconds: 3600, enabled: "0"}},
+            **turbo
+          expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+          expect(response.body).to include("spam_protection-config")
+          expect(response.body).to include("saved")
+        end
+
+        it "returns 422 when enabling with no staff role" do
+          config.moderation_settings.update!(staff_role_id: nil)
+          create(:plugin_activation, server_configuration: config, plugin: spam_plugin, enabled: false)
+
+          patch server_spam_protection_path(guild.id),
+            params: {spam_protection: {channel_threshold: 3, window_seconds: 10, similarity: 0.9,
+                                       match_symbol_only_messages: "0", action: "purge", punishment: "none",
+                                       timeout_seconds: 3600, enabled: "1"}},
+            **turbo
+          expect(response).to have_http_status(:unprocessable_content)
+        end
+
+        it "falls back to a redirect without Turbo" do
+          patch server_spam_protection_path(guild.id),
+            params: {spam_protection: {channel_threshold: 3, window_seconds: 10, similarity: 0.9,
+                                       match_symbol_only_messages: "0", action: "purge", punishment: "none",
+                                       timeout_seconds: 3600, enabled: "0"}}
+          expect(response).to redirect_to(server_spam_protection_path(guild.id))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds the three Server Shield config pages (PR 6 of the moderation suite): group overview, Cross-Channel Spam Guard, and Scam Image Detection.

## What's in here

- **New building-block components**: `SidebarGroup` (disclosure nav group with status dots + persisted open state), `NumberStepper` (min-clamped, no UI cap, "Recommended default" subscript), `RangeSlider` (native range input; renders percent, submits the raw percent, converted to a 0.75–1.0 float exactly once), `PrereqGate` (blocking reason + deep-link CTA), `RadioCardGroup` (sensitivity presets), and a custom `megaphone-slash` SVG glyph (Phosphor ships none).
- **Three pages** under `resource :moderation / :spam_protection / :image_scanning`, each a standard show/update controller calling the existing Configure ops. Copy lifted verbatim from the approved mockup (committed here as `docs/design/moderation-config.html`), with the renamed display names substituted.
- **Overview**: staff-role card (required marker, TomSelect with role colour dots), sub-plugin directory rows with status badges + enable toggles, "How text matching works" explainer. States: logging missing (PrereqGate), group disabled, staff role missing, permission warning.
- **Sub-pages**: detection/sensitivity/keywords/response cards per the mockup; group-disabled and staff-role-missing states; "Report as scam" context-menu hint on the image-scanning page.
- **Op-seam guard** (from the PR 2 review): `Ops::Moderation::Configure` now rejects clearing `staff_role_id` while a sub-plugin is enabled; the now-dead defensive nil branch in `SpamGuard#notify` is dropped.
- **Bug found by the coverage gate**: Phlex shadows `Kernel#format` with a zero-arg method, so rendering any role with a non-zero colour raised `ArgumentError`. Fixed with `String#%`.

All gates green locally: rspec (1477), standardrb, active_record_doctor, undercover, i18n-tasks.