### PR TITLE
Warn when the staff role lacks Manage Messages

### DIFF
--- a/app/bot/guild_metadata.rb
+++ b/app/bot/guild_metadata.rb
@@ -37,7 +37,7 @@ module GuildMetadata
 
   def roles(server)
     server.roles.map do |role|
-      {discord_id: role.id, name: role.name, position: role.position, managed: role.managed?, color: role.color.combined}
+      {discord_id: role.id, name: role.name, position: role.position, managed: role.managed?, color: role.color.combined, permissions: role.permissions.bits}
     end
   end
 

--- a/app/components/moderation/overview_form.rb
+++ b/app/components/moderation/overview_form.rb
@@ -14,7 +14,8 @@ class Components::Moderation::OverviewForm < Components::Base
         server_configuration: @config,
         staff_role_id: @context.staff_role_id,
         missing: !@context.staff_role_present?,
-        permission_warning: @context.permission_warning?
+        permission_warning: @context.permission_warning?,
+        staff_permission_warning: @context.staff_permission_warning?
       )
       render Components::Moderation::SubPluginDirectory.new(
         server_configuration: @config,

--- a/app/components/moderation/staff_role_card.rb
+++ b/app/components/moderation/staff_role_card.rb
@@ -3,11 +3,12 @@
 class Components::Moderation::StaffRoleCard < Components::Base
   DEFAULT_COLOR = "#99aab5"
 
-  def initialize(server_configuration:, staff_role_id:, missing:, permission_warning:)
+  def initialize(server_configuration:, staff_role_id:, missing:, permission_warning:, staff_permission_warning:)
     @config = server_configuration
     @staff_role_id = staff_role_id
     @missing = missing
     @permission_warning = permission_warning
+    @staff_permission_warning = staff_permission_warning
   end
 
   def view_template
@@ -29,7 +30,8 @@ class Components::Moderation::StaffRoleCard < Components::Base
       )
       missing_warning if @missing
       p(class: "mt-1.5 text-xs text-text-muted") { t(".help") } unless @missing
-      permission_warning_callout if @permission_warning
+      warning_callout(t(".permission_warning_bold"), t(".permission_warning_body")) if @permission_warning
+      warning_callout(t(".staff_permission_warning_bold"), t(".staff_permission_warning_body")) if @staff_permission_warning
     end
   end
 
@@ -58,14 +60,14 @@ class Components::Moderation::StaffRoleCard < Components::Base
     end
   end
 
-  def permission_warning_callout
+  def warning_callout(bold, body)
     div(class: "mt-3") do
       render Components::Callout.new(variant: :warning) do
         plain ""
         span do
-          b(class: "text-warning") { t(".permission_warning_bold") }
+          b(class: "text-warning") { bold }
           whitespace
-          plain t(".permission_warning_body")
+          plain body
         end
       end
     end

--- a/app/models/server_role.rb
+++ b/app/models/server_role.rb
@@ -5,4 +5,11 @@ class ServerRole < ApplicationRecord
 
   validates :discord_id, presence: true, uniqueness: {scope: :server_configuration_id}
   validates :name, presence: true
+
+  MANAGE_MESSAGES = 1 << 13
+  ADMINISTRATOR = 1 << 3
+
+  def manage_messages?
+    permissions.anybits?(MANAGE_MESSAGES | ADMINISTRATOR)
+  end
 end

--- a/app/operations/server_configuration/server_roles/sync.rb
+++ b/app/operations/server_configuration/server_roles/sync.rb
@@ -9,7 +9,7 @@ module Ops
         def call
           roles.each do |data|
             role = server_configuration.server_roles.find_or_initialize_by(discord_id: data[:discord_id])
-            role.update!(name: data[:name], position: data[:position], managed: data[:managed], color: data[:color] || 0)
+            role.update!(name: data[:name], position: data[:position], managed: data[:managed], color: data[:color] || 0, permissions: data[:permissions] || 0)
           end
           server_configuration.server_roles.where.not(discord_id: roles.map { |r| r[:discord_id] }).delete_all
           server_configuration.update!(bot_role_position:)

