### PR TITLE
Add escalated punishment tier for confirmed-scam images

### DIFF
--- a/app/components/moderation/image_scanning_form.rb
+++ b/app/components/moderation/image_scanning_form.rb
@@ -113,6 +113,7 @@ class Components::Moderation::ImageScanningForm < Components::Base
       div(class: "grid gap-5") do
         action_field
         punishment_field
+        confirmed_punishment_field
       end
     end
   end
@@ -140,6 +141,18 @@ class Components::Moderation::ImageScanningForm < Components::Base
         value: @settings.punishment,
         timeout_seconds: @settings.timeout_seconds
       )
+    end
+  end
+
+  def confirmed_punishment_field
+    div do
+      label(class: "block text-sm font-semibold mb-1.5") { t(".response.confirmed_punishment.label") }
+      render Components::Moderation::PunishmentControl.new(
+        name: "image_scanning[confirmed_punishment]",
+        value: @settings.confirmed_punishment,
+        timeout_seconds: @settings.confirmed_timeout_seconds
+      )
+      p(class: "text-xs text-text-muted mt-1.5") { t(".response.confirmed_punishment.help") }
     end
   end
 

--- a/app/components/moderation/punishment_control.rb
+++ b/app/components/moderation/punishment_control.rb
@@ -80,7 +80,6 @@ class Components::Moderation::PunishmentControl < Components::Base
   end
 
   def timeout_field_name
-    prefix = @name.sub(/\[punishment\]$/, "")
-    "#{prefix}[timeout_seconds]"
+    @name.sub(/punishment\]$/, "timeout_seconds]")
   end
 end

--- a/app/controllers/servers/image_scanning_controller.rb
+++ b/app/controllers/servers/image_scanning_controller.rb
@@ -21,6 +21,8 @@ class Servers::ImageScanningController < ApplicationController
       action: image_scanning_params[:action],
       punishment: image_scanning_params[:punishment],
       timeout_seconds: image_scanning_params[:timeout_seconds],
+      confirmed_punishment: image_scanning_params[:confirmed_punishment],
+      confirmed_timeout_seconds: image_scanning_params[:confirmed_timeout_seconds],
       custom_keyword_min_hits: image_scanning_params[:custom_keyword_min_hits],
       custom_keywords: image_scanning_params[:custom_keywords],
       enabled: image_scanning_params[:enabled]
@@ -46,6 +48,8 @@ class Servers::ImageScanningController < ApplicationController
         :action,
         :punishment,
         :timeout_seconds,
+        :confirmed_punishment,
+        :confirmed_timeout_seconds,
         :custom_keyword_min_hits,
         :enabled,
         custom_keywords: []

--- a/app/operations/moderation/image_scanning/configure.rb
+++ b/app/operations/moderation/image_scanning/configure.rb
@@ -12,6 +12,8 @@ module Ops
           :action,
           :punishment,
           :timeout_seconds,
+          :confirmed_punishment,
+          :confirmed_timeout_seconds,
           :custom_keywords,
           :custom_keyword_min_hits,
           :enabled
@@ -23,6 +25,8 @@ module Ops
             action:,
             punishment:,
             timeout_seconds:,
+            confirmed_punishment:,
+            confirmed_timeout_seconds:,
             custom_keyword_min_hits:,
             custom_keywords: Array(custom_keywords).reject(&:blank?)
           )

--- a/app/plugins/moderation/image_scanning/settings.rb
+++ b/app/plugins/moderation/image_scanning/settings.rb
@@ -14,6 +14,9 @@ module Moderation
 
       string_enum :sensitivity, %w[relaxed standard strict]
       string_enum :action, %w[none delete], prefix: true
+      string_enum :confirmed_punishment, %w[none timeout kick ban], prefix: true
+      validates :confirmed_timeout_seconds,
+        numericality: {only_integer: true, greater_than_or_equal_to: 60, less_than_or_equal_to: 2_419_200}
       validates :custom_keyword_min_hits,
         numericality: {only_integer: true, greater_than_or_equal_to: 1}
       validate :custom_keywords_within_limit

--- a/app/plugins/moderation/scan_processor.rb
+++ b/app/plugins/moderation/scan_processor.rb
@@ -20,7 +20,7 @@ module Moderation
         signals: context.signals,
         settings: context.settings
       )
