### PR TITLE
Document local setup in README and .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,13 @@
 # Copy to .env for local dev (loaded by dotenv-rails). Production uses real env vars.
 
 # --- Discord bot ---
+# Bot token from the Discord developer portal (Bot tab). Required.
 DISCORD_TOKEN=
+# The application ID (General Information tab). Used to build the bot invite link
+# on the website.
 CLIENT_ID=
+# Your Discord user ID. Grants access to owner-only commands and receives
+# owner notification DMs. Leave blank to disable both.
 OWNER_ID=
 # Test server for local development: :guild commands (e.g. /ping) register here
 # instantly. Leave blank in production — there guild commands register per-server
@@ -12,6 +17,8 @@ TEST_SERVER_ID=
 SHARD_COUNT=1
 
 # --- Discord OAuth2 (web config UI login) ---
+# OAuth2 client credentials (OAuth2 tab of the same application). The redirect
+# URI <WEB_BASE_URL>/auth/discord/callback must be registered there.
 DISCORD_CLIENT_ID=
 DISCORD_CLIENT_SECRET=
 
@@ -30,5 +37,11 @@ DATABASE_URL=postgres://root:password@localhost:5678/shrkbot_db
 # Leave blank to disable the subscriber (the bot logs it's off and runs anyway).
 # Solid Queue itself is Postgres-backed and doesn't need this.
 REDIS_URL=redis://localhost:6379/0
-
+# OCR sidecar for Scam Image Detection (compose service `ocr`, behind the `ocr`
+# profile: `docker compose --profile ocr up -d ocr`). Only needed when working
+# on image scanning; the default reaches the sidecar from inside the compose
+# network.
 OCR_URL='http://ocr:8000'
+# Hostname/IP of the production box. Only used by Kamal (config/deploy.yml)
+# when deploying; leave blank for local dev.
+DEPLOY_HOST=

--- a/README.md
+++ b/README.md
@@ -1,24 +1,68 @@
-# README
+# shrkbot
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+A Discord bot with a companion website. All per-server configuration lives on the site; the bot handles Discord interactions and events. For what the bot actually does, see [shrkbot.com](https://shrkbot.com).
 
-Things you may want to cover:
+This README covers getting the bot running locally. Architecture and how-tos (adding plugins, commands, events) live in [docs/](docs/).
 
-* Ruby version
+## Prerequisites
 
-* System dependencies
+* Ruby 4.0.5 (see `.ruby-version`)
+* Docker — `docker-compose.yml` provides Postgres and Redis. You can also run the whole app inside compose; the comments in `.env.example` cover both setups.
+* A Discord application ([developer portal](https://discord.com/developers/applications)) with:
+  * a bot token
+  * the **MESSAGE CONTENT** privileged intent enabled (required by Server Shield)
+  * the OAuth2 redirect URI `http://localhost:3000/auth/discord/callback` for logging into the local web UI
 
-* Configuration
+## Setup
 
-* Database creation
+```
+cp .env.example .env   # then fill in the blanks — the comments explain each value
+docker compose up -d db redis
+bin/setup              # installs dependencies, prepares the database, starts the web server
+```
 
-* Database initialization
+In separate terminals:
 
-* How to run the test suite
+```
+bin/bot    # the gateway connection
+bin/jobs   # background jobs (reminder delivery)
+```
 
-* Services (job queues, cache servers, search engines, etc.)
+Set `TEST_SERVER_ID` in `.env` to your test server so guild commands register there instantly. If you work on Scam Image Detection, you'll also need the OCR sidecar: `docker compose --profile ocr up -d ocr`.
 
-* Deployment instructions
+## AI-assisted development
 
-* ...
+If you want to use coding agents but keep them isolated from the rest of your machine, the compose file includes a sandbox: the `dev` container (built from `Dockerfile.dev`) ships Ruby, the GitHub CLI, Claude Code, and Copilot CLI as an unprivileged user, with the repo mounted at `/app`. Secrets (`.env`, `.env.deploy`) are masked inside the container, and the compose file and Dockerfiles are mounted read-only, so the agent can't read your credentials or loosen its own sandbox.
+
+Agent state lives on the host under `~/.ai-sandbox` so it survives container rebuilds. One-time setup:
+
+```
+mkdir -p ~/.ai-sandbox/shrkbot/{claude,local-state,local-share}
+touch ~/.ai-sandbox/shrkbot/claude.json
+```
+
+Then:
+
+* put the git identity the agent should commit with into `~/.ai-sandbox/gitconfig-shrkbot`,
+* optionally put a GitHub PAT into `~/.ai-sandbox/github-pat-private` (used for pushes; scope it to this repo),
+* make sure `gh auth login` has been run on the host — `~/.config/gh` is mounted in.
+
+Start it with:
+
+```
+docker compose run --rm dev bash
+```
+
+and run your agent from there. It talks to the same compose Postgres as the other services.
+
+## Contributing
+
+Issues and pull requests are welcome. Branch off `main` and make sure `bundle exec rspec` and `bundle exec standardrb` pass before opening a PR — CI runs the full gate set either way. For anything beyond a small fix, open an issue first so we can talk it through, and check the how-tos in [docs/](docs/) before adding features.
+
+## Deployment
+
+Deploys to a single box via [Kamal 2](https://kamal-deploy.org) — see [docs/deployment.md](docs/deployment.md).
+
+## License
+
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ and run your agent from there. It talks to the same compose Postgres as the othe
 
 ## Contributing
 
-Issues and pull requests are welcome. Branch off `main` and make sure `bundle exec rspec` and `bundle exec standardrb` pass before opening a PR — CI runs the full gate set either way. For anything beyond a small fix, open an issue first so we can talk it through, and check the how-tos in [docs/](docs/) before adding features.
+Found a bug, or missing a feature? Open an issue, or send an email to [info@shrkbot.com](mailto:info@shrkbot.com) — both are read. If you'd like to add something yourself, fork the project and open a PR; the how-tos in [docs/](docs/) will get you started. For bigger changes it's worth opening an issue first so we can talk it through before you put the work in.
 
 ## Deployment
 


### PR DESCRIPTION
Replaces the Rails generator stub README with actual local setup docs: Discord application prerequisites, compose usage, the AI sandbox (`dev`) container, and a short contributing section. Every value in `.env.example` now has a comment explaining what it is and where it comes from.

Feature descriptions intentionally stay out — that's what the website is for.