### PR TITLE
Deploy OCR sidecar as Kamal accessory

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -44,6 +44,7 @@ env:
     WEB_BASE_URL: https://shrkbot.com
     DB_HOST: shrkbot-db
     REDIS_URL: redis://shrkbot-redis:6379/0
+    OCR_URL: http://shrkbot-ocr:8000
     SHARD_COUNT: "1"
   secret:
     - SECRET_KEY_BASE
@@ -72,3 +73,14 @@ accessories:
     host: <%= ENV["DEPLOY_HOST"] %>
     network: kamal
     cmd: redis-server --save ""
+  ocr:
+    image: ghcr.io/badblackshark/shrkbot-ocr:latest
+    host: <%= ENV["DEPLOY_HOST"] %>
+    network: kamal
+    options:
+      cpus: 2
+    env:
+      clear:
+        OMP_NUM_THREADS: "2"
+    volumes:
+      - shrkbot_ocr_models:/home/ocr/.paddlex

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,12 +2,12 @@
 
 shrkbot deploys to a single Hetzner box via [Kamal 2](https://kamal-deploy.org).
 One Docker image, three processes (web/bot/jobs) plus managed accessories
-(Postgres, Redis), all orchestrated by Kamal from your laptop.
+(Postgres, Redis, the OCR sidecar), all orchestrated by Kamal from your laptop.
 
 ## Prerequisites
 
 ### Server
-- Hetzner box running Docker + docker-compose (pre-installed).
+- Hetzner box running Docker (pre-installed).
 - DNS A-records for **both** `shrkbot.com` and `www.shrkbot.com` pointing at the
   box IP — these must resolve before the first deploy; kamal-proxy's Let's Encrypt
   HTTP-01 challenge needs them resolving correctly.
@@ -30,13 +30,24 @@ Intents** section in the Discord Developer Portal. Without it Discord sends
 `event.message.content` as an empty string, so content-based spam detection will
 not fire.
 
+#### Invite permissions
+
+The invite link's permission set must include everything Server Shield acts with:
+
+- **Mention @everyone, @here and All Roles** — staff-role pings on flag/notify posts
+- **Manage Messages** — spam purge and scam image removal
+- **Moderate Members** — the timeout punishment
+- **Kick Members** / **Ban Members** — only needed when a server configures those
+  punishments
+
+Re-invite the bot with the updated link if it was originally invited with fewer
+permissions.
+
 ## Secrets
 
-Create a gitignored `.deploy.env` on your laptop and source it before deploying:
-
-```sh
-source .deploy.env
-```
+Create a gitignored `.env.deploy` in the repo root on your laptop.
+`config/deploy.yml` loads it itself (Kamal 2 no longer autoloads dotenv files),
+so no `source` step is needed.
 
 Variable reference:
 
@@ -55,22 +66,55 @@ Variable reference:
 Alternatively, use `kamal secrets fetch` with a secrets manager — see
 [Kamal docs on secrets](https://kamal-deploy.org/docs/configuration/secrets/).
 
+## OCR sidecar image
+
+The Scam Image Detection feature talks to a Python OCR sidecar (`ocr/`), deployed
+as the `ocr` Kamal accessory. Kamal only pulls the accessory image — build and push
+it manually whenever `ocr/` changes:
+
+```sh
+docker build --platform linux/amd64 -t ghcr.io/badblackshark/shrkbot-ocr:latest ocr/
+docker push ghcr.io/badblackshark/shrkbot-ocr:latest
+```
+
+`--platform linux/amd64` is mandatory on Apple Silicon: paddlepaddle aarch64 wheels
+segfault at inference, so an arm64 image would build fine and then crash on every
+scan (and the emulated image cannot be smoke-tested locally either — PaddleOCR
+initialisation hangs under Rosetta; see `ocr/README.md`). Verify against the
+deployed box instead.
+
+Then boot (first time) or restart (after a push) the accessory:
+
+```sh
+bin/kamal accessory boot ocr     # first deploy
+bin/kamal accessory reboot ocr   # picks up a newly pushed image
+```
+
+Operational notes:
+
+- PaddleOCR models download on first start into the `shrkbot_ocr_models` volume,
+  so restarts don't re-download them. First boot takes a few minutes; the
+  container's Docker health check (`GET /health`, 180s start period) shows
+  `healthy` once the model is loaded — check with `docker ps` on the box or
+  `bin/kamal accessory details ocr`.
+- The app reaches it as `http://shrkbot-ocr:8000` (`OCR_URL` in `deploy.yml`);
+  the accessory is not exposed through kamal-proxy.
+
 ## First deploy
 
 ```sh
-source .deploy.env
 bin/kamal setup
 ```
 
-`kamal setup` boots the db and redis accessories, builds the amd64 image, pushes it
-to GHCR, starts the web/bot/jobs processes, and has kamal-proxy provision the TLS
-certificate. Migrations run automatically on web boot via the entrypoint
-(`RUN_DB_PREPARE=1` is set on the web role only, so the three processes don't race).
+`kamal setup` boots the accessories (db, redis, ocr — push the sidecar image
+first, see above), builds the amd64 app image, pushes it to GHCR, starts the
+web/bot/jobs processes, and has kamal-proxy provision the TLS certificate.
+Migrations run automatically on web boot via the entrypoint (`RUN_DB_PREPARE=1`
+is set on the web role only, so the three processes don't race).
 
 ## Redeploys
 
 ```sh
-source .deploy.env
 bin/kamal deploy
 ```
 
@@ -85,6 +129,9 @@ bin/kamal app exec -r web "bin/rails console"
 
 # Postgres accessory logs
 bin/kamal accessory logs db
+
+# OCR sidecar logs
+bin/kamal accessory logs ocr
 
 # Roll back to the previous image
 bin/kamal rollback

--- a/ocr/Dockerfile
+++ b/ocr/Dockerfile
@@ -15,6 +15,11 @@ COPY service.py preprocess.py ./
 
 RUN useradd -r -u 1001 -m ocr
 USER ocr
+# Pre-create the model cache so a named volume mounted here inherits ocr's
+# ownership (fresh volumes otherwise mount root-owned and downloads fail).
+RUN mkdir -p /home/ocr/.paddlex
 
 EXPOSE 8000
+HEALTHCHECK --interval=30s --timeout=5s --start-period=180s --retries=3 \
+  CMD ["python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health', timeout=4)"]
 CMD ["uvicorn", "service:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## What

PR 7 of the Server Shield suite — production deployment for the OCR sidecar (PR 3, #111).

- **`config/deploy.yml`**: new `ocr` accessory — `ghcr.io/badblackshark/shrkbot-ocr:latest`, same host, kamal network, `--cpus 2`, `OMP_NUM_THREADS=2`, no proxy. Model-cache volume (`shrkbot_ocr_models:/home/ocr/.paddlex`) so container restarts don't re-download PaddleOCR models. App env gains `OCR_URL: http://shrkbot-ocr:8000` (matches the `shrkbot-db`/`shrkbot-redis` accessory naming Kamal derives).
- **`ocr/Dockerfile`**: Docker `HEALTHCHECK` against `GET /health` (180s start period for first-boot model load); pre-creates `/home/ocr/.paddlex` as the `ocr` user so the named volume inherits non-root ownership (fresh volumes otherwise mount root-owned and the model download fails).
- **`docs/deployment.md`**: sidecar build/push instructions (manual `docker build`/`push`; `--platform linux/amd64` mandatory — aarch64 paddle wheels segfault at inference), accessory boot/reboot + ops-cheatsheet entries, invite-permissions section (Mention All Roles, Manage Messages, Moderate Members, Kick/Ban when punishments configured), MESSAGE CONTENT intent already documented.
- Docs fix: `source .deploy.env` instructions were stale — the file is `.env.deploy` and `deploy.yml` loads it itself since #118.

Model warmup baked into the image was considered and rejected: `PaddleOCR()` init hangs under Rosetta emulation, so a warmup `RUN` would hang every image build on Apple Silicon. The cache volume gives the same restart benefit without that hazard.

## Verification

- Full Kamal config validated locally (`bin/kamal config` renders and accepts the accessory).
- All gates green: rspec (1552 examples), standardrb, active_record_doctor, undercover.
- `docker build` + live accessory boot not verifiable in the sandbox (no Docker) — needs the usual on-box verification.

## Your steps (documented in the PR's docs changes)

1. Build + push the sidecar image (linux/amd64), then `bin/kamal accessory boot ocr` and `bin/kamal deploy` (app needs the new `OCR_URL`).
2. Discord portal: MESSAGE CONTENT intent + re-invite with the extended permission set if the bot was invited before Server Shield.