### PR TITLE
Make the moderation staff ping optional

### DIFF
--- a/app/components/moderation/overview_form.rb
+++ b/app/components/moderation/overview_form.rb
@@ -17,6 +17,7 @@ class Components::Moderation::OverviewForm < Components::Base
         permission_warning: @context.permission_warning?,
         staff_permission_warning: @context.staff_permission_warning?
       )
+      render Components::Moderation::StaffPingCard.new(ping_staff: @context.ping_staff)
       render Components::Moderation::SubPluginDirectory.new(
         server_configuration: @config,
         context: @context

--- a/app/components/moderation/staff_ping_card.rb
+++ b/app/components/moderation/staff_ping_card.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Components::Moderation::StaffPingCard < Components::Base
+  def initialize(ping_staff:)
+    @ping_staff = ping_staff
+  end
+
+  def view_template
+    render Components::Card.new do
+      div(class: "flex items-center justify-between max-w-md gap-4") do
+        label(class: "text-sm font-semibold") { t(".label") }
+        render Components::Toggle.new(
+          name: "moderation[ping_staff]",
+          checked: @ping_staff,
+          label: t(".label"),
+          size: :md
+        )
+      end
+      p(class: "mt-1.5 text-xs text-text-muted max-w-md") { t(".help") }
+    end
+  end
+end

--- a/app/components/moderation/staff_ping_card.rb
+++ b/app/components/moderation/staff_ping_card.rb
@@ -7,8 +7,11 @@ class Components::Moderation::StaffPingCard < Components::Base
 
   def view_template
     render Components::Card.new do
-      div(class: "flex items-center justify-between max-w-md gap-4") do
-        label(class: "text-sm font-semibold") { t(".label") }
+      div(class: "flex items-center justify-between gap-4") do
+        div(class: "max-w-md") do
+          label(class: "text-sm font-semibold") { t(".label") }
+          p(class: "mt-1.5 text-xs text-text-muted") { t(".help") }
+        end
         render Components::Toggle.new(
           name: "moderation[ping_staff]",
           checked: @ping_staff,
@@ -16,7 +19,6 @@ class Components::Moderation::StaffPingCard < Components::Base
           size: :md
         )
       end
-      p(class: "mt-1.5 text-xs text-text-muted max-w-md") { t(".help") }
     end
   end
 end

--- a/app/controllers/servers/moderation_controller.rb
+++ b/app/controllers/servers/moderation_controller.rb
@@ -18,7 +18,8 @@ class Servers::ModerationController < ApplicationController
     result = Ops::Moderation::Configure.call(
       server_configuration: @server_configuration,
       staff_role_id: moderation_params[:staff_role_id],
-      enabled: moderation_params[:enabled]
+      enabled: moderation_params[:enabled],
+      ping_staff: moderation_params[:ping_staff]
     )
     activation = result.value
     @enabled = activation.enabled?
@@ -34,7 +35,7 @@ class Servers::ModerationController < ApplicationController
   private
 
   def moderation_params
-    params.expect(moderation: [:staff_role_id, :enabled])
+    params.expect(moderation: [:staff_role_id, :enabled, :ping_staff])
   end
 
   def build_context

--- a/app/operations/moderation/configure.rb
+++ b/app/operations/moderation/configure.rb
@@ -5,11 +5,12 @@ module Ops
     class Configure < ApplicationOperation
       include Ops::PluginConfiguration
 
-      receives :server_configuration, :staff_role_id, :enabled
+      receives :server_configuration, :staff_role_id, :enabled, :ping_staff
 
       def call
         settings = server_configuration.moderation_settings
         settings.assign_attributes(staff_role_id: staff_role_id.presence)
+        settings.ping_staff = ping_staff unless ping_staff.nil?
         activation = staged_activation
 
         return logging_guard_failure(activation) if enabling? && !logging_ready?

--- a/app/plugins/moderation/events/spam_guard.rb
+++ b/app/plugins/moderation/events/spam_guard.rb
@@ -84,8 +84,9 @@ module Moderation
     end
 
     def notify(config, settings, staff_role_id, entries)
+      ping = config.moderation_settings.ping_staff
       channels = entries.map(&:channel_id).uniq
-      body = StaffPing.prefix(staff_role_id) + I18n.t(
+      body = StaffPing.prefix(staff_role_id, ping:) + I18n.t(
         "moderation.spam_protection.notification.body",
         author: "<@#{event.author.id}>",
         count: channels.size,
@@ -101,7 +102,7 @@ module Moderation
         title: I18n.t("moderation.spam_protection.notification.title.#{settings.action}"),
         body:,
         meta: I18n.t("moderation.spam_protection.notification.meta.#{settings.action}"),
-        allowed_mentions: {parse: [], roles: [staff_role_id]}
+        allowed_mentions: {parse: [], roles: StaffPing.allowed_roles(staff_role_id, ping:)}
       )
     end
 

--- a/app/plugins/moderation/staff_ping.rb
+++ b/app/plugins/moderation/staff_ping.rb
@@ -4,8 +4,16 @@ module Moderation
   module StaffPing
     module_function
 
-    def prefix(staff_role_id)
+    def prefix(staff_role_id, ping: true)
+      return "" unless ping
+
       "<@&#{staff_role_id}>: "
+    end
+
+    def allowed_roles(staff_role_id, ping: true)
+      return [] unless ping
+
+      [staff_role_id].compact
     end
   end
 end

--- a/app/plugins/moderation/verdict_executor.rb
+++ b/app/plugins/moderation/verdict_executor.rb
@@ -37,7 +37,9 @@ module Moderation
 
     def flag(verdict, context, phash, image_bytes:, removed:)
       config = context.settings.server_configuration
-      staff_role_id = config.moderation_settings.staff_role_id
+      settings = config.moderation_settings
+      staff_role_id = settings.staff_role_id
+      ping = settings.ping_staff
       state = removed ? "removed" : "flagged"
       image = image_bytes && Discord::FileUpload.new(image_bytes, File.basename(URI(context.attachment_url).path))
 
@@ -45,7 +47,7 @@ module Moderation
         config,
         bot: context.bot,
         title: I18n.t("moderation.image_scanning.flag.title.#{state}"),
-        body: StaffPing.prefix(staff_role_id) + I18n.t(
+        body: StaffPing.prefix(staff_role_id, ping:) + I18n.t(
           "moderation.image_scanning.flag.body",
           author: "<@#{context.member.id}>",
           channel: "<##{context.channel_id}>",
@@ -54,7 +56,7 @@ module Moderation
         meta: I18n.t("moderation.image_scanning.flag.meta.#{state}"),
         image:,
         components: buttons(phash),
-        allowed_mentions: {parse: [], roles: [staff_role_id].compact}
+        allowed_mentions: {parse: [], roles: StaffPing.allowed_roles(staff_role_id, ping:)}
       )
     end
 

--- a/app/presenters/moderation/overview_context.rb
+++ b/app/presenters/moderation/overview_context.rb
@@ -26,6 +26,10 @@ module Moderation
       @config.moderation_settings&.staff_role_id
     end
 
+    def ping_staff
+      @config.moderation_settings&.ping_staff
+    end
+
     def staff_role_present?
       staff_role_id.present?
     end

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -172,9 +172,13 @@ en:
             purge: Purge the messages
           punishment:
             label: Also punish the sender
+      staff_ping_card:
+        help: Mention the staff role at the top of every moderation log entry. Turn
+          it off for a quieter log staff check on their own.
+        label: Ping staff on alerts
       staff_role_card:
-        help: Shared by every Moderation sub-plugin. Pinged on every alert, and exempt
-          from spam detection. Pick one before enabling any sub-plugin.
+        help: Shared by every Moderation sub-plugin, and exempt from spam detection.
+          Pick one before enabling any sub-plugin.
         label: Staff role
         missing_warning: Required. Every sub-plugin stays off until a staff role is
           picked.

--- a/db/migrate/20260711095649_add_ping_staff_to_moderation_settings.rb
+++ b/db/migrate/20260711095649_add_ping_staff_to_moderation_settings.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPingStaffToModerationSettings < ActiveRecord::Migration[8.1]
+  def change
+    add_column :moderation_settings, :ping_staff, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_10_214856) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_11_095649) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -56,11 +56,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_10_214856) do
     t.integer "timeout_seconds", default: 3600, null: false
     t.datetime "updated_at", null: false
     t.index ["server_configuration_id"], name: "index_image_scanning_settings_on_server_configuration_id", unique: true
