### PR TITLE
Convert fake string enums to real Rails enums

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -2,4 +2,13 @@
 
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
+
+  def self.string_enum(name, values, validate: true, **options)
+    enum(
+      name,
+      values.to_h { |value| [value.to_sym, value.to_s] },
+      validate:,
+      **options
+    )
+  end
 end

--- a/app/models/channel_overwrite.rb
+++ b/app/models/channel_overwrite.rb
@@ -4,5 +4,6 @@ class ChannelOverwrite < ApplicationRecord
   belongs_to :server_channel
 
   validates :target_id, presence: true, uniqueness: {scope: :server_channel_id}
-  validates :target_type, presence: true, inclusion: {in: %w[role member]}
+  validates :target_type, presence: true
+  enum :target_type, {role: "role", member: "member"}, validate: {allow_nil: true}
 end

--- a/app/models/channel_overwrite.rb
+++ b/app/models/channel_overwrite.rb
@@ -5,5 +5,5 @@ class ChannelOverwrite < ApplicationRecord
 
   validates :target_id, presence: true, uniqueness: {scope: :server_channel_id}
   validates :target_type, presence: true
-  enum :target_type, {role: "role", member: "member"}, validate: {allow_nil: true}
+  string_enum :target_type, %w[role member], validate: {allow_nil: true}
 end

--- a/app/operations/moderation/phashes/confirm.rb
+++ b/app/operations/moderation/phashes/confirm.rb
@@ -9,7 +9,7 @@ module Ops
         private
 
         def verdict
-          "confirmed"
+          :confirmed
         end
       end
     end

--- a/app/operations/moderation/phashes/dismiss.rb
+++ b/app/operations/moderation/phashes/dismiss.rb
@@ -9,7 +9,7 @@ module Ops
         private
 
         def verdict
-          "dismissed"
+          :dismissed
         end
       end
     end

--- a/app/plugins/moderation/commands/report_scam.rb
+++ b/app/plugins/moderation/commands/report_scam.rb
@@ -55,7 +55,7 @@ module Moderation
 
     def post_log(config, message, log_image)
       settings = config.image_scanning_settings