--- a/app/presenters/moderation/overview_context.rb
+++ b/app/presenters/moderation/overview_context.rb
@@ -35,6 +35,13 @@ module Moderation
       false
     end
 
+    def staff_permission_warning?
+      return false unless staff_role_id
+
+      role = @config.server_roles.find_by(discord_id: staff_role_id)
+      role.present? && !role.manage_messages?
+    end
+
     def sub_plugin_rows
       SUB_PLUGINS.map do |sub|
         key = sub[:key]

--- a/config/locales/legal.en.yml
+++ b/config/locales/legal.en.yml
@@ -51,11 +51,11 @@ en:
         to read which servers you manage.'
       data_guild: 'Server configuration: the server''s Discord ID, name, icon reference
         and approximate member count, plus a cached copy of its channels and roles
-        (IDs, names, types, colours, positions) and their permission overwrites —
-        which can reference member Discord IDs — mirrored from Discord so the dashboard
-        can display and apply your setup. Also which plugins are enabled, and the
-        welcome, logging, role-menu and moderation settings admins configure — including
-        any custom scam-keyword list.'
+        (IDs, names, types, colours, positions, permission sets) and their permission
+        overwrites — which can reference member Discord IDs — mirrored from Discord
+        so the dashboard can display and apply your setup. Also which plugins are
+        enabled, and the welcome, logging, role-menu and moderation settings admins
+        configure — including any custom scam-keyword list.'
       data_h: What we store and why
       data_lead: 'We store only what the enabled features need:'
       data_notifications: 'Dashboard notifications: short activity entries (an event

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -183,6 +183,11 @@ en:
           until it's restored.
         permission_warning_bold: Staff pings will fail.
         placeholder: Pick a role…
+        staff_permission_warning_body: It doesn't have the Manage Messages permission,
+          so its members won't see staff-only commands like Report as scam. Give the
+          role Manage Messages, or grant it access under Server Settings → Integrations
+          → shrkbot.
+        staff_permission_warning_bold: This role can't see staff commands.
       sub_plugin_directory:
         eyebrow: Sub-plugins
       sub_plugin_row:

--- a/db/migrate/20260710214856_add_permissions_to_server_roles.rb
+++ b/db/migrate/20260710214856_add_permissions_to_server_roles.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPermissionsToServerRoles < ActiveRecord::Migration[8.1]
+  def change
+    add_column :server_roles, :permissions, :bigint, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_08_222812) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_10_214856) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -56,11 +56,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_08_222812) do
     t.integer "timeout_seconds", default: 3600, null: false
     t.datetime "updated_at", null: false
     t.index ["server_configuration_id"], name: "index_image_scanning_settings_on_server_configuration_id", unique: true
-    t.check_constraint "action::text = ANY (ARRAY['none'::character varying, 'delete'::character varying]::text[])", name: "image_scanning_settings_action_check"
+    t.check_constraint "action::text = ANY (ARRAY['none'::character varying::text, 'delete'::character varying::text])", name: "image_scanning_settings_action_check"
     t.check_constraint "cardinality(custom_keywords) <= 200", name: "image_scanning_settings_custom_keywords_count_check"
     t.check_constraint "custom_keyword_min_hits >= 1 AND (cardinality(custom_keywords) = 0 OR custom_keyword_min_hits <= cardinality(custom_keywords))", name: "image_scanning_settings_min_hits_check"
