### PR TITLE
Register guild commands per server based on enabled plugins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,10 +9,6 @@ CLIENT_ID=
 # Your Discord user ID. Grants access to owner-only commands and receives
 # owner notification DMs. Leave blank to disable both.
 OWNER_ID=
-# Test server for local development: :guild commands (e.g. /ping) register here
-# instantly. Leave blank in production — there guild commands register per-server
-# on plugin enable. Without it, guild commands are skipped (see the boot log).
-TEST_SERVER_ID=
 # One shard handles thousands of guilds — only raise this if Discord requires it.
 SHARD_COUNT=1
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bin/bot    # the gateway connection
 bin/jobs   # background jobs (reminder delivery)
 ```
 
-Set `TEST_SERVER_ID` in `.env` to your test server so guild commands register there instantly. If you work on Scam Image Detection, you'll also need the OCR sidecar: `docker compose --profile ocr up -d ocr`.
+Guild commands register per-server automatically — no env var needed. If you work on Scam Image Detection, you'll also need the OCR sidecar: `docker compose --profile ocr up -d ocr`.
 
 ## AI-assisted development
 

--- a/app/bot/base_command.rb
+++ b/app/bot/base_command.rb
@@ -3,7 +3,7 @@
 class BaseCommand
   include WithConnection
 
-  Registration = Struct.new(:name, :description, :permissions, :owner_only, :context, :type, :options_block) do
+  Registration = Struct.new(:name, :description, :permissions, :owner_only, :context, :type, :options_block, :plugin) do
     def global?
       context == :global
     end
@@ -42,6 +42,11 @@ class BaseCommand
       @register_in || :guild
     end
 
+    def plugin(value = nil)
+      @plugin = value if value
+      @plugin
+    end
+
     def command_type(value = nil)
       @command_type = value if value
       @command_type || :chat_input
@@ -61,7 +66,8 @@ class BaseCommand
         owner_only: owner_only?,
         context: register_in,
         type: command_type,
-        options_block: chat_input ? options : nil
+        options_block: chat_input ? options : nil,
+        plugin:
       )
     end
 

--- a/app/bot/bot_config.rb
+++ b/app/bot/bot_config.rb
@@ -18,10 +18,6 @@ module BotConfig
     ENV["OWNER_ID"]
   end
 
-  def test_server_id
-    ENV["TEST_SERVER_ID"]
-  end
-
   def redis_url
     ENV["REDIS_URL"]
   end

--- a/app/bot/command_backfill.rb
+++ b/app/bot/command_backfill.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class CommandBackfill < BaseEvent
+  on :ready
+
+  def handle
+    syncer = GuildCommandSync.new(event.bot)
+    event.bot.servers.keys.each { |discord_id| syncer.sync(discord_id) }
+  end
+end

--- a/app/bot/command_payload.rb
+++ b/app/bot/command_payload.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class CommandPayload
+  def initialize(registration)
+    @registration = registration
+  end
+
+  def to_h
+    payload = {
+      name: @registration.name,
+      description: @registration.description,
+      type: Discordrb::ApplicationCommand::TYPES[@registration.type] || @registration.type
+    }
+
+    if @registration.permissions.present?
+      payload[:default_member_permissions] = Discordrb::Permissions.bits(@registration.permissions).to_s
+    end
+
+    if @registration.options_block
+      builder = Discordrb::Interactions::OptionBuilder.new
+      @registration.options_block.call(builder)
+      payload[:options] = builder.to_a
+    end
+
+    if @registration.global?
+      payload[:contexts] = @registration.contexts.map { |ctx| Discordrb::Interaction::CONTEXTS[ctx] }
+    end
+
+    payload
+  end
+end

--- a/app/bot/command_registrar.rb
+++ b/app/bot/command_registrar.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
 class CommandRegistrar
-  def initialize(bot, commands:, instant_global: false, define_commands: true)
+  def initialize(bot, commands:, define_commands: true)
     @bot = bot
     @commands = commands.select(&:registrable)
-    @instant_global = instant_global
     @define_commands = define_commands
   end
 
@@ -12,40 +11,26 @@ class CommandRegistrar
 
   def register_all
     commands.each do |klass|
-      next unless registrable_here?(klass)
-
-      define(klass) if @define_commands
       attach(klass)
       attach_autocomplete(klass) if klass.autocomplete?
     end
+
+    define_global if @define_commands
   end
 
   private
 
-  def test_server_id
-    BotConfig.test_server_id
-  end
+  def define_global
+    return if Rails.env.development?
 
-  def registrable_here?(klass)
-    reg = klass.registration
-    return true if reg.global? || test_server_id.present?
+    global_payloads = commands
+      .select { |klass| klass.registration.global? }
+      .map { |klass| CommandPayload.new(klass.registration).to_h }
 
-    Rails.logger.warn("[CommandRegistrar] skipping :guild command /#{reg.name} — TEST_SERVER_ID not set")
-    false
-  end
-
-  def define(klass)
-    reg = klass.registration
-    to_guild = !reg.global? || (@instant_global && test_server_id.present?)
-
-    bot.register_application_command(
-      reg.name,
-      reg.description,
-      server_id: to_guild ? test_server_id : nil,
-      default_member_permissions: reg.permissions.presence,
-      contexts: to_guild ? nil : reg.contexts,
-      type: reg.type,
-      &reg.options_block
+    Discordrb::API::Application.bulk_overwrite_global_commands(
+      bot.token,
+      bot.profile.id,
+      global_payloads
     )
   end
 

--- a/app/bot/command_setup.rb
+++ b/app/bot/command_setup.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class CommandSetup < BaseEvent
+  on :server_create
+
+  def handle
+    GuildCommandSync.new(event.bot).sync(event.server.id)
+  end
+end

--- a/app/bot/config_bus.rb
+++ b/app/bot/config_bus.rb
@@ -5,6 +5,10 @@ module ConfigBus
 
   module_function
 
+  def sync_commands(server_configuration)
+    publish(type: "commands_sync", discord_id: server_configuration.discord_id)
+  end
+
   def repost_roles(role_set)
     publish(type: "roles_repost", set_id: role_set.id)
   end

--- a/app/bot/config_subscriber.rb
+++ b/app/bot/config_subscriber.rb
@@ -33,6 +33,8 @@ class ConfigSubscriber
 
   def route(event)
     case event[:type]
+    when "commands_sync"
+      sync_commands(event[:discord_id])
     when "roles_repost"
       repost_roles(event[:set_id])
     when "roles_post"
@@ -42,6 +44,10 @@ class ConfigSubscriber
     when "roles_menu_remove"
       remove_menu(event[:set_id])
     end
+  end
+
+  def sync_commands(discord_id)
+    GuildCommandSync.new(bot).sync(discord_id)
   end
 
   def repost_roles(set_id)

--- a/app/bot/guild_command_set.rb
+++ b/app/bot/guild_command_set.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class GuildCommandSet
+  def initialize(discord_id, commands: BaseCommand.descendants)
+    @discord_id = discord_id
+    @commands = commands.select(&:registrable)
+  end
+
+  def payloads
+    included_commands.map { |klass| CommandPayload.new(klass.registration).to_h }
+  end
+
+  private
+
+  def included_commands
+    @commands.select { |klass| include_command?(klass) }
+  end
+
+  def include_command?(klass)
+    reg = klass.registration
+    return include_global? if reg.global?
+
+    include_guild?(reg)
+  end
+
+  def include_global?
+    Rails.env.development?
+  end
+
+  def include_guild?(reg)
+    return true if reg.plugin.nil?
+
+    parent_key = PluginCatalog.find(reg.plugin)&.parent
+    enabled_keys.include?(reg.plugin) && (parent_key.nil? || enabled_keys.include?(parent_key))
+  end
+
+  def enabled_keys
+    @enabled_keys ||= fetch_enabled_keys
+  end
+
+  def fetch_enabled_keys
+    config = ServerConfiguration.find_by(discord_id: @discord_id)
+    return [] unless config
+
+    config.plugins.enabled.pluck(:key).map(&:to_sym)
+  end
+end

--- a/app/bot/guild_command_sync.rb
+++ b/app/bot/guild_command_sync.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class GuildCommandSync
+  def initialize(bot)
+    @bot = bot
+  end
+
+  def sync(discord_id)
+    overwrite(discord_id, GuildCommandSet.new(discord_id).payloads)
+  end
+
+  private
+
+  def overwrite(discord_id, payloads)
+    Discordrb::API::Application.bulk_overwrite_guild_commands(
+      @bot.token,
+      @bot.profile.id,
+      discord_id,
+      payloads
+    )
+  rescue => e
+    Rails.logger.error("[GuildCommandSync] #{discord_id}: #{e.class}: #{e.message}")
+  end
+end

--- a/app/operations/server_configuration/plugins/toggle.rb
+++ b/app/operations/server_configuration/plugins/toggle.rb
@@ -27,6 +27,7 @@ module Ops
         end
 
         def publish_side_effects(activation)
+          ConfigBus.sync_commands(server_configuration)
           return unless plugin.key == :roles
 
           ::Roles::MenuToggle.publish(server_configuration, enabled: activation.enabled?)

--- a/app/plugins/moderation/commands/report_scam.rb
+++ b/app/plugins/moderation/commands/report_scam.rb
@@ -7,6 +7,7 @@ module Moderation
     command_name "Report as scam"
     command_type :message
     register_in :guild
+    plugin :image_scanning
     requires_permissions :manage_messages
 
     def execute

--- a/bin/bot
+++ b/bin/bot
@@ -22,7 +22,6 @@ bots.each_with_index do |bot, index|
   CommandRegistrar.new(
     bot,
     commands: BaseCommand.descendants,
-    instant_global: Rails.env.development?,
     define_commands: index.zero?
   ).register_all
   EventRegistrar.new(bot, events: BaseEvent.descendants).register_all

--- a/docs/adding-a-command.md
+++ b/docs/adding-a-command.md
@@ -39,9 +39,13 @@ end
 
 - `command_name "x"` — required; the slash command name. A subclass without it is skipped.
 - `description "…"` — shown in Discord and reused on the website. Write it well; it's user-facing.
-- `register_in :guild | :global` — `:guild` (default) registers per-server and is
-  hidden where the plugin is disabled; `:global` is always-on and works in DMs. See
-  [architecture.md](architecture.md#registration-context).
+- `register_in :guild | :global` — `:guild` (default) bulk-overwrites per server on
+  ready/join/plugin-toggle; a guild command only appears in servers where its plugin
+  (and that plugin's parent, if any) is enabled. `:global` is registered once globally
+  and works in DMs. See [architecture.md](architecture.md#registration-context).
+- `plugin :key` — optional; ties a guild command to a `PluginCatalog` key so it only
+  registers in guilds where that plugin is enabled. Omit for always-on guild commands
+  (e.g. `/ping`).
 - `requires_permissions :a, :b` — native Discord permission symbols; all must be held.
   Omit for an everyone-command. The `OWNER_ID` env var is a global override.
 - `owner_only` — restrict to the configured owner.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -194,21 +194,17 @@ declaration is available to everyone.
 
 Declared with `register_in`:
 
-- `:guild` (default) — guild-scoped registration; appears instantly, toggles
-  per-server, Discord hides it where the plugin is disabled. Guild commands cannot
-  appear in DMs.
-- `:global` — registered once with `contexts = [:server, :bot_dm]`; always-on; works
-  in DMs. Reminders is the one global feature.
+- `:guild` (default) — bulk-overwritten per guild on ready (`CommandBackfill`),
+  server join (`CommandSetup`), and plugin toggle (ConfigBus `commands_sync`). A
+  command's `plugin :key` macro ties it to a `PluginCatalog` key; it only registers
+  in guilds where that plugin (and its parent, if any) is enabled. Plugin-less guild
+  commands register in every guild. Guild commands cannot appear in DMs.
+- `:global` — registered once globally in production via `CommandRegistrar#define_global`.
+  In development, global commands are folded into every guild's bulk-overwrite set for
+  instant appearance (no ~1h propagation delay). Always-on; works in DMs.
 
 `CommandRegistrar` notes:
 
