### PR TITLE
Equalize dashboard plugin card heights and refresh sidebar dots on save

### DIFF
--- a/app/components/plugin_row.rb
+++ b/app/components/plugin_row.rb
@@ -18,21 +18,29 @@ class Components::PluginRow < Components::Base
   end
 
   def view_template
-    render Components::Card.new(enabled: @enabled, id: "plugin-#{@key}", class: "flex items-center gap-4") do
+    render Components::Card.new(enabled: @enabled, id: "plugin-#{@key}", class: "flex min-h-[108px] flex-wrap items-center gap-x-4 gap-y-3") do
+      identity
+      div(class: "ml-auto flex flex-none items-center gap-3") do
+        configure_link
+        toggle
+      end
+    end
+  end
+
+  private
+
+  def identity
+    div(class: "flex min-w-0 flex-[1_1_320px] items-center gap-4") do
       render Components::PluginTile.new(icon: plugin_icon(@key), enabled: @enabled)
       div(class: "min-w-0 flex-1") do
         div(class: "flex flex-wrap items-center gap-2") do
           span(class: "font-display font-semibold") { name }
           status_badge
         end
-        p(class: "mt-0.5 text-sm text-text-secondary") { t(".plugin.#{@key}.description") }
+        p(class: "mt-0.5 text-sm leading-[1.5] text-pretty text-text-secondary") { t(".plugin.#{@key}.description") }
       end
-      configure_link
-      toggle
     end
   end
-
-  private
 
   def toggle
     if @locked

--- a/app/components/plugin_tile.rb
+++ b/app/components/plugin_tile.rb
@@ -3,7 +3,7 @@
 class Components::PluginTile < Components::Base
   SIZES = {
     sm: {box: "size-9", icon: "size-4"},
-    md: {box: "size-11", icon: "size-5"},
+    md: {box: "size-11", icon: "size-[22px]"},
     lg: {box: "size-12", icon: "size-6"}
   }.freeze
 

--- a/app/views/servers/logging/update.turbo_stream.erb
+++ b/app/views/servers/logging/update.turbo_stream.erb
@@ -1,2 +1,3 @@
 <%= turbo_stream.replace "logging-config", html: render(Components::Logging::ConfigForm.new(server_configuration: @server_configuration, enable_error: @enable_error)) %>
 <%= turbo_stream.append "toasts", html: render(Components::Toast.new(**@toast)) if @toast %>
+<%= turbo_stream.replace "plugin-sidebar", html: render(Components::PluginSidebar.new(server_configuration: @server_configuration, active_key: :logging)) %>

--- a/app/views/servers/roles/update.turbo_stream.erb
+++ b/app/views/servers/roles/update.turbo_stream.erb
@@ -1,2 +1,3 @@
 <%= turbo_stream.replace "roles-config", html: render(Components::Roles::ConfigForm.new(server_configuration: @server_configuration)) if @success %>
 <%= turbo_stream.append "toasts", html: render(Components::Toast.new(**@toast)) %>
+<%= turbo_stream.replace "plugin-sidebar", html: render(Components::PluginSidebar.new(server_configuration: @server_configuration, active_key: :roles)) %>

--- a/app/views/servers/welcomes/update.turbo_stream.erb
+++ b/app/views/servers/welcomes/update.turbo_stream.erb
@@ -1,2 +1,3 @@
 <%= turbo_stream.replace "welcomes-config", html: render(Components::Welcomes::ConfigForm.new(server_configuration: @server_configuration, enable_error: @enable_error)) %>
 <%= turbo_stream.append "toasts", html: render(Components::Toast.new(**@toast)) if @toast %>
+<%= turbo_stream.replace "plugin-sidebar", html: render(Components::PluginSidebar.new(server_configuration: @server_configuration, active_key: :welcomes)) %>

--- a/spec/components/plugin_tile_spec.rb
+++ b/spec/components/plugin_tile_spec.rb
@@ -16,8 +16,7 @@ RSpec.describe Components::PluginTile do
 
     it "fills with teal and uses the fill-weight glyph" do
       expect(html).to include("bg-accent-fill").and include("text-white")
