### PR TITLE
Make .env.deploy win over inherited shell env during kamal runs

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -1,4 +1,4 @@
-<% require "dotenv"; Dotenv.load(".env.deploy") %>
+<% require "dotenv"; Dotenv.load(".env.deploy", overwrite: true) %>
 service: shrkbot
 image: badblackshark/shrkbot
 


### PR DESCRIPTION
One-liner: `Dotenv.load` never overwrites variables already present in the environment, so a shell that still had the test bot's `DISCORD_TOKEN` (etc.) exported deployed the test bot even after `.env.deploy` was updated with production values. `overwrite: true` makes the file authoritative, matching what `docs/deployment.md` already promises.