-- Until per-server registration lands (Phase 8), `:guild` commands register to
-  `TEST_SERVER_ID`. A `:guild` command with no `TEST_SERVER_ID` is **skipped**, not
-  silently registered globally (global propagation takes up to ~1h and has no
-  per-server toggle).
-- `instant_global` (dev only) registers `:global` commands to the test server too,
-  for instant appearance; guild-scoped, so they don't reach DMs in dev. Production
-  registers them truly globally.
 - `define_commands: false` attaches handlers without redefining the (application-
   global) command definitions — under sharding only the first shard defines them.
 - discordrb's `autocomplete(name)` matches the focused **option**, not the command,
@@ -405,8 +401,11 @@ hands off to an operation inside a `with_connection` block (its own AR
 connection, like every other bot thread). A malformed or failing event is logged
 and reported to the owner rather than killing the listener.
 
-Four event types are currently defined:
+Five event types are currently defined:
 
+- **`commands_sync`** — published with a `discord_id` whenever a plugin is toggled
+  for a server. The bot calls `GuildCommandSync#sync` for that guild, re-running the
+  filtered bulk-overwrite so the command list reflects the new plugin state immediately.
 - **`roles_post`** — published per surviving role set after a successful web save
   when the roles plugin is enabled. The bot calls `Roles::MessagePoster.post`,
   which edits the set's existing message in place if `message_id` is set, or