-      expect(html).to eq(described_class.new(icon: "users-three", enabled: true).call)
-      expect(html).to include(PhosphorIcons::Icon.new("users-three", style: :fill, class: "size-5").to_svg)
+      expect(html).to include(PhosphorIcons::Icon.new("users-three", style: :fill, class: "size-[22px]").to_svg)
     end
   end
 
@@ -26,7 +25,7 @@ RSpec.describe Components::PluginTile do
 
     it "is muted sand with a regular-weight glyph" do
       expect(html).to include("bg-surface-sunken").and include("text-text-muted")
-      expect(html).to include(PhosphorIcons::Icon.new("scroll", style: :regular, class: "size-5").to_svg)
+      expect(html).to include(PhosphorIcons::Icon.new("scroll", style: :regular, class: "size-[22px]").to_svg)
     end
   end
 

--- a/spec/requests/logging_config_spec.rb
+++ b/spec/requests/logging_config_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe "Logging config", type: :request do
           expect(config.logging_setting.action_enabled?("roles.role_gained")).to be(true)
           expect(config.plugins.enabled.exists?(key: :logging)).to be(true)
           expect(response.body).to include("saved")
+          expect(response.body).to include('target="plugin-sidebar"')
         end
 
         it "exposes which channels are public so it can warn before saving" do

--- a/spec/requests/roles_config_spec.rb
+++ b/spec/requests/roles_config_spec.rb
@@ -96,6 +96,7 @@ RSpec.describe "Roles config", type: :request do
           expect(config.role_setting.role_sets.last.assignable_roles.map(&:role_id)).to contain_exactly(222)
           expect(config.plugins.enabled.exists?(key: :roles)).to be(true)
           expect(response.body).to include("saved")
+          expect(response.body).to include('target="plugin-sidebar"')
         end
 
         it "returns 422 without a body replace when enabling without a channel" do

--- a/spec/requests/welcomes_config_spec.rb
+++ b/spec/requests/welcomes_config_spec.rb
@@ -96,6 +96,7 @@ RSpec.describe "Welcomes config", type: :request do
           expect(config.welcome_settings.reload.channel_id).to eq(111)
           expect(config.plugins.enabled.exists?(key: :welcomes)).to be(true)
           expect(response.body).to include("saved")
+          expect(response.body).to include('target="plugin-sidebar"')
         end
 
         it "re-renders the form with an inline error when enabling without a channel" do


### PR DESCRIPTION
Two leftovers from the Server Shield config UI work (#115):

**Dashboard card heights.** Server Shield's two-line description made its dashboard card visibly taller than the others. Every `PluginRow` card now carries a two-line minimum height (`min-h-[108px]` = card padding + name row + two lines of description), with the description keeping its natural height so the existing vertical centering keeps one-line rows optically balanced. `min-h` rather than `h`, so a future three-line description grows the card instead of clipping. Identity (tile + text) and actions (Configure + toggle) are now two wrapping flex groups, so on narrow viewports the actions drop to their own right-aligned line instead of squeezing — no media queries. The md tile glyph is bumped 20px → 22px to better fill the 44px tile (top of the design-system range). Layout direction (rows over a tile grid) confirmed by design review: a 2-col grid would break the aligned toggle column and wrap nearly every description to two lines anyway.

**Stale sidebar status dots.** The welcomes, logging, and roles config pages never re-rendered the plugin sidebar after an enable-toggle save, leaving their status dots stale until a full reload. Ported the `plugin-sidebar` turbo_stream replace the moderation pages already use; happy-path request specs assert it. Reminders untouched — it's always-on, so its dot can't go stale.

Boyscout: removed a tautological assertion in `plugin_tile_spec.rb` (subject compared to itself re-instantiated).

All gates green locally: rspec (1552 examples), standardrb, active_record_doctor, undercover.