### PR TITLE
Fix 'within' alignment and showcase Server Shield on landing page

### DIFF
--- a/app/components/moderation/spam_protection_form.rb
+++ b/app/components/moderation/spam_protection_form.rb
@@ -45,7 +45,7 @@ class Components::Moderation::SpamProtectionForm < Components::Base
           default: 4,
           unit: t(".detection.trigger_threshold.channels_unit")
         )
-        span(class: "text-sm text-text-secondary h-10 inline-flex items-center") do
+        span(class: "text-sm text-text-secondary h-8 inline-flex items-center") do
           t(".detection.trigger_threshold.within")
         end
         render Components::NumberStepper.new(

--- a/app/views/home.rb
+++ b/app/views/home.rb
@@ -67,7 +67,7 @@ class Views::Home < Views::Base
 
   def plugin_cards(decorative: false)
     div(class: "flex", aria_hidden: decorative ? "true" : nil) do
-      %i[roles welcomes logging reminders].each { |key| plugin_card(key) }
+      %i[roles welcomes logging moderation reminders].each { |key| plugin_card(key) }
     end
   end
 

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -387,6 +387,8 @@ en:
       plugins:
         logging: 'Record moderation events to a private staff channel: role changes,
           joins, leaves.'
+        moderation: 'Automated moderation beyond Discord''s AutoMod: catch cross-channel
+          spam and unwanted images.'
         reminders: Let members set personal reminders, delivered in the channel or
           by DM.
         roles: Let members self-assign roles from a tidy menu you post in a channel.


### PR DESCRIPTION
Two small visual fixes:

- **Spam guard config:** the "within" connector between the two number steppers sat lower than the steppers — its box was 40px tall (`h-10`) while the stepper rows are 32px (`size-8` buttons), so the centred text landed 4px low. Now `h-8`.
- **Landing page:** Server Shield added to the plugin marquee, with new showcase copy in `web.en.yml` ("Automated moderation beyond Discord's AutoMod: catch cross-channel spam and unwanted images."). Icon and name reuse the existing `PluginNav`/`plugin_row` sources.

All gates green locally (rspec 1643/0, standardrb, active_record_doctor, undercover, i18n-tasks missing + check-normalized).