-    t.check_constraint "action::text = ANY (ARRAY['none'::character varying::text, 'delete'::character varying::text])", name: "image_scanning_settings_action_check"
+    t.check_constraint "action::text = ANY (ARRAY['none'::character varying, 'delete'::character varying]::text[])", name: "image_scanning_settings_action_check"
     t.check_constraint "cardinality(custom_keywords) <= 200", name: "image_scanning_settings_custom_keywords_count_check"
     t.check_constraint "custom_keyword_min_hits >= 1 AND (cardinality(custom_keywords) = 0 OR custom_keyword_min_hits <= cardinality(custom_keywords))", name: "image_scanning_settings_min_hits_check"
-    t.check_constraint "punishment::text = ANY (ARRAY['none'::character varying::text, 'timeout'::character varying::text, 'kick'::character varying::text, 'ban'::character varying::text])", name: "image_scanning_settings_punishment_check"
-    t.check_constraint "sensitivity::text = ANY (ARRAY['relaxed'::character varying::text, 'standard'::character varying::text, 'strict'::character varying::text])", name: "image_scanning_settings_sensitivity_check"
+    t.check_constraint "punishment::text = ANY (ARRAY['none'::character varying, 'timeout'::character varying, 'kick'::character varying, 'ban'::character varying]::text[])", name: "image_scanning_settings_punishment_check"
+    t.check_constraint "sensitivity::text = ANY (ARRAY['relaxed'::character varying, 'standard'::character varying, 'strict'::character varying]::text[])", name: "image_scanning_settings_sensitivity_check"
     t.check_constraint "timeout_seconds >= 60 AND timeout_seconds <= 2419200", name: "image_scanning_settings_timeout_seconds_check"
   end
 
