### PR TITLE
Use Discord's default install link for invites

### DIFF
--- a/app/bot/bot_config.rb
+++ b/app/bot/bot_config.rb
@@ -34,6 +34,10 @@ module BotConfig
     ENV["CLIENT_ID"]
   end
 
+  def invite_url
+    "https://discord.com/oauth2/authorize?client_id=#{client_id}"
+  end
+
   def web_base_url
     ENV.fetch("WEB_BASE_URL")
   end

--- a/app/bot/commands/info.rb
+++ b/app/bot/commands/info.rb
@@ -6,7 +6,6 @@ module Commands
     description "Show information about shrkbot - its code, stack, and how to add it to your server."
     register_in :global
 
-    INVITE_URL = "https://discord.com/oauth2/authorize?client_id=346043915142561793"
     MASCOT_PATH = Rails.root.join("app/assets/images/shrkbot-mascot.png")
 
     def execute
@@ -58,7 +57,7 @@ module Commands
     def header
       "### #{event.bot.profile.username}\n" \
         "I was written in [Ruby](https://www.ruby-lang.org/) by [badBlackShark](https://github.com/badBlackShark/).\n" \
-        "My code lives [here](https://github.com/badBlackShark/shrkbot). Want me on your server? [Invite me!](#{INVITE_URL})"
+        "My code lives [here](https://github.com/badBlackShark/shrkbot). Want me on your server? [Invite me!](#{BotConfig.invite_url})"
     end
 
     def credits

--- a/app/views/servers/index.rb
+++ b/app/views/servers/index.rb
@@ -109,7 +109,7 @@ class Views::Servers::Index < Views::Base
   end
 
   def generic_invite_url
-    "https://discord.com/oauth2/authorize?client_id=#{BotConfig.client_id}&scope=bot+applications.commands"
+    BotConfig.invite_url
   end
 
   def invite_url(guild)

--- a/spec/bot/bot_config_spec.rb
+++ b/spec/bot/bot_config_spec.rb
@@ -36,6 +36,14 @@ RSpec.describe BotConfig do
     end
   end
 
+  describe ".invite_url" do
+    it "builds the OAuth authorize link from CLIENT_ID" do
+      with_env("CLIENT_ID", "12345") do
+        expect(described_class.invite_url).to eq("https://discord.com/oauth2/authorize?client_id=12345")
+      end
+    end
+  end
+
   describe ".rest_token" do
     subject(:rest_token) { described_class.rest_token }
 

--- a/spec/bot/commands/info_spec.rb
+++ b/spec/bot/commands/info_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Commands::Info do
       body = texts(args).join("\n")
       expect(body).to include("shrkbot")
       expect(body).to include("Ruby")
-      expect(body).to include(described_class::INVITE_URL)
+      expect(body).to include(BotConfig.invite_url)
       expect(body).to include("discordrb").and include("Ruby on Rails")
       expect(body).to include("/donate")
     end


### PR DESCRIPTION
## Problem
Inviting shrkbot via the website didn't create its managed role / grant permissions. The invite URL forced `scope=bot+applications.commands` with no `permissions` param, which overrides the install settings configured in the developer portal — the bot joined with nothing.

## Fix
- Website invite links now use the bare `https://discord.com/oauth2/authorize?client_id=…` form, which defers to the app's default install settings.
- Extracted the URL into `BotConfig.invite_url`; `/info` had the same URL hardcoded with a literal client ID and now shares it (rule of two).

## Gates
rspec (1564 examples, 0 failures), standardrb, active_record_doctor, undercover — all green.