-      VerdictExecutor.call(verdict:, context:, phash: hex, image_bytes: bytes)
+      VerdictExecutor.call(verdict:, context:, phash: hex, hash_state: state, image_bytes: bytes)
     rescue Ocr::Error => e
       Rails.logger.warn("[Moderation::ScanProcessor] scan failed: #{e.class}: #{e.message}")
     end

--- a/app/plugins/moderation/verdict_executor.rb
+++ b/app/plugins/moderation/verdict_executor.rb
@@ -6,13 +6,13 @@ module Moderation
   module VerdictExecutor
     module_function
 
-    def call(verdict:, context:, phash:, image_bytes: nil)
+    def call(verdict:, context:, phash:, hash_state:, image_bytes: nil)
       case verdict.action
       when :flag_for_review
         flag(verdict, context, phash, image_bytes:, removed: false)
       when :remove
         delete_message(context) if context.settings.action_delete?
-        punish(context)
+        punish(context, hash_state)
         flag(verdict, context, phash, image_bytes:, removed: true)
       end
     end
@@ -23,14 +23,17 @@ module Moderation
       Rails.logger.warn("[Moderation::VerdictExecutor] delete failed in ##{context.channel_id}: #{e.class}: #{e.message}")
     end
 
-    def punish(context)
-      return if context.settings.punishment_none?
+    def punish(context, hash_state)
+      settings = context.settings
+      confirmed = hash_state == :own_confirmed
+      punishment = confirmed ? settings.confirmed_punishment : settings.punishment
+      return if punishment == "none"
 
       Punisher.call(
         member: context.member,
         server: context.server,
-        punishment: context.settings.punishment,
-        timeout_seconds: context.settings.timeout_seconds,
+        punishment:,
+        timeout_seconds: confirmed ? settings.confirmed_timeout_seconds : settings.timeout_seconds,
         reason: I18n.t("moderation.image_scanning.punishment.reason")
       )
     end

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -116,6 +116,10 @@ en:
             flag_only: Flag only
             help: Flag only leaves the image up and pings staff to review it.
             label: When a scam is detected
+          confirmed_punishment:
+            help: Overrides the punishment above for images a moderator has confirmed
+              as scam on this server. Confirmations from other servers don't count.
+            label: If confirmed as a scam on this server
           punishment:
             label: Also punish the sender
       matching_explainer:

--- a/db/migrate/20260711125937_add_confirmed_punishment_to_image_scanning_settings.rb
+++ b/db/migrate/20260711125937_add_confirmed_punishment_to_image_scanning_settings.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddConfirmedPunishmentToImageScanningSettings < ActiveRecord::Migration[8.1]
+  def change
+    add_column :image_scanning_settings, :confirmed_punishment, :string, null: false, default: "none"
+    add_column :image_scanning_settings, :confirmed_timeout_seconds, :integer, null: false, default: 3600
+
+    add_check_constraint :image_scanning_settings,
+      "confirmed_punishment IN ('none', 'timeout', 'kick', 'ban')",
+      name: "image_scanning_settings_confirmed_punishment_check"
+    add_check_constraint :image_scanning_settings,
+      "confirmed_timeout_seconds >= 60 AND confirmed_timeout_seconds <= 2419200",
+      name: "image_scanning_settings_confirmed_timeout_seconds_check"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_11_095649) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_11_125937) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -47,6 +47,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_11_095649) do
 
   create_table "image_scanning_settings", id: :string, default: -> { "('iss_'::text || gen_random_uuid())" }, force: :cascade do |t|
     t.string "action", default: "delete", null: false
+    t.string "confirmed_punishment", default: "none", null: false
+    t.integer "confirmed_timeout_seconds", default: 3600, null: false
     t.datetime "created_at", null: false
     t.integer "custom_keyword_min_hits", default: 2, null: false
     t.text "custom_keywords", default: [], null: false, array: true
@@ -58,6 +60,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_11_095649) do
     t.index ["server_configuration_id"], name: "index_image_scanning_settings_on_server_configuration_id", unique: true
     t.check_constraint "action::text = ANY (ARRAY['none'::character varying, 'delete'::character varying]::text[])", name: "image_scanning_settings_action_check"
     t.check_constraint "cardinality(custom_keywords) <= 200", name: "image_scanning_settings_custom_keywords_count_check"