--- a/spec/bot/bot_config_spec.rb
+++ b/spec/bot/bot_config_spec.rb
@@ -24,12 +24,6 @@ RSpec.describe BotConfig do
     end
   end
 
-  describe ".test_server_id" do
-    it "reads TEST_SERVER_ID from the environment" do
-      with_env("TEST_SERVER_ID", "42") { expect(described_class.test_server_id).to eq("42") }
-    end
-  end
-
   describe ".web_base_url" do
     it "reads WEB_BASE_URL from the environment" do
       with_env("WEB_BASE_URL", "https://shrkbot.gg") { expect(described_class.web_base_url).to eq("https://shrkbot.gg") }

--- a/spec/bot/command_backfill_spec.rb
+++ b/spec/bot/command_backfill_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CommandBackfill do
+  subject(:handle) { described_class.new(event).handle }
+
+  let(:bot) { double("bot", servers: {111 => double("s1"), 222 => double("s2")}) }
+  let(:event) { double("event", bot:) }
+  let(:syncer) { instance_double(GuildCommandSync) }
+
+  before do
+    allow(GuildCommandSync).to receive(:new).with(bot).and_return(syncer)
+    allow(syncer).to receive(:sync)
+  end
+
+  it "syncs every server the bot knows about" do
+    handle
+    expect(syncer).to have_received(:sync).with(111)
+    expect(syncer).to have_received(:sync).with(222)
+  end
+end

