### PR TITLE
Lift op-surfaced error strings into i18n

### DIFF
--- a/app/models/plugin_activation.rb
+++ b/app/models/plugin_activation.rb
@@ -22,6 +22,6 @@ class PluginActivation < ApplicationRecord
     definition = PluginCatalog.find(plugin.key)
     return if definition.nil? || definition.prerequisites_met?(server_configuration)
 
-    errors.add(:enabled, "requires the plugin's settings to be configured first")
+    errors.add(:enabled, I18n.t("operations.plugin_activation.requires_settings"))
   end
 end

--- a/app/operations/logging/configure.rb
+++ b/app/operations/logging/configure.rb
@@ -31,7 +31,7 @@ module Ops
       end
 
       def moderation_dependency_failure(activation)
-        activation.errors.add(:enabled, "can't be turned off or lose its channel while Server Shield is enabled")
+        activation.errors.add(:enabled, I18n.t("operations.logging.moderation_dependency"))
         failure(activation.errors[:enabled], value: activation)
       end
 

--- a/app/operations/logging/settings/update.rb
+++ b/app/operations/logging/settings/update.rb
@@ -7,7 +7,7 @@ module Ops
         receives :server_configuration, :channel_id
 
         def call
-          return failure("A channel is required.") if channel_id.blank?
+          return failure(I18n.t("operations.logging.channel_required")) if channel_id.blank?
 
           setting = server_configuration.logging_setting
           setting.update!(channel_id:)
@@ -20,7 +20,7 @@ module Ops
           channel = server_configuration.server_channels.find_by(discord_id: channel_id)
           return [] unless channel&.everyone_visible?
 
-          ["This channel is visible to @everyone; mod-action logs would be public."]
+          [I18n.t("operations.logging.channel_public_warning")]
         end
       end
     end

--- a/app/operations/moderation/configure.rb
+++ b/app/operations/moderation/configure.rb
@@ -32,12 +32,12 @@ module Ops
       end
 
       def logging_guard_failure(activation)
-        activation.errors.add(:enabled, "requires the Logging plugin enabled with a log channel set")
+        activation.errors.add(:enabled, I18n.t("operations.moderation.logging_required"))
         failure(activation.errors[:enabled], value: activation)
       end
 
       def staff_role_clear_failure(activation)
-        activation.errors.add(:staff_role_id, "A staff role is required while a sub-plugin is enabled.")
+        activation.errors.add(:staff_role_id, I18n.t("operations.moderation.staff_role_in_use"))
         failure(activation.errors[:staff_role_id], value: activation)
       end
 

--- a/app/operations/moderation/sub_plugin_configuration.rb
+++ b/app/operations/moderation/sub_plugin_configuration.rb
@@ -10,7 +10,7 @@ module Ops
       end
 
       def staff_role_guard_failure(activation)
-        activation.errors.add(:enabled, "requires a staff role set on the Server Shield overview")
+        activation.errors.add(:enabled, I18n.t("operations.moderation.staff_role_required"))
         failure(activation.errors[:enabled], value: activation)
       end
     end

--- a/app/operations/reminders/create.rb
+++ b/app/operations/reminders/create.rb
@@ -9,8 +9,8 @@ module Ops
 
       def call
         span = ::Reminders::Duration.parse(duration)
