### PR TITLE
Trust Discord-native command permissions at runtime

### DIFF
--- a/app/bot/announce_modal.rb
+++ b/app/bot/announce_modal.rb
@@ -20,7 +20,7 @@ class AnnounceModal < BaseEvent
   end
 
   def owner?
-    CommandPermissions.permitted?(event:, required: [], owner_only: true)
+    CommandPermissions.permitted?(event:, owner_only: true)
   end
 
   def reject

--- a/app/bot/base_command.rb
+++ b/app/bot/base_command.rb
@@ -126,7 +126,6 @@ class BaseCommand
   def permitted?
     CommandPermissions.permitted?(
       event:,
-      required: self.class.requires_permissions,
       owner_only: self.class.owner_only?
     )
   end

--- a/app/bot/command_permissions.rb
+++ b/app/bot/command_permissions.rb
@@ -3,15 +3,10 @@
 module CommandPermissions
   module_function
 
-  def permitted?(event:, required:, owner_only:)
+  def permitted?(event:, owner_only:)
     return true if owner?(event)
-    return false if owner_only
-    return true if required.empty?
 
-    member = event.user
-    return false unless member.respond_to?(:permission?)
-
-    required.all? { |perm| member.permission?(perm) }
+    !owner_only
   end
 
   def owner?(event)

--- a/app/bot/commands/info.rb
+++ b/app/bot/commands/info.rb
@@ -47,11 +47,7 @@ module Commands
     def configurable?
       return false unless event.server_id
 
-      CommandPermissions.permitted?(
-        event:,
-        required: [:manage_server],
-        owner_only: false
-      )
+      CommandPermissions.owner?(event) || event.user.permission?(:manage_server)
     end
 
     def header

--- a/app/plugins/moderation/commands/report_scam.rb
+++ b/app/plugins/moderation/commands/report_scam.rb
@@ -23,12 +23,6 @@ module Moderation
 
     private
 
-    def permitted?
-      return true if super
-
-      StaffGate.allows?(event.user, config.moderation_settings.staff_role_id)
-    end
-
     def config
       @config ||= ServerConfiguration.find_by(discord_id: event.server.id)
     end

--- a/docs/adding-a-command.md
+++ b/docs/adding-a-command.md
@@ -46,8 +46,14 @@ end
 - `plugin :key` — optional; ties a guild command to a `PluginCatalog` key so it only
   registers in guilds where that plugin is enabled. Omit for always-on guild commands
   (e.g. `/ping`).