-    t.check_constraint "punishment::text = ANY (ARRAY['none'::character varying, 'timeout'::character varying, 'kick'::character varying, 'ban'::character varying]::text[])", name: "image_scanning_settings_punishment_check"
-    t.check_constraint "sensitivity::text = ANY (ARRAY['relaxed'::character varying, 'standard'::character varying, 'strict'::character varying]::text[])", name: "image_scanning_settings_sensitivity_check"
+    t.check_constraint "punishment::text = ANY (ARRAY['none'::character varying::text, 'timeout'::character varying::text, 'kick'::character varying::text, 'ban'::character varying::text])", name: "image_scanning_settings_punishment_check"
+    t.check_constraint "sensitivity::text = ANY (ARRAY['relaxed'::character varying::text, 'standard'::character varying::text, 'strict'::character varying::text])", name: "image_scanning_settings_sensitivity_check"
     t.check_constraint "timeout_seconds >= 60 AND timeout_seconds <= 2419200", name: "image_scanning_settings_timeout_seconds_check"
   end
 
@@ -100,7 +100,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_08_222812) do
     t.string "verdict", null: false
     t.index ["phash_id", "server_configuration_id"], name: "idx_on_phash_id_server_configuration_id_693185e6e1", unique: true
     t.index ["server_configuration_id"], name: "index_phash_confirmations_on_server_configuration_id"
-    t.check_constraint "verdict::text = ANY (ARRAY['confirmed'::character varying, 'dismissed'::character varying]::text[])", name: "phash_confirmations_verdict_check"
+    t.check_constraint "verdict::text = ANY (ARRAY['confirmed'::character varying::text, 'dismissed'::character varying::text])", name: "phash_confirmations_verdict_check"
   end
 
   create_table "phashes", id: :string, default: -> { "('phs_'::text || gen_random_uuid())" }, force: :cascade do |t|
@@ -195,6 +195,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_08_222812) do
     t.bigint "discord_id", null: false
     t.boolean "managed", default: false, null: false
     t.string "name", null: false
+    t.bigint "permissions", default: 0, null: false
     t.integer "position"
     t.string "server_configuration_id", null: false
     t.datetime "updated_at", null: false
@@ -334,9 +335,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_08_222812) do
     t.datetime "updated_at", null: false
     t.integer "window_seconds", default: 15, null: false
     t.index ["server_configuration_id"], name: "index_spam_protection_settings_on_server_configuration_id", unique: true
-    t.check_constraint "action::text = ANY (ARRAY['purge'::character varying, 'notify_only'::character varying]::text[])", name: "spam_protection_settings_action_check"
+    t.check_constraint "action::text = ANY (ARRAY['purge'::character varying::text, 'notify_only'::character varying::text])", name: "spam_protection_settings_action_check"
     t.check_constraint "channel_threshold >= 2 AND channel_threshold <= 500", name: "spam_protection_settings_channel_threshold_check"
-    t.check_constraint "punishment::text = ANY (ARRAY['none'::character varying, 'timeout'::character varying, 'kick'::character varying, 'ban'::character varying]::text[])", name: "spam_protection_settings_punishment_check"
+    t.check_constraint "punishment::text = ANY (ARRAY['none'::character varying::text, 'timeout'::character varying::text, 'kick'::character varying::text, 'ban'::character varying::text])", name: "spam_protection_settings_punishment_check"
     t.check_constraint "similarity >= 0.75::double precision AND similarity <= 1.0::double precision", name: "spam_protection_settings_similarity_check"
     t.check_constraint "timeout_seconds >= 60 AND timeout_seconds <= 2419200", name: "spam_protection_settings_timeout_seconds_check"
     t.check_constraint "window_seconds >= 1 AND window_seconds <= 60", name: "spam_protection_settings_window_seconds_check"

--- a/spec/bot/guild_metadata_spec.rb
+++ b/spec/bot/guild_metadata_spec.rb
@@ -27,10 +27,10 @@ RSpec.describe GuildMetadata do
   describe ".roles" do
     subject(:roles) { described_class.roles(server) }
 
-    let(:server) { double("server", roles: [double("role", id: 222, name: "Admin", position: 3, managed?: false, color: double(combined: 0x37a79e))]) }
+    let(:server) { double("server", roles: [double("role", id: 222, name: "Admin", position: 3, managed?: false, color: double(combined: 0x37a79e), permissions: double(bits: 8192))]) }
 
