### PR TITLE
Show the server switcher on every single-server page

### DIFF
--- a/app/components/plugin_shell.rb
+++ b/app/components/plugin_shell.rb
@@ -10,8 +10,17 @@ class Components::PluginShell < Components::Base
   def view_template(&block)
     render Components::AppShell.new(
       user: @user,
+      current_server: switcher&.guild,
       current_server_id: @server_configuration.discord_id,
+      servers: switcher&.configured_guilds || [],
+      plugin_counts: switcher&.plugin_counts || {},
       sidebar: Components::PluginSidebar.new(server_configuration: @server_configuration, active_key: @active_key)
     ), &block
+  end
+
+  private
+
+  def switcher
+    view_context.server_switcher if view_context.respond_to?(:server_switcher)
   end
 end

--- a/app/controllers/concerns/requires_manageable_server.rb
+++ b/app/controllers/concerns/requires_manageable_server.rb
@@ -7,6 +7,7 @@ module RequiresManageableServer
 
   included do
     before_action :require_manageable_server
+    helper_method :server_switcher
   end
 
   private
@@ -16,6 +17,13 @@ module RequiresManageableServer
     return if @server_configuration && manageable_server?(params[:server_id])
 
     redirect_to servers_path, alert: t("servers.not_found")
+  end
+
+  def server_switcher
+    @server_switcher ||= CachedDashboard.for(
+      discord_id: params[:server_id].to_i,
+      manageable_ids: manageable_server_ids
+    )
   end
 
   def manageable_server?(discord_id)

--- a/spec/components/plugin_shell_spec.rb
+++ b/spec/components/plugin_shell_spec.rb
@@ -35,4 +35,25 @@ RSpec.describe Components::PluginShell do
       expect(html).to include("Dashboard")
     end
   end
+
+  context "when the request exposes a server switcher" do
+    let(:name) { "Dev Refuge" }
+    let!(:other) { create(:server_configuration, discord_id: 900_000_002, name: "Other Guild", member_count: 3) }
+    let(:switcher) do
+      CachedDashboard.for(
+        discord_id: config.discord_id,
+        manageable_ids: [config.discord_id, other.discord_id]
+      )
+    end
+
+    before do
+      without_partial_double_verification do
+        allow(view_context).to receive(:server_switcher).and_return(switcher)
+      end
+    end
+
+    it "renders the switcher with the other manageable servers" do
+      expect(html).to include("Other Guild")
+    end
+  end
 end


### PR DESCRIPTION
## What

The server switcher dropdown now appears on all single-server pages (every plugin config page), not just the dashboard.

## Why it only showed on the dashboard

`AppShell` renders the switcher only when it receives a `current_server`. `ServersController#show` passed one; `PluginShell` never did — it only forwarded `current_server_id` (for notifications). So plugin config pages rendered the shell without a switcher.

## How

- `RequiresManageableServer` (included by every plugin config controller) gains a memoized `server_switcher` — `CachedDashboard.for(discord_id:, manageable_ids:)` — exposed as a `helper_method`. Resolving it in the shared concern means every single-server page gets it and none can be missed.
- `PluginShell` reads `view_context.server_switcher` (nil-safe) and forwards `current_server`/`servers`/`plugin_counts` to `AppShell`.

## Trade-offs

- Switcher data comes from `CachedDashboard` (DB only — the bot syncs guild name/icon/member count). No Discord round-trip and no failure path on a config-page load. The dashboard's own switcher is live-first, so a just-renamed guild can read slightly stale here until the next bot sync — acceptable for nav chrome.
- Nil-safe throughout: unsynced names or a non-plugin render context yield no switcher, identical to today's behaviour.
- Only lists servers already in the session's manageable set, so no new data exposure.

## Tests

- `PluginShell` spec covers the switcher-present path; existing cases already cover its absence.
- Gates green locally: rspec (1650), standardrb, active_record_doctor, undercover (no missing coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)