--- a/spec/bot/command_payload_spec.rb
+++ b/spec/bot/command_payload_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "discordrb"
+
+RSpec.describe CommandPayload do
+  def build_registration(overrides = {})
+    BaseCommand::Registration.new(
+      overrides.fetch(:name, :test),
+      overrides.fetch(:description, "A test command"),
+      overrides.fetch(:permissions, []),
+      overrides.fetch(:owner_only, false),
+      overrides.fetch(:context, :guild),
+      overrides.fetch(:type, :chat_input),
+      overrides.fetch(:options_block, nil),
+      overrides.fetch(:plugin, nil)
+    )
+  end
+
+  describe "#to_h" do
+    context "with a chat_input command with options and permissions" do
+      subject(:payload) { described_class.new(registration).to_h }
+
+      let(:registration) do
+        build_registration(
+          name: :greet,
+          description: "Say hello",
+          permissions: [:manage_messages],
+          options_block: proc { |opts| opts.string("target", "Who to greet", required: true) }
+        )
+      end
+
+      it "includes name and description" do
+        expect(payload[:name]).to eq(:greet)
+        expect(payload[:description]).to eq("Say hello")
+      end
+
+      it "maps type to integer 1 for chat_input" do
+        expect(payload[:type]).to eq(1)
+      end
+
+      it "includes default_member_permissions as a string of bits" do
+        bits = Discordrb::Permissions.bits([:manage_messages]).to_s
+        expect(payload[:default_member_permissions]).to eq(bits)
+      end
+
+      it "includes options array" do
+        expect(payload[:options]).to be_an(Array)
+        expect(payload[:options]).not_to be_empty
+      end
+
+      it "omits contexts for a guild command" do
+        expect(payload).not_to have_key(:contexts)
+      end
+    end
+
+    context "with a message context-menu command" do
+      subject(:payload) { described_class.new(registration).to_h }
+
+      let(:registration) do
+        build_registration(
+          name: "Report as scam",
+          description: "",
+          type: :message,
+          options_block: nil
+        )
+      end
+
+      it "maps type to integer 3 for message" do
+        expect(payload[:type]).to eq(3)
+      end
+
+      it "has an empty description" do
+        expect(payload[:description]).to eq("")
+      end
+
+      it "omits options key when no options_block" do
+        expect(payload).not_to have_key(:options)
+      end
+    end
+
+    context "with a global command" do
+      subject(:payload) { described_class.new(registration).to_h }
+
+      let(:registration) do
+        build_registration(
+          context: :global,
+          name: :info,
+          description: "Bot info"
+        )
+      end
+
+      it "includes contexts as integers" do
+        expect(payload[:contexts]).to be_an(Array)
+        expect(payload[:contexts]).to all(be_an(Integer))
+      end
+    end
+
+    context "with a guild command" do
+      subject(:payload) { described_class.new(registration).to_h }
+
+      let(:registration) do
+        build_registration(context: :guild)
+      end
+
+      it "omits contexts key" do
+        expect(payload).not_to have_key(:contexts)
+      end
+    end
+
+    context "with no permissions" do
+      subject(:payload) { described_class.new(registration).to_h }
+
+      let(:registration) do
+        build_registration(permissions: [])
+      end
+
+      it "omits default_member_permissions key" do
+        expect(payload).not_to have_key(:default_member_permissions)
+      end
+    end
+  end
+end

--- a/spec/bot/command_registrar_spec.rb
+++ b/spec/bot/command_registrar_spec.rb
@@ -1,40 +1,34 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "discordrb"
 
 RSpec.describe CommandRegistrar do
-  # Records what the registrar pushes, standing in for Discordrb::Bot. We assert
-  # WE call the boundary correctly; discordrb's own behavior is not under test.
   let(:fake_bot) do
     Class.new do
-      attr_reader :defined, :handlers
+      attr_reader :handlers, :autocompletes
 
       def initialize
-        @defined = []
         @handlers = {}
         @autocompletes = []
-      end
-
-      attr_reader :autocompletes
-
-      def register_application_command(name, description, server_id:, default_member_permissions:, contexts:, type:, &block)
-        @defined << {name:, description:, server_id:, default_member_permissions:, contexts:, type:, block:}
       end
 
       def application_command(name, &block)
         @handlers[name] = block
       end
 
-      # Mirrors discordrb: the positional name matches the focused OPTION; the
-      # command is filtered via attributes[:command_name].
       def autocomplete(name = nil, attributes = {}, &block)
         @autocompletes << {name:, attributes:, block:}
       end
-    end.new
-  end
 
