### PR TITLE
Survive Redis outages on the config bus

### DIFF
--- a/app/bot/config_bus.rb
+++ b/app/bot/config_bus.rb
@@ -33,5 +33,7 @@ module ConfigBus
     end
 
     Redis.new(url:).publish(CHANNEL, JSON.generate(payload))
+  rescue Redis::BaseConnectionError => e
+    Rails.logger.error("[ConfigBus] dropping #{payload[:type]} — #{e.class}: #{e.message}")
   end
 end

--- a/app/bot/config_subscriber.rb
+++ b/app/bot/config_subscriber.rb
@@ -9,10 +9,15 @@ class ConfigSubscriber
 
   def start
     Thread.new do
-      Redis.new(url: BotConfig.redis_url).subscribe(ConfigBus::CHANNEL) do |on|
-        on.message do |_channel, payload|
-          handle(payload)
+      loop do
+        Redis.new(url: BotConfig.redis_url).subscribe(ConfigBus::CHANNEL) do |on|
+          on.message do |_channel, payload|
+            handle(payload)
+          end
         end
+      rescue Redis::BaseConnectionError => e
+        Rails.logger.warn("[ConfigSubscriber] Redis connection lost (#{e.message}), retrying in 5s")
+        sleep 5
       end
     end
   end

--- a/app/bot/config_subscriber.rb
+++ b/app/bot/config_subscriber.rb
@@ -3,6 +3,8 @@
 class ConfigSubscriber
   include WithConnection
 
+  RECONNECT_DELAY = 5
+
   def initialize(bot)
     @bot = bot
   end
@@ -16,8 +18,8 @@ class ConfigSubscriber
           end
         end
       rescue Redis::BaseConnectionError => e
-        Rails.logger.warn("[ConfigSubscriber] Redis connection lost (#{e.message}), retrying in 5s")
-        sleep 5
+        Rails.logger.warn("[ConfigSubscriber] Redis connection lost (#{e.class}: #{e.message}), retrying in #{RECONNECT_DELAY}s")
+        sleep RECONNECT_DELAY
       end
     end
   end

--- a/spec/bot/config_bus_spec.rb
+++ b/spec/bot/config_bus_spec.rb
@@ -62,6 +62,20 @@ RSpec.describe ConfigBus do
   end
 
   describe ".publish" do
+    context "when Redis is unreachable" do
+      let(:set) { create(:role_set) }
+
+      before do
+        allow(redis).to receive(:publish).and_raise(Redis::BaseConnectionError, "down")
+        allow(Rails.logger).to receive(:error)
+      end
+
+      it "swallows the error and logs the dropped event" do
+        expect { described_class.post_roles(set) }.not_to raise_error
+        expect(Rails.logger).to have_received(:error).with(a_string_including("dropping roles_post"))
+      end
+    end
+
     context "when BotConfig.redis_url is nil" do
       let(:set) { create(:role_set) }
 

--- a/spec/bot/config_subscriber_spec.rb
+++ b/spec/bot/config_subscriber_spec.rb
@@ -14,12 +14,36 @@ RSpec.describe ConfigSubscriber do
     it "subscribes on the config channel and routes each message to #handle" do
       allow(Thread).to receive(:new).and_yield
       allow(Redis).to receive(:new).with(url: BotConfig.redis_url).and_return(redis)
-      allow(redis).to receive(:subscribe).with(ConfigBus::CHANNEL).and_yield(on)
+      allow(redis).to receive(:subscribe).with(ConfigBus::CHANNEL).and_yield(on).and_raise(StopIteration)
       allow(on).to receive(:message).and_yield("shrkbot:config", "payload")
 
       expect(subscriber).to receive(:handle).with("payload")
 
       subscriber.start
+    end
+
+    context "when the Redis connection drops" do
+      let(:attempts) { [] }
+
+      before do
+        allow(Thread).to receive(:new).and_yield
+        allow(Redis).to receive(:new).and_return(redis)
+        allow(subscriber).to receive(:sleep)
+        allow(Rails.logger).to receive(:warn)
+        allow(redis).to receive(:subscribe) do
+          attempts << :subscribe
+          raise Redis::BaseConnectionError, "down" if attempts.size == 1
+          raise StopIteration
+        end
+      end
+
+      it "logs, waits, and resubscribes" do
+        subscriber.start
+
+        expect(attempts.size).to eq(2)
+        expect(subscriber).to have_received(:sleep).with(5)
+        expect(Rails.logger).to have_received(:warn).with(a_string_including("Redis connection lost"))
+      end
     end
   end
 

--- a/spec/bot/config_subscriber_spec.rb
+++ b/spec/bot/config_subscriber_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ConfigSubscriber do
         subscriber.start
 
         expect(attempts.size).to eq(2)
-        expect(subscriber).to have_received(:sleep).with(5)
+        expect(subscriber).to have_received(:sleep).with(described_class::RECONNECT_DELAY)
         expect(Rails.logger).to have_received(:warn).with(a_string_including("Redis connection lost"))
       end
     end


### PR DESCRIPTION
## Problem (prod incident, 2026-07-11)

`ConfigSubscriber#start` subscribed once with no rescue. Redis being down at bot boot — or dropping mid-run — killed the subscriber thread silently: the bot stayed up but never heard ConfigBus again until a container restart.

Same incident, publish side: `ConfigBus.publish` raised inside `Ops::Roles::Configure#call` after the DB writes had committed, so a Redis outage 500'd the web save even though the config persisted.

## Fix

- **Subscriber**: wrap the subscription in a retry loop — on `Redis::BaseConnectionError`, log a warning, sleep 5s, resubscribe. Shrinks the lost-publish window to ~5s. Durable delivery (e.g. via Solid Queue) deliberately skipped as too heavy for a fire-and-forget pub/sub.
- **Publisher**: rescue `Redis::BaseConnectionError` in `ConfigBus.publish`, log the dropped event. The save succeeds; only the bot sync is lost. `Ops::Roles::Configure` already publishes after its transaction commits, so no ordering change was needed there.

Specs cover the resubscribe-after-drop path and the swallowed publish error.