@@ -75,6 +75,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_10_214856) do
 
   create_table "moderation_settings", id: :string, default: -> { "('mds_'::text || gen_random_uuid())" }, force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.boolean "ping_staff", default: true, null: false
     t.string "server_configuration_id", null: false
     t.bigint "staff_role_id"
     t.datetime "updated_at", null: false
@@ -100,7 +101,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_10_214856) do
     t.string "verdict", null: false
     t.index ["phash_id", "server_configuration_id"], name: "idx_on_phash_id_server_configuration_id_693185e6e1", unique: true
     t.index ["server_configuration_id"], name: "index_phash_confirmations_on_server_configuration_id"
-    t.check_constraint "verdict::text = ANY (ARRAY['confirmed'::character varying::text, 'dismissed'::character varying::text])", name: "phash_confirmations_verdict_check"
+    t.check_constraint "verdict::text = ANY (ARRAY['confirmed'::character varying, 'dismissed'::character varying]::text[])", name: "phash_confirmations_verdict_check"
   end
 
   create_table "phashes", id: :string, default: -> { "('phs_'::text || gen_random_uuid())" }, force: :cascade do |t|
@@ -335,9 +336,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_10_214856) do
     t.datetime "updated_at", null: false
     t.integer "window_seconds", default: 15, null: false
     t.index ["server_configuration_id"], name: "index_spam_protection_settings_on_server_configuration_id", unique: true
-    t.check_constraint "action::text = ANY (ARRAY['purge'::character varying::text, 'notify_only'::character varying::text])", name: "spam_protection_settings_action_check"
+    t.check_constraint "action::text = ANY (ARRAY['purge'::character varying, 'notify_only'::character varying]::text[])", name: "spam_protection_settings_action_check"
     t.check_constraint "channel_threshold >= 2 AND channel_threshold <= 500", name: "spam_protection_settings_channel_threshold_check"
-    t.check_constraint "punishment::text = ANY (ARRAY['none'::character varying::text, 'timeout'::character varying::text, 'kick'::character varying::text, 'ban'::character varying::text])", name: "spam_protection_settings_punishment_check"
+    t.check_constraint "punishment::text = ANY (ARRAY['none'::character varying, 'timeout'::character varying, 'kick'::character varying, 'ban'::character varying]::text[])", name: "spam_protection_settings_punishment_check"
     t.check_constraint "similarity >= 0.75::double precision AND similarity <= 1.0::double precision", name: "spam_protection_settings_similarity_check"
     t.check_constraint "timeout_seconds >= 60 AND timeout_seconds <= 2419200", name: "spam_protection_settings_timeout_seconds_check"
     t.check_constraint "window_seconds >= 1 AND window_seconds <= 60", name: "spam_protection_settings_window_seconds_check"