-  before do
-    allow(BotConfig).to receive(:test_server_id).and_return("srv_123")
+      def token
+        "Bot test-token"
+      end
+
+      def profile
+        Struct.new(:id).new(1)
+      end
+    end.new
   end
 
   let(:guild_cmd) do
@@ -54,77 +48,76 @@ RSpec.describe CommandRegistrar do
     end
   end
 
-  context "registering a :guild command" do
-    subject(:register_all) { described_class.new(fake_bot, commands: [guild_cmd]).register_all }
-
-    it "registers against the test server with its permissions" do
-      register_all
-      cmd = fake_bot.defined.sole
-      expect(cmd[:name]).to eq(:ping)
-      expect(cmd[:server_id]).to eq("srv_123")
-      expect(cmd[:default_member_permissions]).to eq([:manage_server])
-      expect(cmd[:contexts]).to be_nil
-      expect(cmd[:type]).to eq(:chat_input)
-    end
-  end
-
-  context "registering a context-menu command" do
-    let(:menu_cmd) do
-      Class.new(BaseCommand) do
-        command_name "Report as scam"
-        command_type :message
-        requires_permissions :manage_messages
-        register_in :guild
-      end
-    end
-
-    subject(:register_all) { described_class.new(fake_bot, commands: [menu_cmd]).register_all }
-
-    it "passes the :message type through to the boundary" do
-      register_all
-      cmd = fake_bot.defined.sole
-      expect(cmd[:type]).to eq(:message)
-      expect(cmd[:description]).to eq("")
-    end
-  end
-
-  context "registering a :global command" do
-    subject(:register_all) { described_class.new(fake_bot, commands: [global_cmd]).register_all }
-
-    it "registers with no server and DM-capable contexts" do
-      register_all
-      cmd = fake_bot.defined.sole
-      expect(cmd[:server_id]).to be_nil
-      expect(cmd[:contexts]).to eq(%i[server bot_dm])
-      expect(cmd[:default_member_permissions]).to be_nil # empty perms → nil, not []
-    end
-  end
-
-  context "registering a :global command in instant_global mode (dev)" do
-    subject(:register_all) { described_class.new(fake_bot, commands: [global_cmd], instant_global: true).register_all }
-
-    it "registers against the test server (appears instantly)" do
-      register_all
-      cmd = fake_bot.defined.sole
-      expect(cmd[:server_id]).to eq("srv_123") # guild-scoped → appears instantly
-      expect(cmd[:contexts]).to be_nil # guild commands are server-only
-    end
-  end
-
   context "handler dispatch" do
-    subject(:register_all) { described_class.new(fake_bot, commands: [global_cmd]).register_all }
+    subject(:register_all) { described_class.new(fake_bot, commands: [guild_cmd, global_cmd]).register_all }
 
     before do
-      register_all
-      allow(BotConfig).to receive(:owner_id).and_return(nil)
+      allow(Discordrb::API::Application).to receive(:bulk_overwrite_global_commands)
+      allow(Rails.env).to receive(:development?).and_return(false)
     end
 
-    it "attaches a handler that dispatches to the command class" do
+    it "attaches handlers for all registrable commands" do
+      register_all
+      expect(fake_bot.handlers.key?(:ping)).to be(true)
       expect(fake_bot.handlers.key?(:info)).to be(true)
+    end
 
+    it "dispatches to the command class on invocation" do
+      register_all
       event = double("event", user: double(id: 1), respond: nil)
       expect(global_cmd).to receive(:dispatch).with(event)
       fake_bot.handlers[:info].call(event)
+    end
+  end
+
+  context "with define_commands true and env not development" do
+    subject(:register_all) do
+      described_class.new(fake_bot, commands: [guild_cmd, global_cmd]).register_all
+    end
+
+    before do
+      allow(Rails.env).to receive(:development?).and_return(false)
+    end
+
+    it "calls bulk_overwrite_global_commands with only global command payloads" do
+      captured_payloads = nil
+      allow(Discordrb::API::Application).to receive(:bulk_overwrite_global_commands) do |_token, _id, payloads|
+        captured_payloads = payloads
+      end
+
+      register_all
+
+      expect(captured_payloads).not_to be_nil
+      names = captured_payloads.map { |p| p[:name] }
+      expect(names).to include(:info)
+      expect(names).not_to include(:ping)
+    end
+  end
+
+  context "in development environment" do
+    subject(:register_all) do
+      described_class.new(fake_bot, commands: [global_cmd]).register_all
+    end
+
+    before do
+      allow(Rails.env).to receive(:development?).and_return(true)
+    end
+
+    it "does not call bulk_overwrite_global_commands" do
+      expect(Discordrb::API::Application).not_to receive(:bulk_overwrite_global_commands)
+      register_all
+    end
+  end
+
+  context "with define_commands: false (a non-first shard)" do
+    subject(:register_all) do
+      described_class.new(fake_bot, commands: [global_cmd], define_commands: false).register_all
+    end
+
+    it "attaches the handler without calling bulk_overwrite_global_commands" do
+      expect(Discordrb::API::Application).not_to receive(:bulk_overwrite_global_commands)
+      register_all
+      expect(fake_bot.handlers.key?(:info)).to be(true)
     end
   end
 