-      deleted = settings.action == "delete" && delete_message(message)
+      deleted = settings.action_delete? && delete_message(message)
       meta_key = deleted ? "removed" : "kept"
       ActivityLog.post(
         config,

--- a/app/plugins/moderation/events/spam_guard.rb
+++ b/app/plugins/moderation/events/spam_guard.rb
@@ -21,7 +21,7 @@ module Moderation
       return unless hit
       return sweep_followup(hit, settings, config) if hit.followup?
 
-      purge(hit.entries) if settings.action == "purge"
+      purge(hit.entries) if settings.action_purge?
       punish(settings)
       notify(config, settings, staff_role_id, hit.entries)
     end
@@ -72,7 +72,7 @@ module Moderation
     end
 
     def punish(settings)
-      return if settings.punishment == "none"
+      return if settings.punishment_none?
 
       Punisher.call(
         member: event.author,
@@ -106,7 +106,7 @@ module Moderation
     end
 
     def sweep_followup(hit, settings, config)
-      return unless settings.action == "purge"
+      return unless settings.action_purge?
 
       purge(hit.entries)
       entry = hit.entries.first

--- a/app/plugins/moderation/image_scanning/settings.rb
+++ b/app/plugins/moderation/image_scanning/settings.rb
@@ -12,8 +12,8 @@ module Moderation
 
       belongs_to :server_configuration
 
-      enum :sensitivity, {relaxed: "relaxed", standard: "standard", strict: "strict"}, validate: true
-      enum :action, {none: "none", delete: "delete"}, prefix: true, validate: true
+      string_enum :sensitivity, %w[relaxed standard strict]
+      string_enum :action, %w[none delete], prefix: true
       validates :custom_keyword_min_hits,
         numericality: {only_integer: true, greater_than_or_equal_to: 1}
       validate :custom_keywords_within_limit

--- a/app/plugins/moderation/image_scanning/settings.rb
+++ b/app/plugins/moderation/image_scanning/settings.rb
@@ -8,14 +8,12 @@ module Moderation
 
       self.table_name = "image_scanning_settings"
 
-      SENSITIVITIES = %w[relaxed standard strict].freeze
-      ACTIONS = %w[none delete].freeze
       MAX_KEYWORDS = 200
 
       belongs_to :server_configuration
 
-      validates :sensitivity, inclusion: {in: SENSITIVITIES}
-      validates :action, inclusion: {in: ACTIONS}
+      enum :sensitivity, {relaxed: "relaxed", standard: "standard", strict: "strict"}, validate: true
+      enum :action, {none: "none", delete: "delete"}, prefix: true, validate: true
       validates :custom_keyword_min_hits,
         numericality: {only_integer: true, greater_than_or_equal_to: 1}
       validate :custom_keywords_within_limit

--- a/app/plugins/moderation/phash_confirmation.rb
+++ b/app/plugins/moderation/phash_confirmation.rb
@@ -8,6 +8,6 @@ module Moderation
     belongs_to :server_configuration
 
     validates :verdict, presence: true
-    enum :verdict, {confirmed: "confirmed", dismissed: "dismissed"}, validate: {allow_nil: true}
+    string_enum :verdict, %w[confirmed dismissed], validate: {allow_nil: true}
   end
 end

--- a/app/plugins/moderation/phash_confirmation.rb
+++ b/app/plugins/moderation/phash_confirmation.rb
@@ -4,11 +4,10 @@ module Moderation
   class PhashConfirmation < ApplicationRecord
     self.table_name = "phash_confirmations"
 
-    VERDICTS = %w[confirmed dismissed].freeze
-
     belongs_to :phash, class_name: "Moderation::Phash"
     belongs_to :server_configuration
 
-    validates :verdict, presence: true, inclusion: {in: VERDICTS}
+    validates :verdict, presence: true
+    enum :verdict, {confirmed: "confirmed", dismissed: "dismissed"}, validate: {allow_nil: true}
   end
 end

--- a/app/plugins/moderation/punishable.rb
+++ b/app/plugins/moderation/punishable.rb
@@ -4,10 +4,8 @@ module Moderation
   module Punishable
     extend ActiveSupport::Concern
 
-    PUNISHMENTS = %w[none timeout kick ban].freeze
-
     included do
-      validates :punishment, inclusion: {in: PUNISHMENTS}
+      enum :punishment, {none: "none", timeout: "timeout", kick: "kick", ban: "ban"}, prefix: true, validate: true
       validates :timeout_seconds,
         numericality: {only_integer: true, greater_than_or_equal_to: 60, less_than_or_equal_to: 2_419_200}
     end

--- a/app/plugins/moderation/punishable.rb
+++ b/app/plugins/moderation/punishable.rb
@@ -5,7 +5,7 @@ module Moderation
     extend ActiveSupport::Concern
 
     included do
-      enum :punishment, {none: "none", timeout: "timeout", kick: "kick", ban: "ban"}, prefix: true, validate: true
+      string_enum :punishment, %w[none timeout kick ban], prefix: true
       validates :timeout_seconds,
         numericality: {only_integer: true, greater_than_or_equal_to: 60, less_than_or_equal_to: 2_419_200}
     end

--- a/app/plugins/moderation/spam_protection/settings.rb
+++ b/app/plugins/moderation/spam_protection/settings.rb
@@ -10,7 +10,7 @@ module Moderation
 
       belongs_to :server_configuration
 
-      enum :action, {purge: "purge", notify_only: "notify_only"}, prefix: true, validate: true
+      string_enum :action, %w[purge notify_only], prefix: true
 
       validates :channel_threshold,
         numericality: {only_integer: true, greater_than_or_equal_to: 2, less_than_or_equal_to: 500}

--- a/app/plugins/moderation/spam_protection/settings.rb
+++ b/app/plugins/moderation/spam_protection/settings.rb
@@ -8,9 +8,9 @@ module Moderation
 
       self.table_name = "spam_protection_settings"
 
-      ACTIONS = %w[purge notify_only].freeze
-
       belongs_to :server_configuration
+
+      enum :action, {purge: "purge", notify_only: "notify_only"}, prefix: true, validate: true
 
       validates :channel_threshold,
         numericality: {only_integer: true, greater_than_or_equal_to: 2, less_than_or_equal_to: 500}
@@ -18,7 +18,6 @@ module Moderation
         numericality: {only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 60}
       validates :similarity,
         numericality: {greater_than_or_equal_to: 0.75, less_than_or_equal_to: 1.0}
-      validates :action, inclusion: {in: ACTIONS}
 
       def self.active_for(discord_id)
         active_group_settings(discord_id, :spam_protection) { |config| config.spam_protection_settings }

--- a/app/plugins/moderation/verdict_executor.rb
+++ b/app/plugins/moderation/verdict_executor.rb
@@ -11,7 +11,7 @@ module Moderation
       when :flag_for_review
         flag(verdict, context, phash, image_bytes:, removed: false)
       when :remove
-        delete_message(context) if context.settings.action == "delete"
+        delete_message(context) if context.settings.action_delete?
         punish(context)
         flag(verdict, context, phash, image_bytes:, removed: true)
       end
@@ -24,7 +24,7 @@ module Moderation
     end
 
     def punish(context)
-      return if context.settings.punishment == "none"
+      return if context.settings.punishment_none?
 
       Punisher.call(
         member: context.member,

--- a/app/plugins/roles/message.rb
+++ b/app/plugins/roles/message.rb
@@ -15,7 +15,7 @@ module Roles
 
     def public_message(set)
       blocks =
-        if set.selection_mode == "single"
+        if set.single?
           [Discord::Components.text(single_content(set)), Discord::Components.separator, *button_rows(role_buttons(set))]
         else
           [Discord::Components.text(multi_content(set)), Discord::Components.separator, manage_section(set)]

--- a/app/plugins/roles/set.rb
+++ b/app/plugins/roles/set.rb
@@ -10,7 +10,7 @@ module Roles
 
     validates :name, presence: true
     validates :selection_mode, presence: true
-    enum :selection_mode, {single: "single", multi: "multi"}, validate: {allow_nil: true}
+    string_enum :selection_mode, %w[single multi], validate: {allow_nil: true}
 
     def channel_id
       channel_override || role_setting.channel_id

--- a/app/plugins/roles/set.rb
+++ b/app/plugins/roles/set.rb
@@ -9,7 +9,8 @@ module Roles
       foreign_key: "role_set_id", dependent: :delete_all
 
     validates :name, presence: true
-    validates :selection_mode, presence: true, inclusion: {in: %w[single multi]}
+    validates :selection_mode, presence: true
+    enum :selection_mode, {single: "single", multi: "multi"}, validate: {allow_nil: true}
 
     def channel_id
       channel_override || role_setting.channel_id

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -40,6 +40,15 @@ Discord snowflakes (`discord_id`, `user_id`, `channel_id`, `role_id`,
 Model validations and DB constraints must mirror each other (CI enforces this via
 `active_record_doctor`). Index foreign keys and read paths on new tables.
 
+Enum-like string columns use the `string_enum` macro (`ApplicationRecord`), which
+maps each value to its identical string and validates membership instead of raising
+on assignment — a bad web param fails through the normal validation path. Keep the
+column's `IN (...)` DB check constraint alongside it. Pass `prefix: true` whenever a
+value would collide with an Active Record method (`none` always does); columns that
+are `NOT NULL` without a default also keep an explicit `presence` validator and pass
+`validate: {allow_nil: true}` so nil reports "can't be blank" and doctor sees the
+mirror.
+
 ## Operations (`app/operations/`, `Ops::` namespace)
 
 All writes and business logic live in operations — the shared seam between the bot

--- a/spec/models/channel_overwrite_spec.rb
+++ b/spec/models/channel_overwrite_spec.rb
@@ -29,9 +29,7 @@ RSpec.describe ChannelOverwrite do
     context "with role" do
       let(:target_type) { "role" }
 
-      it "returns true for role?" do
-        expect(overwrite.role?).to be(true)
-      end
+      it { is_expected.to be_role }
     end
   end
 

--- a/spec/models/channel_overwrite_spec.rb
+++ b/spec/models/channel_overwrite_spec.rb
@@ -25,6 +25,14 @@ RSpec.describe ChannelOverwrite do
 
       it { is_expected.to be_valid }
     end
+
+    context "with role" do
+      let(:target_type) { "role" }
+
+      it "returns true for role?" do
+        expect(overwrite.role?).to be(true)
+      end
+    end
   end
 
   describe "target_id uniqueness" do

--- a/spec/operations/moderation/image_scanning/configure_spec.rb
+++ b/spec/operations/moderation/image_scanning/configure_spec.rb
@@ -134,4 +134,17 @@ RSpec.describe Ops::Moderation::ImageScanning::Configure do
       expect(config.plugin_activations.find_by(plugin:)&.enabled).to be_falsey
     end
   end
+
+  context "with an unknown action" do
+    let(:action) { "purge" }
+    let(:enabled) { "0" }
+
+    it "fails" do
+      expect(result).to be_failure
+    end
+
+    it "reports an error mentioning action" do
+      expect(result.errors.join(" ")).to match(/action/i)
+    end
+  end
 end

--- a/spec/operations/moderation/spam_protection/configure_spec.rb
+++ b/spec/operations/moderation/spam_protection/configure_spec.rb
@@ -110,4 +110,17 @@ RSpec.describe Ops::Moderation::SpamProtection::Configure do
       expect(result.value.errors[:enabled]).to be_present
     end
   end
+
+  context "with an unknown action" do
+    let(:action) { "delete" }
+    let(:enabled) { "0" }
+
+    it "fails" do
+      expect(result).to be_failure
+    end
+
+    it "reports an error mentioning action" do
+      expect(result.errors.join(" ")).to match(/action/i)
+    end
+  end
 end

--- a/spec/plugins/moderation/commands/report_scam_spec.rb
+++ b/spec/plugins/moderation/commands/report_scam_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Moderation::ReportScam do
     )
   end
 
-  let(:image_scanning_settings) { double("image_scanning_settings", action: "none") }
+  let(:image_scanning_settings) { double("image_scanning_settings", action: "none", action_delete?: false) }
   let(:client) { double("client") }
 
   before do
@@ -109,7 +109,7 @@ RSpec.describe Moderation::ReportScam do
   end
 
   context "when at least one image was confirmed and action is delete" do
-    let(:image_scanning_settings) { double("image_scanning_settings", action: "delete") }
+    let(:image_scanning_settings) { double("image_scanning_settings", action: "delete", action_delete?: true) }
 
     it "deletes the reported message" do
       execute
@@ -132,7 +132,7 @@ RSpec.describe Moderation::ReportScam do
   end
 
   context "when the delete fails" do
-    let(:image_scanning_settings) { double("image_scanning_settings", action: "delete") }
+    let(:image_scanning_settings) { double("image_scanning_settings", action: "delete", action_delete?: true) }
 
     before do
       allow(target).to receive(:delete).and_raise(RuntimeError, "forbidden")
@@ -148,7 +148,7 @@ RSpec.describe Moderation::ReportScam do
   end
 
   context "when at least one image was confirmed and action is none" do
-    let(:image_scanning_settings) { double("image_scanning_settings", action: "none") }
+    let(:image_scanning_settings) { double("image_scanning_settings", action: "none", action_delete?: false) }
 
     it "does not delete the message" do
       execute

--- a/spec/plugins/moderation/commands/report_scam_spec.rb
+++ b/spec/plugins/moderation/commands/report_scam_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Moderation::ReportScam do
     )
   end
 
-  let(:image_scanning_settings) { double("image_scanning_settings", action: "none", action_delete?: false) }
+  let(:image_scanning_settings) { double("image_scanning_settings", action_delete?: false) }
   let(:client) { double("client") }
 
   before do
@@ -109,7 +109,7 @@ RSpec.describe Moderation::ReportScam do
   end
 
   context "when at least one image was confirmed and action is delete" do
-    let(:image_scanning_settings) { double("image_scanning_settings", action: "delete", action_delete?: true) }
+    let(:image_scanning_settings) { double("image_scanning_settings", action_delete?: true) }
 
     it "deletes the reported message" do
       execute
@@ -132,7 +132,7 @@ RSpec.describe Moderation::ReportScam do
   end
 
   context "when the delete fails" do
-    let(:image_scanning_settings) { double("image_scanning_settings", action: "delete", action_delete?: true) }
+    let(:image_scanning_settings) { double("image_scanning_settings", action_delete?: true) }
 
     before do
       allow(target).to receive(:delete).and_raise(RuntimeError, "forbidden")
@@ -148,7 +148,7 @@ RSpec.describe Moderation::ReportScam do
   end
 
   context "when at least one image was confirmed and action is none" do
-    let(:image_scanning_settings) { double("image_scanning_settings", action: "none", action_delete?: false) }
+    let(:image_scanning_settings) { double("image_scanning_settings", action_delete?: false) }
 
     it "does not delete the message" do
       execute

--- a/spec/plugins/moderation/events/spam_guard_spec.rb
+++ b/spec/plugins/moderation/events/spam_guard_spec.rb
@@ -39,7 +39,9 @@ RSpec.describe Moderation::SpamGuard do
       window_seconds: 60,
       similarity: 1.0,
       action:,
+      action_purge?: action == "purge",
       punishment:,
+      punishment_none?: punishment == "none",
       timeout_seconds: 300,
       match_symbol_only_messages:
     )

--- a/spec/plugins/moderation/image_scanning/settings_spec.rb
+++ b/spec/plugins/moderation/image_scanning/settings_spec.rb
@@ -21,6 +21,11 @@ RSpec.describe Moderation::ImageScanning::Settings do
         expect(settings).to be_valid
       end
     end
+
+    it "returns true for strict? when set to strict" do
+      settings.sensitivity = "strict"
+      expect(settings.strict?).to be(true)
+    end
   end
 
   describe "action" do

--- a/spec/plugins/moderation/image_scanning/settings_spec.rb
+++ b/spec/plugins/moderation/image_scanning/settings_spec.rb
@@ -22,9 +22,12 @@ RSpec.describe Moderation::ImageScanning::Settings do
       end
     end
 
-    it "returns true for strict? when set to strict" do
-      settings.sensitivity = "strict"
-      expect(settings.strict?).to be(true)
+    context "when set to strict" do
+      before do
+        settings.sensitivity = "strict"
+      end
+
+      it { is_expected.to be_strict }
     end
   end
 

--- a/spec/plugins/moderation/phash_confirmation_spec.rb
+++ b/spec/plugins/moderation/phash_confirmation_spec.rb
@@ -40,11 +40,11 @@ RSpec.describe Moderation::PhashConfirmation do
     end
   end
 
-  describe "enum predicates" do
-    subject(:confirmation) { build(:phash_confirmation, verdict: "confirmed") }
-
-    it "returns true for confirmed?" do
-      expect(confirmation.confirmed?).to be(true)
+  context "when confirmed" do
+    before do
+      confirmation.verdict = "confirmed"
     end
+
+    it { is_expected.to be_confirmed }
   end
 end

--- a/spec/plugins/moderation/phash_confirmation_spec.rb
+++ b/spec/plugins/moderation/phash_confirmation_spec.rb
@@ -34,9 +34,17 @@ RSpec.describe Moderation::PhashConfirmation do
   end
 
   it "accepts each allowed verdict" do
-    Moderation::PhashConfirmation::VERDICTS.each do |verdict|
+    described_class.verdicts.keys.each do |verdict|
       confirmation.verdict = verdict
       expect(confirmation).to be_valid
+    end
+  end
+
+  describe "enum predicates" do
+    subject(:confirmation) { build(:phash_confirmation, verdict: "confirmed") }
+
+    it "returns true for confirmed?" do
+      expect(confirmation.confirmed?).to be(true)
     end
   end
 end

--- a/spec/plugins/moderation/spam_protection/settings_spec.rb
+++ b/spec/plugins/moderation/spam_protection/settings_spec.rb
@@ -86,9 +86,16 @@ RSpec.describe Moderation::SpamProtection::Settings do
       expect(settings).to be_valid
     end
 
-    it "returns true for action_notify_only? when set to notify_only" do
-      settings.action = "notify_only"
-      expect(settings.action_notify_only?).to be(true)
+    it "maps each value to its identical string" do
+      expect(described_class.actions).to eq("purge" => "purge", "notify_only" => "notify_only")
+    end
+
+    context "when set to notify_only" do
+      before do
+        settings.action = "notify_only"
+      end
+
+      it { is_expected.to be_action_notify_only }
     end
   end
 
@@ -105,9 +112,12 @@ RSpec.describe Moderation::SpamProtection::Settings do
       end
     end
 
-    it "returns true for punishment_none? when set to none" do
-      settings.punishment = "none"
-      expect(settings.punishment_none?).to be(true)
+    context "when set to none" do
+      before do
+        settings.punishment = "none"
+      end
+
+      it { is_expected.to be_punishment_none }
     end
   end
 

--- a/spec/plugins/moderation/spam_protection/settings_spec.rb
+++ b/spec/plugins/moderation/spam_protection/settings_spec.rb
@@ -85,6 +85,11 @@ RSpec.describe Moderation::SpamProtection::Settings do
       settings.action = "notify_only"
       expect(settings).to be_valid
     end
+
+    it "returns true for action_notify_only? when set to notify_only" do
+      settings.action = "notify_only"
+      expect(settings.action_notify_only?).to be(true)
+    end
   end
 
   describe "punishment (via Punishable)" do
@@ -98,6 +103,11 @@ RSpec.describe Moderation::SpamProtection::Settings do
         settings.punishment = punishment
         expect(settings).to be_valid
       end
+    end
+
+    it "returns true for punishment_none? when set to none" do
+      settings.punishment = "none"
+      expect(settings.punishment_none?).to be(true)
     end
   end
 

--- a/spec/plugins/moderation/verdict_executor_spec.rb
+++ b/spec/plugins/moderation/verdict_executor_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe Moderation::VerdictExecutor do
   let(:settings) do
     double(
       "settings",
-      action: settings_action,
       action_delete?: settings_action == "delete",
       punishment:,
       punishment_none?: punishment == "none",

--- a/spec/plugins/moderation/verdict_executor_spec.rb
+++ b/spec/plugins/moderation/verdict_executor_spec.rb
@@ -34,7 +34,9 @@ RSpec.describe Moderation::VerdictExecutor do
     double(
       "settings",
       action: settings_action,
+      action_delete?: settings_action == "delete",
       punishment:,
+      punishment_none?: punishment == "none",
       timeout_seconds: 300,
       sensitivity: "standard",
       server_configuration:

--- a/spec/plugins/roles/set_spec.rb
+++ b/spec/plugins/roles/set_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe Roles::Set do
       let(:selection_mode) { "single" }
 
       it { is_expected.to be_valid }
+
+      it "returns true for single?" do
+        expect(set.single?).to be(true)
+      end
     end
   end
 


### PR DESCRIPTION
## What

Refactor R1 — every fake string enum (string column + `inclusion` validation + DB check) becomes a real string-backed Rails enum: symbol API, predicates, scopes, one source of truth. Columns and their check constraints are untouched, so no migration.

Seven conversions across six models: `ChannelOverwrite.target_type`, `Roles::Set.selection_mode`, `Moderation::PhashConfirmation.verdict` (caught by the sweep, beyond the known list), `punishment` (in `Moderation::Punishable`, covers both settings models), `SpamProtection::Settings.action`, `ImageScanning::Settings.sensitivity` + `.action`.

Declarations go through a new **`ApplicationRecord.string_enum`** macro — takes the value list once, maps each value to its identical string, defaults to validating membership. Establishes the pattern for future enum columns; documented in `docs/architecture.md`.

Two deviations from the planned approach, both for the better:

- **`validate: true` instead of an op-boundary ArgumentError guard.** Rails 7.1+ native option: an unknown assignment becomes a plain validation error, so web-fed Configure ops fail through their existing `settings.valid?` path with the standard inline field error — no raise, no helper code. Op specs assert unknown-value params yield a failure, not a 500.
- **`prefix: true` on `punishment` and both `action` enums** — the `none` value collides with `ActiveRecord::Base.none` unprefixed; spam's `action` is prefixed for symmetry (`action_purge?` / `action_delete?` / `punishment_none?`).

NOT NULL columns without defaults (`target_type`, `verdict`, `selection_mode`) keep an explicit `presence` validator with `validate: {allow_nil: true}` on the enum — nil reports "can't be blank" and active_record_doctor sees the NOT NULL mirror (it doesn't count the enum validation).

Raw string comparisons at call sites became predicates (`set.single?`, `settings.action_purge?`, …). Deliberately unchanged: `Classifier::THRESHOLDS` string keys, `PhashIndex` pluck comparisons, `Punisher`'s case statement (value seam, not a model), i18n key interpolations, and form components reading attribute values — string-backed enums still return the raw string on read.

`logging_settings.enabled_actions` (jsonb map) is not an enum and was left alone, per plan.

## Verification

All gates green: rspec (1563 examples), standardrb, active_record_doctor, undercover. Model specs keep their invalid-value examples (still valid semantics under `validate: true`) plus new predicate examples; each Configure op has an unknown-param-fails spec.