-    it "maps each role to a plain hash with its position, managed flag, and colour" do
-      expect(roles).to eq([{discord_id: 222, name: "Admin", position: 3, managed: false, color: 0x37a79e}])
+    it "maps each role to a plain hash with its position, managed flag, colour, and permissions" do
+      expect(roles).to eq([{discord_id: 222, name: "Admin", position: 3, managed: false, color: 0x37a79e, permissions: 8192}])
     end
   end
 

--- a/spec/components/moderation/overview_form_spec.rb
+++ b/spec/components/moderation/overview_form_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Components::Moderation::OverviewForm do
       staff_role_id: nil,
       staff_role_present?: false,
       permission_warning?: false,
+      staff_permission_warning?: false,
       sub_plugin_rows: []
     )
   end

--- a/spec/components/moderation/staff_role_card_spec.rb
+++ b/spec/components/moderation/staff_role_card_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe Components::Moderation::StaffRoleCard do
       server_configuration: config,
       staff_role_id: nil,
       missing: false,
-      permission_warning: false
+      permission_warning: false,
+      staff_permission_warning: false
     ).render_in(view_context)
   end
 
@@ -45,7 +46,8 @@ RSpec.describe Components::Moderation::StaffRoleCard do
         server_configuration: config,
         staff_role_id: 999,
         missing: true,
-        permission_warning: false
+        permission_warning: false,
+        staff_permission_warning: false
       ).render_in(view_context)
     end
 
@@ -64,7 +66,8 @@ RSpec.describe Components::Moderation::StaffRoleCard do
         server_configuration: config,
         staff_role_id: 501,
         missing: false,
-        permission_warning: true
+        permission_warning: true,
+        staff_permission_warning: false
       ).render_in(view_context)
     end
 
@@ -74,6 +77,26 @@ RSpec.describe Components::Moderation::StaffRoleCard do
 
     it "renders the permission warning body" do
       expect(html).to include("Mention All Roles")
+    end
+  end
+
+  context "when there is a staff permission warning" do
+    subject(:html) do
+      described_class.new(
+        server_configuration: config,
+        staff_role_id: 501,
+        missing: false,
+        permission_warning: false,
+        staff_permission_warning: true
+      ).render_in(view_context)
+    end
+
+    it "renders the staff permission warning bold text" do
+      expect(html).to include("This role can&#39;t see staff commands.")
+    end
+
+    it "renders the staff permission warning body" do
+      expect(html).to include("Manage Messages")
     end
   end
 end

--- a/spec/models/server_role_spec.rb
+++ b/spec/models/server_role_spec.rb
@@ -28,4 +28,32 @@ RSpec.describe ServerRole do
       expect(build(:server_role, discord_id: 555)).to be_valid
     end
   end
+
+  describe "#manage_messages?" do
+    subject(:result) { role.manage_messages? }
+
+    context "when role has MANAGE_MESSAGES bit" do
+      let(:role) { build(:server_role, permissions: ServerRole::MANAGE_MESSAGES) }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when role has ADMINISTRATOR bit only" do
+      let(:role) { build(:server_role, permissions: ServerRole::ADMINISTRATOR) }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when role has an unrelated bit (VIEW_CHANNEL = 1 << 10)" do
+      let(:role) { build(:server_role, permissions: 1 << 10) }
+
+      it { is_expected.to be(false) }
+    end
+
+    context "when role has no permissions" do
+      let(:role) { build(:server_role, permissions: 0) }
+
+      it { is_expected.to be(false) }
+    end
+  end
 end

--- a/spec/operations/server_configuration/server_roles/sync_spec.rb
+++ b/spec/operations/server_configuration/server_roles/sync_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Ops::ServerConfiguration::ServerRoles::Sync do
   describe "upserting roles" do
     let(:roles) do
       [
-        {discord_id: 111, name: "Admin", position: 3, managed: false},
-        {discord_id: 222, name: "Bot", position: 2, managed: true}
+        {discord_id: 111, name: "Admin", position: 3, managed: false, permissions: 8192},
+        {discord_id: 222, name: "Bot", position: 2, managed: true, permissions: 0}
       ]
     end
 