@@ -139,69 +132,34 @@ RSpec.describe CommandRegistrar do
       end
     end
 
-    subject(:register_all) { described_class.new(fake_bot, commands: [picker, global_cmd]).register_all }
-
-    it "attaches an autocomplete handler filtered by command_name (not focused option) only for commands that define #autocomplete" do
-      register_all
-
-      expect(fake_bot.autocompletes.size).to eq(1) # global_cmd has no #autocomplete
-      reg = fake_bot.autocompletes.first
-      expect(reg[:attributes][:command_name]).to eq(:pick) # matches the command…
-      expect(reg[:name]).to be_nil # …not a focused-option name
-    end
-  end
-
-  context "with define_commands: false (a non-first shard)" do
     subject(:register_all) do
-      described_class.new(fake_bot, commands: [global_cmd], define_commands: false).register_all
+      allow(Discordrb::API::Application).to receive(:bulk_overwrite_global_commands)
+      allow(Rails.env).to receive(:development?).and_return(false)
+      described_class.new(fake_bot, commands: [picker, global_cmd]).register_all
     end
 
-    it "attaches the handler without re-defining the command" do
+    it "attaches an autocomplete handler only for commands that define #autocomplete" do
       register_all
-      expect(fake_bot.defined).to be_empty
-      expect(fake_bot.handlers.key?(:info)).to be(true)
+      expect(fake_bot.autocompletes.size).to eq(1)
+      reg = fake_bot.autocompletes.first
+      expect(reg[:attributes][:command_name]).to eq(:pick)
+      expect(reg[:name]).to be_nil
     end
   end
 
   context "with non-registrable commands" do
-    subject(:register_all) { described_class.new(fake_bot, commands: [abstract]).register_all }
+    subject(:register_all) do
+      described_class.new(fake_bot, commands: [Class.new(BaseCommand)]).register_all
+    end
 
-    let(:abstract) { Class.new(BaseCommand) } # no command_name
+    before do
+      allow(Rails.env).to receive(:development?).and_return(false)
+      allow(Discordrb::API::Application).to receive(:bulk_overwrite_global_commands)
+    end
 
     it "skips them" do
       register_all
-      expect(fake_bot.defined).to be_empty
-    end
-  end
-
-  context "without a test server id" do
-    before do
-      allow(BotConfig).to receive(:test_server_id).and_return(nil)
-    end
-
-    context "registering a :guild command" do
-      subject(:register_all) { described_class.new(fake_bot, commands: [guild_cmd]).register_all }
-
-      before do
-        allow(Rails.logger).to receive(:warn)
-      end
-
-      it "skips it (and their handler) rather than registering globally" do
-        register_all
-
-        expect(fake_bot.defined).to be_empty
-        expect(fake_bot.handlers).to be_empty
-        expect(Rails.logger).to have_received(:warn).with(/skipping :guild command \/ping/)
-      end
-    end
-
-    context "registering a :global command" do
-      subject(:register_all) { described_class.new(fake_bot, commands: [global_cmd]).register_all }
-
-      it "still registers it" do
-        register_all
-        expect(fake_bot.defined.map { |c| c[:name] }).to eq([:info])
-      end
+      expect(fake_bot.handlers).to be_empty
     end
   end
 end

--- a/spec/bot/command_setup_spec.rb
+++ b/spec/bot/command_setup_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CommandSetup do
+  subject(:handle) { described_class.new(event).handle }
+
+  let(:server) { double("server", id: 77) }
+  let(:bot) { double("bot") }
+  let(:event) { double("event", server:, bot:) }
+  let(:syncer) { instance_double(GuildCommandSync) }
+
+  before do
+    allow(GuildCommandSync).to receive(:new).with(bot).and_return(syncer)
+    allow(syncer).to receive(:sync)
+  end
+
+  it "syncs commands for the joined server" do
+    handle
+    expect(syncer).to have_received(:sync).with(77)
+  end
+end

--- a/spec/bot/config_subscriber_spec.rb
+++ b/spec/bot/config_subscriber_spec.rb
@@ -45,6 +45,21 @@ RSpec.describe ConfigSubscriber do
       end
     end
 
+    context "with a commands_sync event" do
+      let(:syncer) { instance_double(GuildCommandSync) }
+      let(:payload) { JSON.generate(type: "commands_sync", discord_id: 99_999) }
+
+      before do
+        allow(GuildCommandSync).to receive(:new).with(bot).and_return(syncer)
+        allow(syncer).to receive(:sync)
+      end
+
+      it "syncs commands for the given discord_id" do
+        subscriber.handle(payload)
+        expect(syncer).to have_received(:sync).with(99_999)
+      end
+    end
+
     context "with an unknown event type" do
       let(:payload) { JSON.generate(type: "something_else", set_id: "x") }
 