--- a/spec/components/moderation/overview_form_spec.rb
+++ b/spec/components/moderation/overview_form_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Components::Moderation::OverviewForm do
     instance_double(
       Moderation::OverviewContext,
       staff_role_id: nil,
+      ping_staff: true,
       staff_role_present?: false,
       permission_warning?: false,
       staff_permission_warning?: false,
@@ -26,6 +27,10 @@ RSpec.describe Components::Moderation::OverviewForm do
 
   it "renders the staff role card" do
     expect(html).to include("moderation[staff_role_id]")
+  end
+
+  it "renders the staff ping toggle" do
+    expect(html).to include("moderation[ping_staff]")
   end
 
   it "renders no enable_error callout by default" do

--- a/spec/components/moderation/staff_ping_card_spec.rb
+++ b/spec/components/moderation/staff_ping_card_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::Moderation::StaffPingCard do
+  include_context "component view context"
+
+  subject(:html) { described_class.new(ping_staff:).render_in(view_context) }
+
+  let(:ping_staff) { true }
+
+  it "renders the ping toggle with the correct field name" do
+    expect(html).to include('name="moderation[ping_staff]"')
+  end
+
+  it "renders the label and help text" do
+    expect(html).to include("Ping staff on alerts")
+    expect(html).to include("Mention the staff role")
+  end
+
+  context "when ping_staff is enabled" do
+    it "renders the checkbox as checked" do
+      expect(html).to match(/type="checkbox"[^>]*\bchecked\b/)
+    end
+  end
+
+  context "when ping_staff is disabled" do
+    let(:ping_staff) { false }
+
+    it "renders the checkbox unchecked" do
+      expect(html).not_to match(/type="checkbox"[^>]*\bchecked\b/)
+    end
+  end
+end

--- a/spec/operations/moderation/configure_spec.rb
+++ b/spec/operations/moderation/configure_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe Ops::Moderation::Configure do
     described_class.call(
       server_configuration: config,
       staff_role_id:,
-      enabled:
+      enabled:,
+      ping_staff:
     )
   end
 
@@ -16,6 +17,7 @@ RSpec.describe Ops::Moderation::Configure do
   let!(:settings) { config.create_moderation_settings! }
   let(:staff_role_id) { 111_222_333 }
   let(:enabled) { "1" }
+  let(:ping_staff) { "1" }
 
   context "when enabling without logging ready (no logging plugin enabled)" do
     it "fails with an error on the enabled field" do
@@ -148,6 +150,32 @@ RSpec.describe Ops::Moderation::Configure do
     it "saves the staff_role_id" do
       result
       expect(config.moderation_settings.reload.staff_role_id).to eq(111_222_333)
+    end
+  end
+
+  context "when saving ping_staff: '0'" do
+    let(:enabled) { "0" }
+    let(:ping_staff) { "0" }
+
+    it "succeeds" do
+      expect(result).to be_success
+    end
+
+    it "persists ping_staff as false" do
+      result
+      expect(config.moderation_settings.reload.ping_staff).to be(false)
+    end
+  end
+
+  context "when saving ping_staff: '1'" do
+    let(:enabled) { "0" }
+    let(:ping_staff) { "1" }
+
+    before { settings.update!(ping_staff: false) }
+
+    it "persists ping_staff as true" do
+      result
+      expect(config.moderation_settings.reload.ping_staff).to be(true)
     end
   end
 end

--- a/spec/plugins/moderation/events/spam_guard_spec.rb
+++ b/spec/plugins/moderation/events/spam_guard_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe Moderation::SpamGuard do
   let(:event) { double("event", from_bot?: false, server:, author:, message:, channel:, bot:) }
 
   let(:logging_setting) { double("logging_setting", channel_id: log_channel_id) }
-  let(:moderation_settings) { double("moderation_settings", staff_role_id:) }
+  let(:ping_staff) { true }
+  let(:moderation_settings) { double("moderation_settings", staff_role_id:, ping_staff:) }
   let(:config) do
     double(
       "server_configuration",
@@ -338,19 +339,57 @@ RSpec.describe Moderation::SpamGuard do
     end
   end
 
+  context "when ping_staff is false" do
+    let(:action) { "notify_only" }
+    let(:ping_staff) { false }
+
+    before do
+      allow(bot).to receive(:channel).with(1).and_return(double("ch1", delete_message: nil))
+      allow(bot).to receive(:channel).with(2).and_return(double("ch2", delete_message: nil))
+      allow(bot).to receive(:channel).with(3).and_return(double("ch3", delete_message: nil))
+      allow(Discord::Components).to receive(:send_to)
+    end
+
+    it "notifies with empty roles in allowed_mentions" do
+      expect(Discord::Components).to receive(:send_to).with(
+        log_channel,
+        anything,
+        allowed_mentions: {parse: [], roles: []},
+        attachments: nil
+      )
+
+      simulate_message(channel_id: 1, message_id: 10)
+      simulate_message(channel_id: 2, message_id: 20)
+      simulate_message(channel_id: 3, message_id: 30)
+    end
+
+    it "does not start the body with a role mention" do
+      body = nil
+      allow(Discord::Components).to receive(:send_to) do |_channel, rendered, **|
+        body = rendered[:components].first[:components].first[:content]
+      end
+
+      simulate_message(channel_id: 1, message_id: 10)
+      simulate_message(channel_id: 2, message_id: 20)
+      simulate_message(channel_id: 3, message_id: 30)
+
+      expect(body).not_to start_with("<@&")
+    end
+  end
+
   context "when no staff role is configured" do
     let(:action) { "notify_only" }
-    let(:moderation_settings) { double("moderation_settings", staff_role_id: nil) }
+    let(:moderation_settings) { double("moderation_settings", staff_role_id: nil, ping_staff: true) }
 
     before do
       allow(Discord::Components).to receive(:send_to)
     end
 
-    it "notifies with nil in the roles array (seam guard prevents this in production)" do
+    it "notifies with an empty roles array (seam guard prevents this in production)" do
       expect(Discord::Components).to receive(:send_to).with(
         log_channel,
         anything,
-        allowed_mentions: {parse: [], roles: [nil]},
+        allowed_mentions: {parse: [], roles: []},
         attachments: nil
       )
 

--- a/spec/plugins/moderation/staff_ping_spec.rb
+++ b/spec/plugins/moderation/staff_ping_spec.rb
@@ -3,13 +3,57 @@
 require "rails_helper"
 
 RSpec.describe Moderation::StaffPing do
-  subject(:prefix) { described_class.prefix(staff_role_id) }
+  describe ".prefix" do
+    subject(:prefix) { described_class.prefix(staff_role_id, **kwargs) }
 
-  context "with a staff role id" do
-    let(:staff_role_id) { 123 }
+    let(:kwargs) { {} }
 
-    it "renders a role mention with a colon and trailing space" do
-      expect(prefix).to eq("<@&123>: ")
+    context "with a staff role id" do
+      let(:staff_role_id) { 123 }
+
+      it "renders a role mention with a colon and trailing space" do
+        expect(prefix).to eq("<@&123>: ")
+      end
+    end
+
+    context "with ping: false" do
+      let(:staff_role_id) { 123 }
+      let(:kwargs) { {ping: false} }
+
+      it "returns an empty string" do
+        expect(prefix).to eq("")
+      end
+    end
+  end
+
+  describe ".allowed_roles" do
+    subject(:allowed_roles) { described_class.allowed_roles(staff_role_id, **kwargs) }
+
+    let(:kwargs) { {} }
+
+    context "with a staff role id" do
+      let(:staff_role_id) { 123 }
+
+      it "returns the id wrapped in an array" do
+        expect(allowed_roles).to eq([123])
+      end
+    end
+
+    context "with ping: false" do
+      let(:staff_role_id) { 123 }
+      let(:kwargs) { {ping: false} }
+
+      it "returns an empty array" do
+        expect(allowed_roles).to eq([])
+      end
+    end
+
+    context "with nil id and ping: true" do
+      let(:staff_role_id) { nil }
+
+      it "returns an empty array" do
+        expect(allowed_roles).to eq([])
+      end
     end
   end
 end

--- a/spec/plugins/moderation/verdict_executor_spec.rb
+++ b/spec/plugins/moderation/verdict_executor_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe Moderation::VerdictExecutor do
   let(:bot) { double("bot", channel: message_channel) }
 
   let(:logging_setting) { double("logging_setting", channel_id: channel_id) }
-  let(:moderation_settings) { double("moderation_settings", staff_role_id:) }
+  let(:ping_staff) { true }
+  let(:moderation_settings) { double("moderation_settings", staff_role_id:, ping_staff:) }
   let(:server_configuration) do
     double(
       "server_configuration",
@@ -278,6 +279,27 @@ RSpec.describe Moderation::VerdictExecutor do
         server_configuration,
         hash_including(allowed_mentions: {parse: [], roles: []})
       )
+    end
+  end
+
+  context "when ping_staff is false" do
+    let(:ping_staff) { false }
+
+    it "posts with empty roles in allowed_mentions" do
+      execute
+
+      expect(ActivityLog).to have_received(:post).with(
+        server_configuration,
+        hash_including(allowed_mentions: {parse: [], roles: []})
+      )
+    end
+
+    it "does not start the body with a role mention" do
+      execute
+
+      expect(ActivityLog).to have_received(:post) do |_config, kwargs|
+        expect(kwargs[:body]).not_to start_with("<@&")
+      end
     end
   end
 end

--- a/spec/presenters/moderation/overview_context_spec.rb
+++ b/spec/presenters/moderation/overview_context_spec.rb
@@ -85,6 +85,30 @@ RSpec.describe Moderation::OverviewContext do
     end
   end
 
+  describe "#ping_staff" do
+    context "when ping_staff is enabled" do
+      it "returns true" do
+        expect(context.ping_staff).to be(true)
+      end
+    end
+
+    context "when ping_staff is disabled" do
+      before { config.moderation_settings.update!(ping_staff: false) }
+
+      it "returns false" do
+        expect(context.ping_staff).to be(false)
+      end
+    end
+
+    context "when moderation_settings does not exist" do
+      before { config.moderation_settings.destroy! }
+
+      it "returns nil" do
+        expect(described_class.new(config.reload).ping_staff).to be_nil
+      end
+    end
+  end
+
   describe "#staff_role_present?" do
     context "when staff_role_id is set" do
       before { config.moderation_settings.update!(staff_role_id: 555) }

--- a/spec/requests/moderation_config_spec.rb
+++ b/spec/requests/moderation_config_spec.rb
@@ -157,6 +157,13 @@ RSpec.describe "Moderation config", type: :request do
             params: {moderation: {staff_role_id: 500, enabled: "1"}}
           expect(response).to redirect_to(server_moderation_path(guild.id))
         end
+
+        it "sets ping_staff to false when param is '0'" do
+          patch server_moderation_path(guild.id),
+            params: {moderation: {staff_role_id: 500, enabled: "1", ping_staff: "0"}},
+            **turbo
+          expect(config.moderation_settings.reload.ping_staff).to be(false)
+        end
       end
     end
   end


### PR DESCRIPTION
## What

Staff were pinged in **every** moderation log entry (image-scanning flags and cross-channel spam alerts) with no way to turn it off. This adds a per-guild **Ping staff on alerts** toggle to the Server Shield config page.

- **On by default** — existing behaviour is unchanged for every server.
- When off, `StaffPing` renders no `<@&role>` prefix *and* drops the role from `allowed_mentions`, so the alert still posts to the log channel but nobody gets pinged.

## How

- New `ping_staff` boolean column on `moderation_settings` (`null: false, default: true`).
- `StaffPing.prefix` / new `StaffPing.allowed_roles` both take `ping:` and short-circuit to `""` / `[]` when off. Both call sites (`VerdictExecutor#flag`, `SpamGuard#notify`) route through them.
- `Ops::Moderation::Configure` persists the flag; a partial POST that omits the param leaves the stored value untouched (no null-crash at the web boundary).
- New `Components::Moderation::StaffPingCard` rendered under the staff-role card.

## Notes

- The flag is guild config on `moderation_settings`, already purged via `has_one … dependent: :delete` — no privacy-policy change (no new personal-data category).
- Boyscout: `SpamGuard` now compacts the roles array via `StaffPing.allowed_roles`, so a missing staff role yields `roles: []` instead of `[nil]` (matches `VerdictExecutor`); trimmed the now-stale "Pinged on every alert" claim from the staff-role help copy.

Gates green locally: rspec (1669), standardrb, active_record_doctor, i18n-tasks, undercover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)