+    t.check_constraint "confirmed_punishment::text = ANY (ARRAY['none'::character varying, 'timeout'::character varying, 'kick'::character varying, 'ban'::character varying]::text[])", name: "image_scanning_settings_confirmed_punishment_check"
+    t.check_constraint "confirmed_timeout_seconds >= 60 AND confirmed_timeout_seconds <= 2419200", name: "image_scanning_settings_confirmed_timeout_seconds_check"
     t.check_constraint "custom_keyword_min_hits >= 1 AND (cardinality(custom_keywords) = 0 OR custom_keyword_min_hits <= cardinality(custom_keywords))", name: "image_scanning_settings_min_hits_check"
     t.check_constraint "punishment::text = ANY (ARRAY['none'::character varying, 'timeout'::character varying, 'kick'::character varying, 'ban'::character varying]::text[])", name: "image_scanning_settings_punishment_check"
     t.check_constraint "sensitivity::text = ANY (ARRAY['relaxed'::character varying, 'standard'::character varying, 'strict'::character varying]::text[])", name: "image_scanning_settings_sensitivity_check"

--- a/spec/components/moderation/image_scanning_form_spec.rb
+++ b/spec/components/moderation/image_scanning_form_spec.rb
@@ -70,6 +70,14 @@ RSpec.describe Components::Moderation::ImageScanningForm do
     expect(html).to include('name="image_scanning[timeout_seconds]"')
   end
 
+  it "renders the confirmed_punishment control with correct field name" do
+    expect(html).to include('name="image_scanning[confirmed_punishment]"')
+  end
+
+  it "renders the confirmed_timeout_seconds duration select" do
+    expect(html).to include('name="image_scanning[confirmed_timeout_seconds]"')
+  end
+
   it "renders the image scanning explainer" do
     expect(html).to include("How image scanning works")
     expect(html).to include("Nothing is stored.")

--- a/spec/components/moderation/punishment_control_spec.rb
+++ b/spec/components/moderation/punishment_control_spec.rb
@@ -72,4 +72,18 @@ RSpec.describe Components::Moderation::PunishmentControl do
       expect(html).to include('name="image_scanning[timeout_seconds]"')
     end
   end
+
+  context "when used for the confirmed-scam tier" do
+    subject(:html) do
+      described_class.new(
+        name: "image_scanning[confirmed_punishment]",
+        value: "none",
+        timeout_seconds: 3600
+      ).render_in(view_context)
+    end
+
+    it "derives the confirmed timeout field name" do
+      expect(html).to include('name="image_scanning[confirmed_timeout_seconds]"')
+    end
+  end
 end

--- a/spec/operations/moderation/image_scanning/configure_spec.rb
+++ b/spec/operations/moderation/image_scanning/configure_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe Ops::Moderation::ImageScanning::Configure do
       action:,
       punishment:,
       timeout_seconds:,
+      confirmed_punishment:,
+      confirmed_timeout_seconds:,
       custom_keywords:,
       custom_keyword_min_hits:,
       enabled:
@@ -23,6 +25,8 @@ RSpec.describe Ops::Moderation::ImageScanning::Configure do
   let(:action) { "delete" }
   let(:punishment) { "none" }
   let(:timeout_seconds) { 3600 }
+  let(:confirmed_punishment) { "none" }
+  let(:confirmed_timeout_seconds) { 3600 }
   let(:custom_keywords) { [] }
   let(:custom_keyword_min_hits) { 2 }
   let(:enabled) { "1" }

--- a/spec/plugins/moderation/image_scanning/settings_spec.rb
+++ b/spec/plugins/moderation/image_scanning/settings_spec.rb
@@ -71,6 +71,32 @@ RSpec.describe Moderation::ImageScanning::Settings do
     end
   end
 
+  describe "confirmed_punishment" do
+    it "is invalid for an unrecognised value" do
+      settings.confirmed_punishment = "mute"
+      expect(settings).not_to be_valid
+    end
+
+    %w[none timeout kick ban].each do |punishment|
+      it "is valid for #{punishment}" do
+        settings.confirmed_punishment = punishment
+        expect(settings).to be_valid
+      end
+    end
+  end
+
+  describe "confirmed_timeout_seconds" do
+    it "is invalid at 59" do
+      settings.confirmed_timeout_seconds = 59
+      expect(settings).not_to be_valid
+    end
+
+    it "is invalid at 2_419_201" do
+      settings.confirmed_timeout_seconds = 2_419_201
+      expect(settings).not_to be_valid
+    end
+  end
+
   describe "custom_keywords" do
     it "is valid when empty" do
       settings.custom_keywords = []

