### PR TITLE
Load .env.deploy in Kamal config

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -1,3 +1,4 @@
+<% require "dotenv"; Dotenv.load(".env.deploy") %>
 service: shrkbot
 image: badblackshark/shrkbot
 


### PR DESCRIPTION
Kamal 2 dropped the automatic dotenv loading Kamal 1 had, so the `<%= ENV["DEPLOY_HOST"] %>` references in `config/deploy.yml` rendered nil and every `kamal` command failed with `servers/bot/hosts/0: should be a string or a hash` unless the caller manually exported the variables first.

Load `.env.deploy` from `deploy.yml` itself using the `dotenv` gem Kamal already depends on. This keeps the loading scoped to the kamal process (nothing else ever sees the file), and `Dotenv.load` doesn't override variables already present in the environment, so an explicit export still wins.

Verified with `kamal config`, which now resolves hosts from `.env.deploy` with no shell setup.