-        return failure("I couldn't understand that duration. Try something like `1d2h30m`.") unless span
-        return failure("A reminder needs a message.") if message.blank?
+        return failure(I18n.t("operations.reminders.invalid_duration")) unless span
+        return failure(I18n.t("operations.reminders.message_required")) if message.blank?
 
         remind_at = Time.current + span
         reminder = ::Reminders::Reminder.create!(

--- a/app/operations/roles/messages/post.rb
+++ b/app/operations/roles/messages/post.rb
@@ -13,7 +13,7 @@ module Ops
 
           ::Roles::MessagePoster.post(bot, role_set)
 
-          return failure("Could not post the role message - check the channel.") if role_set.message_id.nil?
+          return failure(I18n.t("operations.roles.messages.post_failed")) if role_set.message_id.nil?
 
           ok(role_set)
         end

--- a/app/operations/roles/messages/repost.rb
+++ b/app/operations/roles/messages/repost.rb
@@ -13,7 +13,7 @@ module Ops
           role_set.update!(message_id: nil)
           ::Roles::MessagePoster.post(bot, role_set)
 
-          return failure("Could not post the role message - check the channel.") if role_set.message_id.nil?
+          return failure(I18n.t("operations.roles.messages.post_failed")) if role_set.message_id.nil?
 
           ok(role_set)
         end

--- a/app/operations/server_configuration/plugins/toggle.rb
+++ b/app/operations/server_configuration/plugins/toggle.rb
@@ -12,7 +12,7 @@ module Ops
           activation = PluginActivation.find_or_initialize_by(server_configuration:, plugin:)
           activation.enabled = enabled
           if activation.enabled? && !prerequisites_met?
-            return failure("#{plugin.name} can't be enabled until its required settings are configured.")
+            return failure(I18n.t("operations.server_configuration.plugins.requires_settings", plugin: plugin.name))
           end
           activation.save!
           publish_side_effects(activation)

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -10,6 +10,7 @@ data:
     - ["views.privacy_policy.*", "config/locales/legal.%{locale}.yml"]
     - ["views.terms_of_service.*", "config/locales/legal.%{locale}.yml"]
     - ["components.legal_page.*", "config/locales/legal.%{locale}.yml"]
+    - ["operations.*", "config/locales/operations.%{locale}.yml"]
     - "config/locales/web.%{locale}.yml"
 
 # Relative keys in Views::Servers::Moderation::SubPluginShow resolve at runtime

--- a/config/locales/operations.en.yml
+++ b/config/locales/operations.en.yml
@@ -1,0 +1,25 @@
+---
+en:
+  operations:
+    logging:
+      channel_public_warning: This channel is visible to @everyone; mod-action logs
+        would be public.
+      channel_required: A channel is required.
+      moderation_dependency: can't be turned off or lose its channel while Server
+        Shield is enabled
+    moderation:
+      logging_required: requires the Logging plugin enabled with a log channel set
+      staff_role_in_use: A staff role is required while a sub-plugin is enabled.
+      staff_role_required: requires a staff role set on the Server Shield overview
+    plugin_activation:
+      requires_settings: requires the plugin's settings to be configured first
+    reminders:
+      invalid_duration: I couldn't understand that duration. Try something like `1d2h30m`.
+      message_required: A reminder needs a message.
+    roles:
+      messages:
+        post_failed: Could not post the role message - check the channel.
+    server_configuration:
+      plugins:
+        requires_settings: "%{plugin} can't be enabled until its required settings
+          are configured."


### PR DESCRIPTION
## What

PR 8 of the Server Shield suite — the approved follow-up that lifts all hardcoded op-surfaced user-facing copy into i18n. Repo-wide, not moderation-only; no behaviour change, every string byte-identical.

- New `config/locales/operations.en.yml` holding an `operations.*` namespace (11 keys), routed there by a new `i18n-tasks.yml` write rule. Own file because these strings surface both on the web (turbo inline errors) and in Discord (reminder create errors) — neither `web.en.yml` nor `moderation.en.yml` fit.
- Keys are `operations.<domain>.<message>` — named by domain + message semantics, not full class paths.
- Call sites switched to `I18n.t`: the moderation/logging Configure guards (staff-role-required, logging dependency both directions, staff-role-clear), `Ops::Moderation::SubPluginConfiguration`, `PluginActivation#enabling_requires_prerequisites`, `Ops::ServerConfiguration::Plugins::Toggle` (with `%{plugin}` interpolation), `Ops::Roles::Messages::Post`/`Repost` (now sharing one key for their duplicated message), `Ops::Logging::Settings::Update` (error + the @everyone-visibility warning), `Ops::Reminders::Create`.
- `PluginActivation` lives under `operations.*` deliberately: the namespace means "copy surfaced through the op seam" (its guard message is what `Toggle` failures return), and the Rails-native `activerecord.errors` route would need symbol keys that i18n-tasks can't track without `ignore_unused` entries.

## Verification

All gates green: rspec (1552 examples), standardrb, active_record_doctor, undercover, `i18n-tasks missing` + `check-normalized` (file normalized).