--- a/spec/plugins/moderation/scan_processor_spec.rb
+++ b/spec/plugins/moderation/scan_processor_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Moderation::ScanProcessor do
         signals:,
         settings:
       )
-      expect(Moderation::VerdictExecutor).to have_received(:call).with(verdict:, context:, phash: hex, image_bytes: "bytes")
+      expect(Moderation::VerdictExecutor).to have_received(:call).with(verdict:, context:, phash: hex, hash_state: :none, image_bytes: "bytes")
     end
 
     it "does not touch last_seen" do
@@ -77,7 +77,7 @@ RSpec.describe Moderation::ScanProcessor do
       process
 
       expect(Ops::Moderation::Phashes::MarkSeen).to have_received(:call).with(phash_hex: hex)
-      expect(Moderation::VerdictExecutor).to have_received(:call).with(verdict:, context:, phash: hex, image_bytes: "bytes")
+      expect(Moderation::VerdictExecutor).to have_received(:call).with(verdict:, context:, phash: hex, hash_state: :own_confirmed, image_bytes: "bytes")
     end
   end
 

--- a/spec/plugins/moderation/verdict_executor_spec.rb
+++ b/spec/plugins/moderation/verdict_executor_spec.rb
@@ -4,7 +4,8 @@ require "rails_helper"
 
 RSpec.describe Moderation::VerdictExecutor do
   let(:image_bytes) { "fakepngbytes" }
-  subject(:execute) { described_class.call(verdict:, context:, phash:, image_bytes:) }
+  let(:hash_state) { :none }
+  subject(:execute) { described_class.call(verdict:, context:, phash:, hash_state:, image_bytes:) }
 
   let(:server_id) { 111 }
   let(:member_id) { 222 }
@@ -36,7 +37,6 @@ RSpec.describe Moderation::VerdictExecutor do
       "settings",
       action_delete?: settings_action == "delete",
       punishment:,
-      punishment_none?: punishment == "none",
       timeout_seconds: 300,
       sensitivity: "standard",
       server_configuration:
@@ -266,6 +266,67 @@ RSpec.describe Moderation::VerdictExecutor do
     it "does not invoke the punisher" do
       expect(Moderation::Punisher).not_to receive(:call)
       execute
+    end
+  end
+
+  describe "confirmed-scam escalation" do
+    let(:confirmed_timeout_seconds) { 7200 }
+    let(:confirmed_punishment) { "ban" }
+    let(:punishment) { "timeout" }
+    let(:settings) do
+      double(
+        "settings",
+        action_delete?: false,
+        punishment:,
+        timeout_seconds: 300,
+        confirmed_punishment:,
+        confirmed_timeout_seconds:,
+        sensitivity: "standard",
+        server_configuration:
+      )
+    end
+
+    context "when hash_state is :own_confirmed and confirmed_punishment is 'ban'" do
+      let(:hash_state) { :own_confirmed }
+
+      it "punishes with the confirmed tier, not the general tier" do
+        execute
+
+        expect(Moderation::Punisher).to have_received(:call).with(
+          member:,
+          server:,
+          punishment: "ban",
+          timeout_seconds: confirmed_timeout_seconds,
+          reason: I18n.t("moderation.image_scanning.punishment.reason")
+        )
+      end
+    end
+
+    context "when hash_state is :own_confirmed and confirmed_punishment is 'none'" do
+      let(:hash_state) { :own_confirmed }
+      let(:confirmed_punishment) { "none" }
+
+      it "does not invoke the punisher even though the general punishment is set" do
+        expect(Moderation::Punisher).not_to receive(:call)
+        execute
+      end
+    end
+
+    context "when hash_state is :foreign_confirmed" do
+      let(:hash_state) { :foreign_confirmed }
+      let(:punishment) { "kick" }
+
+      it "punishes with the general tier, not the confirmed tier" do
+        execute
+
+        expect(Moderation::Punisher).to have_received(:call).with(
+          member:,
+          server:,
+          punishment: "kick",
+          timeout_seconds: 300,
+          reason: I18n.t("moderation.image_scanning.punishment.reason")
+        )
+      end
     end
   end
 