--- a/spec/bot/guild_command_set_spec.rb
+++ b/spec/bot/guild_command_set_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "discordrb"
+
+RSpec.describe GuildCommandSet do
+  let(:server) { create(:server_configuration) }
+  let(:discord_id) { server.discord_id }
+
+  let(:moderation_plugin) { create(:plugin, key: "moderation", name: "Server Shield") }
+  let(:image_scanning_plugin) { create(:plugin, key: "image_scanning", name: "Scam Image Detection") }
+
+  def make_command(name:, plugin_key: nil, context: :guild)
+    Class.new(BaseCommand) do
+      command_name name
+      description "test"
+      register_in context
+      plugin plugin_key if plugin_key
+    end
+  end
+
+  let(:plugin_less_cmd) { make_command(name: :ping) }
+  let(:image_scanning_cmd) { make_command(name: :report_scam, plugin_key: :image_scanning) }
+  let(:global_cmd) { make_command(name: :info, context: :global) }
+
+  describe "#payloads" do
+    subject(:payloads) { described_class.new(discord_id, commands: commands).payloads }
+
+    context "plugin-less guild command" do
+      let(:commands) { [plugin_less_cmd] }
+
+      it "is always included" do
+        expect(payloads.map { |p| p[:name] }).to include(:ping)
+      end
+    end
+
+    context "plugin command when activation is missing" do
+      let(:commands) { [image_scanning_cmd] }
+
+      it "is excluded" do
+        expect(payloads).to be_empty
+      end
+    end
+
+    context "plugin command when activation is disabled" do
+      let(:commands) { [image_scanning_cmd] }
+
+      before do
+        create(:plugin_activation, server_configuration: server, plugin: image_scanning_plugin, enabled: false)
+      end
+
+      it "is excluded" do
+        expect(payloads).to be_empty
+      end
+    end
+
+    context "plugin command with the full moderation chain enabled" do
+      let(:commands) { [image_scanning_cmd] }
+      let(:logging_plugin) { create(:plugin, key: "logging", name: "Logging") }
+
+      let(:moderation_activation) do
+        PluginActivation.find_by!(server_configuration: server, plugin: moderation_plugin)
+      end
+
+      before do
+        create(:logging_setting, server_configuration: server)
+        create(:plugin_activation, server_configuration: server, plugin: logging_plugin, enabled: true)
+        create(:moderation_settings, server_configuration: server, staff_role_id: 888)
+        create(:plugin_activation, server_configuration: server, plugin: moderation_plugin, enabled: true)
+        create(:plugin_activation, server_configuration: server, plugin: image_scanning_plugin, enabled: true)
+      end
+
+      it "is included" do
+        expect(payloads.map { |p| p[:name] }).to include(:report_scam)
+      end
+
+      context "when the parent is later disabled" do
+        before do
+          moderation_activation.update!(enabled: false)
+        end
+
+        it "is excluded" do
+          expect(payloads).to be_empty
+        end
+      end
+    end
+
+    context "plugin command whose key has no PluginCatalog definition" do
+      let(:custom_plugin) { create(:plugin, key: "custom", name: "Custom") }
+      let(:custom_cmd) { make_command(name: :custom, plugin_key: :custom) }
+      let(:commands) { [custom_cmd] }
+
+      before do
+        create(:plugin_activation, server_configuration: server, plugin: custom_plugin, enabled: true)
+      end
+
+      it "is included when its activation is enabled" do
+        expect(payloads.map { |p| p[:name] }).to include(:custom)
+      end
+    end
+
+    context "when there is no ServerConfiguration row" do
+      let(:discord_id) { 999_999_999 }
+      let(:commands) { [plugin_less_cmd, image_scanning_cmd] }
+
+      it "includes only plugin-less commands" do
+        expect(payloads.map { |p| p[:name] }).to eq([:ping])
+      end
+    end
+
+    context "global command in test environment (not development)" do
+      let(:commands) { [global_cmd] }
+
+      it "is excluded" do
+        expect(payloads).to be_empty
+      end
+    end
+
+    context "global command when Rails.env is development" do
+      let(:commands) { [global_cmd] }
+
+      before do
+        allow(Rails.env).to receive(:development?).and_return(true)
+      end
+
+      it "is included" do
+        expect(payloads.map { |p| p[:name] }).to include(:info)
+      end
+    end
+  end
+end