-- `requires_permissions :a, :b` — native Discord permission symbols; all must be held.
-  Omit for an everyone-command. The `OWNER_ID` env var is a global override.
+- `requires_permissions :a, :b` — native Discord permission symbols sent as
+  `default_member_permissions`. Discord enforces them server-side; guild admins can
+  override per role/member/channel in Server Settings → Integrations. The bot does not
+  re-check these at runtime — Discord's enforcement and admin overrides are
+  authoritative. Staff-only commands (e.g. the Report-as-scam context menu) default to
+  Manage Messages; a server whose staff role lacks that permission grants it an
+  Integrations override instead. Omit for an everyone-command. The `OWNER_ID` env var
+  is a separate bot-level override for `owner_only` commands.
 - `owner_only` — restrict to the configured owner.
 - `options { … }` — a discordrb `OptionBuilder` block (`string`/`integer`/`boolean`/`user`/`subcommand`/…).
 - `command_type :chat_input | :message | :user` — defaults to `:chat_input` (the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -183,12 +183,14 @@ events subclass `BaseCommand` / `BaseEvent` and auto-register via `.descendants`
 ### Permissions
 
 Permissions are native Discord permission bits declared per command via
-`requires_permissions :moderate_members`. The registrar sets
-`default_member_permissions` from the declaration, so Discord hides and gates the
-command. `CommandPermissions` **re-checks at runtime** — guild admins can override
-command permissions in Discord's integrations UI, so the client-side hiding can't be
-trusted alone. The `OWNER_ID` env var is a global creator override; a command with no
-declaration is available to everyone.
+`requires_permissions :moderate_members`; the registrar sends them as
+`default_member_permissions`. Discord enforces them server-side, and guild admins can
+retune access per role, member, or channel in Server Settings → Integrations. Those
+overrides are authoritative — the bot does not re-check permission bits at runtime, or
+it would veto users an admin deliberately allowed.
+
+`owner_only` combined with the `OWNER_ID` env var remain runtime checks — a bot-level
+concept Discord can't express. A command with no declaration is available to everyone.
 
 ### Registration context
 

--- a/spec/bot/base_command_spec.rb
+++ b/spec/bot/base_command_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe BaseCommand do
   end
 
   describe "#dispatch template" do
-    let(:event) { double("event", user: double(id: 1), member: double(permission?: true), respond: nil, bot: double("bot")) }
+    let(:event) { double("event", user: double(id: 1), respond: nil, bot: double("bot")) }
 
     def command_class(&body)
       Class.new(described_class) do
@@ -123,13 +123,17 @@ RSpec.describe BaseCommand do
       end
     end
 
-    context "when not permitted" do
+    context "when not permitted (owner_only command, non-owner user)" do
       subject(:dispatch) { klass.dispatch(denied_event) }
+
+      before do
+        allow(BotConfig).to receive(:owner_id).and_return("99")
+      end
 
       let(:klass) do
         Class.new(described_class) do
           command_name :probe
-          requires_permissions :manage_server
+          owner_only
 
           def execute
             raise "should not run"
@@ -138,9 +142,7 @@ RSpec.describe BaseCommand do
       end
 
       let(:denied_event) do
-        double("event", user: double(id: 1), member: double, respond: nil).tap do |e|
-          allow(e.member).to receive(:permission?).with(:manage_server).and_return(false)
-        end
+        double("event", user: double(id: 1), respond: nil)
       end
 
       it "replies with a denial and skips #execute" do

--- a/spec/bot/command_permissions_spec.rb
+++ b/spec/bot/command_permissions_spec.rb
@@ -3,18 +3,13 @@
 require "rails_helper"
 
 RSpec.describe CommandPermissions do
-  def event_for(user_id:, with_guild_member: false)
-    user =
-      if with_guild_member
-        double("member", id: user_id, permission?: false)
-      else
-        double("user", id: user_id)
-      end
+  def event_for(user_id:)
+    user = double("user", id: user_id)
     double("event", user:)
   end
 
   describe ".permitted?" do
-    subject(:permitted) { described_class.permitted?(event:, required:, owner_only:) }
+    subject(:permitted) { described_class.permitted?(event:, owner_only:) }
 
     context "when the user is the configured owner" do
       before do
@@ -24,8 +19,15 @@ RSpec.describe CommandPermissions do
       let(:event) { event_for(user_id: 42) }
 
       context "requesting owner_only" do
-        let(:required) { [:manage_server] }
         let(:owner_only) { true }
+
+        it "grants access" do
+          is_expected.to be(true)
+        end
+      end
+
+      context "plain command" do
+        let(:owner_only) { false }
 
         it "grants access" do
           is_expected.to be(true)
@@ -38,8 +40,7 @@ RSpec.describe CommandPermissions do
         allow(BotConfig).to receive(:owner_id).and_return("42")
       end
 
-      let(:event) { event_for(user_id: 7, with_guild_member: true) }
-      let(:required) { [] }
+      let(:event) { event_for(user_id: 7) }
       let(:owner_only) { true }
 
       it "denies access" do
@@ -47,72 +48,16 @@ RSpec.describe CommandPermissions do
       end
     end
 
-    context "when no owner is configured and command requires no permissions" do
+    context "when no owner is configured and command is not owner_only" do
       before do
         allow(BotConfig).to receive(:owner_id).and_return(nil)
       end
 
-      let(:event) { event_for(user_id: 7, with_guild_member: true) }
-      let(:required) { [] }
+      let(:event) { event_for(user_id: 7) }
       let(:owner_only) { false }
 
       it "grants access" do
         is_expected.to be(true)
-      end
-    end
-
-    context "when multiple permissions are required and member lacks one" do
-      before do
-        allow(BotConfig).to receive(:owner_id).and_return(nil)
-      end
-
-      let(:user) do
-        double("member", id: 7).tap do |m|
-          allow(m).to receive(:permission?).with(:manage_server).and_return(true)
-          allow(m).to receive(:permission?).with(:ban_members).and_return(false)
-        end
-      end
-
-      let(:event) { double("event", user:) }
-      let(:required) { %i[manage_server ban_members] }
-      let(:owner_only) { false }
-
-      it "denies access" do
-        is_expected.to be(false)
-      end
-    end
-
-    context "when a single required permission is held" do
-      before do
-        allow(BotConfig).to receive(:owner_id).and_return(nil)
-      end
-
-      let(:user) do
-        double("member", id: 7).tap do |m|
-          allow(m).to receive(:permission?).with(:manage_server).and_return(true)
-        end
-      end
-
-      let(:event) { double("event", user:) }
-      let(:required) { [:manage_server] }
-      let(:owner_only) { false }
-
-      it "grants access" do
-        is_expected.to be(true)
-      end
-    end
-
-    context "when a permission-gated command is used in a DM (plain user without permission?)" do
-      before do
-        allow(BotConfig).to receive(:owner_id).and_return(nil)
-      end
-
-      let(:event) { double("event", user: double("user", id: 7)) }
-      let(:required) { [:manage_server] }
-      let(:owner_only) { false }
-
-      it "denies access" do
-        is_expected.to be(false)
       end
     end
   end

--- a/spec/plugins/moderation/commands/report_scam_spec.rb
+++ b/spec/plugins/moderation/commands/report_scam_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Moderation::ReportScam do
   let(:message_author) { double("author", id: author_id) }
   let(:target) { double("message", attachments:, author: message_author, delete: nil) }
   let(:server) { double("server", id: guild_id) }
-  let(:user) { double("user", id: 555, roles: [], permission?: true) }
+  let(:user) { double("user", id: 555) }
   let(:channel) { double("channel", id: channel_id) }
   let(:bot) { double("bot") }
   let(:event) do
@@ -174,95 +174,6 @@ RSpec.describe Moderation::ReportScam do
 
       expect(ActivityLog).not_to have_received(:post)
       expect(target).not_to have_received(:delete)
-    end
-  end
-
-  describe "call-level permission gate" do
-    subject(:call) { described_class.new(event).call }
-
-    before do
-      allow(BotConfig).to receive(:owner_id).and_return(nil)
-    end
-
-    context "when the user has the staff role but not manage_messages" do
-      let(:staff_role) { double("role", id: 999) }
-      let(:user) { double("user", id: 555, roles: [staff_role], permission?: false) }
-      let(:event) do
-        double(
-          "event",
-          target:,
-          server:,
-          user:,
-          channel:,
-          bot:,
-          defer: nil,
-          edit_response: nil,
-          respond: nil
-        )
-      end
-
-      before do
-        allow(config).to receive(:moderation_settings).and_return(
-          double("moderation_settings", staff_role_id: 999)
-        )
-      end
-
-      it "reaches execute and defers" do
-        call
-        expect(event).to have_received(:defer).with(ephemeral: true)
-      end
-    end
-
-    context "when the user has neither the staff role nor manage_messages" do
-      let(:other_role) { double("role", id: 777) }
-      let(:user) { double("user", id: 555, roles: [other_role], permission?: false) }
-      let(:event) do
-        double(
-          "event",
-          target:,
-          server:,
-          user:,
-          channel:,
-          bot:,
-          defer: nil,
-          edit_response: nil,
-          respond: nil
-        )
-      end
-
-      before do
-        allow(config).to receive(:moderation_settings).and_return(
-          double("moderation_settings", staff_role_id: 999)
-        )
-      end
-
-      it "responds with unauthorized and never defers" do
-        call
-        expect(event).to have_received(:respond).with(hash_including(ephemeral: true))
-        expect(event).not_to have_received(:defer)
-      end
-    end
-
-    context "when the user has manage_messages without the staff role" do
-      let(:user) { double("user", id: 555, roles: [], permission?: true) }
-      let(:event) do
-        double(
-          "event",
-          target:,
-          server:,
-          user:,
-          channel:,
-          bot:,
-          defer: nil,
-          edit_response: nil,
-          respond: nil
-        )
-      end
-
-      it "reaches execute and defers" do
-        call
-        expect(event).to have_received(:defer).with(ephemeral: true)
-      end
     end
   end
 end


### PR DESCRIPTION
**Stacked on #127** — merge that first, then retarget/merge this.

## Why

`requires_permissions` was double-enforced: once by Discord (`default_member_permissions`, server-side since permissions v2) and again by our runtime re-check. The re-check vetoes exactly the users a guild admin deliberately allowed via a Server Settings → Integrations override — e.g. a staff role granted access to `Report as scam` without holding Manage Messages. The old `StaffGate` escape hatch on that command only papered over this for one role on one command.

## What

- `CommandPermissions` no longer re-checks permission bits; it's now purely the `owner_only`/`OWNER_ID` gate (a bot-level concept Discord can't express). `requires_permissions` remains registration-time metadata feeding `default_member_permissions`.
- `ReportScam` drops its `StaffGate` `permitted?` override. A staff role without Manage Messages gets an Integrations override instead — that's now the documented pattern. `StaffGate` itself stays for the confirm/dismiss **components**, which have no native permission gating.
- `Info#configurable?` keeps its manage-server display condition via a direct member check (it was never a security gate — just whether to show the dashboard link).
- Docs: `architecture.md` Permissions section rewritten (old rationale predated permissions v2); `adding-a-command.md` `requires_permissions` bullet updated with the staff-command pattern.

Net −190 lines.

## Follow-up (flagged, not included)

Website warning when the configured staff role lacks Manage Messages — needs role permission bits synced onto `ServerRole` (migration + metadata sync + privacy-policy update), so it's its own chunk.

## Gates

rspec 1631/0 · standardrb · active_record_doctor · undercover vs origin/main — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)