--- a/spec/requests/image_scanning_config_spec.rb
+++ b/spec/requests/image_scanning_config_spec.rb
@@ -102,7 +102,9 @@ RSpec.describe "Image scanning config", type: :request do
         it "saves settings and returns turbo stream on success" do
           patch server_image_scanning_path(guild.id),
             params: {image_scanning: {sensitivity: "standard", action: "delete",
-                                      punishment: "none", timeout_seconds: 3600, custom_keyword_min_hits: 2,
+                                      punishment: "none", timeout_seconds: 3600,
+                                      confirmed_punishment: "none", confirmed_timeout_seconds: 3600,
+                                      custom_keyword_min_hits: 2,
                                       custom_keywords: [], enabled: "0"}},
             **turbo
           expect(response.media_type).to eq("text/vnd.turbo-stream.html")
@@ -117,7 +119,9 @@ RSpec.describe "Image scanning config", type: :request do
 
           patch server_image_scanning_path(guild.id),
             params: {image_scanning: {sensitivity: "standard", action: "delete",
-                                      punishment: "none", timeout_seconds: 3600, custom_keyword_min_hits: 2,
+                                      punishment: "none", timeout_seconds: 3600,
+                                      confirmed_punishment: "none", confirmed_timeout_seconds: 3600,
+                                      custom_keyword_min_hits: 2,
                                       custom_keywords: [], enabled: "1"}},
             **turbo
           expect(response).to have_http_status(:unprocessable_content)
@@ -126,7 +130,9 @@ RSpec.describe "Image scanning config", type: :request do
         it "falls back to a redirect without Turbo" do
           patch server_image_scanning_path(guild.id),
             params: {image_scanning: {sensitivity: "standard", action: "delete",
-                                      punishment: "none", timeout_seconds: 3600, custom_keyword_min_hits: 2,
+                                      punishment: "none", timeout_seconds: 3600,
+                                      confirmed_punishment: "none", confirmed_timeout_seconds: 3600,
+                                      custom_keyword_min_hits: 2,
                                       custom_keywords: [], enabled: "0"}}
           expect(response).to redirect_to(server_image_scanning_path(guild.id))
         end
@@ -135,7 +141,9 @@ RSpec.describe "Image scanning config", type: :request do
           subject(:patch_from_overview) do
             patch server_image_scanning_path(guild.id),
               params: {image_scanning: {sensitivity: "standard", action: "delete",
-                                        punishment: "none", timeout_seconds: 3600, custom_keyword_min_hits: 2,
+                                        punishment: "none", timeout_seconds: 3600,
+                                        confirmed_punishment: "none", confirmed_timeout_seconds: 3600,
+                                        custom_keyword_min_hits: 2,
                                         custom_keywords: [], enabled: "0"},
                        from_overview: "1"}
           end


### PR DESCRIPTION
## What

Image scanning applied a **single** punishment to every removed image — a first-time heuristic hit and a mod-verified scam were treated identically. This adds a second, escalated tier.

- **`confirmed_punishment`** (`none`/`timeout`/`kick`/`ban`) + **`confirmed_timeout_seconds`** on `image_scanning_settings`.
- Fires **only** when a scanned image matches a phash confirmed as scam **on this server** (`hash_state == :own_confirmed`), and **supersedes** the general `punishment` — one action runs, never both.
- `:foreign_confirmed` (confirmed on *other* servers) deliberately does **not** escalate.
- Defaults to `none` — existing servers see no behaviour change until a mod opts in.

## How

- Escalation decision lives in `VerdictExecutor#punish`, which now takes `hash_state` (threaded from `ScanProcessor`) and picks the tier.
- Reuses the existing `PunishmentControl` component for both tiers; its timeout-field-name derivation is generalised from `[punishment]` to any `*punishment` field (backward-compatible for the general tier and `spam_protection`).
- Migration adds both columns with mirrored DB check constraints; model validations mirror them.

## Privacy

No policy change: these are guild-scoped config enums (like the existing `punishment`), not personal data, and already cascade-purge via `server_configuration`.

## Tests

Model enum/range, executor escalation branches (own → confirmed tier, own+none → no punish, foreign → general tier), control field-name derivation, form-component fields, processor call args, configure op, request params. Full suite 1681 green; standardrb, active_record_doctor, undercover, i18n-tasks all clean.

<sub>🤖 Authored with [Claude Code](https://claude.com/claude-code)</sub>