--- a/spec/bot/guild_command_sync_spec.rb
+++ b/spec/bot/guild_command_sync_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "discordrb"
+
+RSpec.describe GuildCommandSync do
+  let(:profile) { double("profile", id: 42) }
+  let(:bot) { double("bot", token: "Bot tok123", profile:) }
+  let(:discord_id) { 12_345 }
+  let(:payloads) { [{name: "ping", description: "test", type: 1}] }
+
+  before do
+    allow(GuildCommandSet).to receive(:new).with(discord_id).and_return(
+      instance_double(GuildCommandSet, payloads:)
+    )
+  end
+
+  describe "#sync" do
+    subject(:sync) { described_class.new(bot).sync(discord_id) }
+
+    it "calls bulk_overwrite_guild_commands with the right arguments" do
+      expect(Discordrb::API::Application).to receive(:bulk_overwrite_guild_commands).with(
+        "Bot tok123",
+        42,
+        discord_id,
+        payloads
+      )
+      sync
+    end
+
+    context "when the API call raises" do
+      before do
+        allow(Discordrb::API::Application).to receive(:bulk_overwrite_guild_commands).and_raise(
+          StandardError, "network failure"
+        )
+        allow(Rails.logger).to receive(:error)
+      end
+
+      it "logs the error" do
+        sync
+        expect(Rails.logger).to have_received(:error).with(
+          a_string_including("[GuildCommandSync]", discord_id.to_s, "StandardError", "network failure")
+        )
+      end
+
+      it "does not re-raise" do
+        expect { sync }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/operations/server_configuration/plugins/toggle_spec.rb
+++ b/spec/operations/server_configuration/plugins/toggle_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe Ops::ServerConfiguration::Plugins::Toggle do
   let(:roles) { create(:plugin, key: "roles", name: "Roles") }
   let(:welcomes) { create(:plugin, key: "welcomes", name: "Welcomes") }
 
+  before do
+    allow(ConfigBus).to receive(:sync_commands)
+  end
+
   context "with a raw checkbox value (form param, not yet cast)" do
     let(:plugin) { roles }
 
@@ -121,6 +125,40 @@ RSpec.describe Ops::ServerConfiguration::Plugins::Toggle do
     end
   end
 
+  context "sync_commands is published on every successful toggle" do
+    before do
+      allow(ConfigBus).to receive(:post_roles)
+      allow(ConfigBus).to receive(:remove_roles_menu)
+    end
+
+    context "when enabling logging" do
+      let(:plugin) { logging }
+      let(:enabled) { true }
+
+      before { server.create_logging_setting!(channel_id: 999) }
+
+      it "publishes sync_commands" do
+        result
+        expect(ConfigBus).to have_received(:sync_commands).with(server)
+      end
+    end
+
+    context "when disabling logging" do
+      let(:plugin) { logging }
+      let(:enabled) { false }
+
+      before do
+        server.create_logging_setting!(channel_id: 999)
+        create(:plugin_activation, server_configuration: server, plugin: logging, enabled: true)
+      end
+
+      it "publishes sync_commands" do
+        result
+        expect(ConfigBus).to have_received(:sync_commands).with(server)
+      end
+    end
+  end
+
   context "toggling roles publishes menu sync" do
     let(:plugin) { roles }
 
@@ -189,6 +227,7 @@ RSpec.describe Ops::ServerConfiguration::Plugins::Toggle do
 
     it "publishes nothing when the operation is refused" do
       result
+      expect(ConfigBus).not_to have_received(:sync_commands)
       expect(ConfigBus).not_to have_received(:post_roles)
       expect(ConfigBus).not_to have_received(:remove_roles_menu)
     end


### PR DESCRIPTION
## Why

Guild commands (`register_in :guild`) were only ever registered to `TEST_SERVER_ID` — a dev-time stopgap. Production has no `TEST_SERVER_ID`, so **no guild command existed on any real server** (`/ping`, `Report as scam`). Surfaced while debugging why the report-scam context menu never showed up.

## What

Per-guild bulk overwrites, filtered by each guild's enabled plugins:

- **`CommandPayload`** — turns a `Registration` into the Discord bulk-overwrite JSON (type mapping, permission bits, options, contexts).
- **`GuildCommandSet`** — the desired command list for one guild: plugin-less guild commands always; plugin-tied commands only where that plugin (and its catalog parent) is enabled; in development, global commands fold in for instant appearance (replaces `instant_global`).
- **`GuildCommandSync`** — the REST PUT (`bulk_overwrite_guild_commands`), rescuing only the API boundary.
- **Triggers:** `CommandBackfill` (ready, all shard guilds), `CommandSetup` (server join), and a new `commands_sync` ConfigBus event published by `Ops::ServerConfiguration::Plugins::Toggle` — so toggling a plugin on the website updates the guild's command list immediately.
- **`BaseCommand.plugin :key`** macro ties a command to a `PluginCatalog` key; `Report as scam` declares `plugin :image_scanning`.
- **`CommandRegistrar`** slims to handler attachment + production-only global bulk overwrite (shard 0). `TEST_SERVER_ID` removed from code, `.env.example`, README, and docs.

## Notes

- `define_global` deliberately has no rescue: it runs at process start before the gateway connects, so a Discord API failure fails the boot loudly instead of starting a bot with stale global commands.
- Registration hides commands per guild; execution-side gating is unchanged (Discord rejects interactions for unregistered commands).
- Docs updated: `architecture.md` registration section, `adding-a-command.md`.

## Gates

rspec 1636/0 · standardrb · active_record_doctor · undercover vs origin/main — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)