@@ -23,6 +23,12 @@ RSpec.describe Ops::ServerConfiguration::ServerRoles::Sync do
       result
 
       expect(server.server_roles.find_by(discord_id: 222)).to have_attributes(position: 2, managed: true)
+    end
+
+    it "stores each role's permissions" do
+      result
+
+      expect(server.server_roles.find_by(discord_id: 111)).to have_attributes(permissions: 8192)
     end
 
     it "records the bot's highest role position on the server" do
@@ -41,6 +47,18 @@ RSpec.describe Ops::ServerConfiguration::ServerRoles::Sync do
 
         expect(server.server_roles.find_by(discord_id: 111)).to have_attributes(name: "Admin", position: 3)
         expect(server.server_roles.where(discord_id: 111).count).to eq(1)
+      end
+    end
+
+    context "when data hash has no :permissions key" do
+      let(:roles) do
+        [{discord_id: 333, name: "Legacy", position: 1, managed: false}]
+      end
+
+      it "defaults permissions to 0" do
+        result
+
+        expect(server.server_roles.find_by(discord_id: 333)).to have_attributes(permissions: 0)
       end
     end
   end

--- a/spec/presenters/moderation/overview_context_spec.rb
+++ b/spec/presenters/moderation/overview_context_spec.rb
@@ -147,6 +147,38 @@ RSpec.describe Moderation::OverviewContext do
     end
   end
 
+  describe "#staff_permission_warning?" do
+    subject(:staff_permission_warning) { context.staff_permission_warning? }
+
+    context "when no staff role configured" do
+      it { is_expected.to be(false) }
+    end
+
+    context "when staff_role_id is set but role absent from server_roles" do
+      before { config.moderation_settings.update!(staff_role_id: 999) }
+
+      it { is_expected.to be(false) }
+    end
+
+    context "when configured role has MANAGE_MESSAGES" do
+      before do
+        create(:server_role, server_configuration: config, discord_id: 700, permissions: 8192)
+        config.moderation_settings.update!(staff_role_id: 700)
+      end
+
+      it { is_expected.to be(false) }
+    end
+
+    context "when configured role has no relevant permissions" do
+      before do
+        create(:server_role, server_configuration: config, discord_id: 701, permissions: 0)
+        config.moderation_settings.update!(staff_role_id: 701)
+      end
+
+      it { is_expected.to be(true) }
+    end
+  end
+
   describe "#sub_plugin_rows" do
     it "returns two rows for spam_protection and image_scanning" do
       rows = context.sub_plugin_rows


### PR DESCRIPTION
## What

Staff-only commands ship with `default_member_permissions: Manage Messages`, so a configured staff role without that permission (or Administrator) silently hides commands like *Report as scam* from its members. This PR:

- stores each role's permission bits (`server_roles.permissions`, bigint, default 0) during the guild role sync;
- adds `ServerRole#manage_messages?` (true for the Manage Messages **or** Administrator bit);
- shows a warning callout on the moderation overview when the configured staff role has neither, pointing at the two fixes (grant Manage Messages, or add a Server Settings → Integrations override);
- updates the privacy policy's cached-roles description to include permission sets.

## Notes

- `db/schema.rb` has incidental check-constraint cast churn (`ARRAY[...]::text[]` → per-element `::text`) — that's the Postgres 18 dump format, matching CI's `postgres:18`.
- The duplicated warning-callout markup in `StaffRoleCard` was extracted into a shared `warning_callout` helper (rule of two).
- Roles synced before a bot redeploy have `permissions: 0` and would warn falsely until the next role sync refreshes them; the sync runs on guild availability, so this self-heals on bot restart.