### PR TITLE
Tooltip convention doc + strip em-dashes from copy

### DIFF
--- a/app/components/legal_page.rb
+++ b/app/components/legal_page.rb
@@ -29,7 +29,7 @@ class Components::LegalPage < Components::Base
   def contact_section
     h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { t(".contact_h") }
     p(class: "mb-4 leading-relaxed text-text-secondary") do
-      plain "#{t(".contact_operator")} — "
+      plain "#{t(".contact_operator")} - "
       a(href: "mailto:#{CONTACT_EMAIL}", class: link_classes) { CONTACT_EMAIL }
       plain " / "
       a(href: SUPPORT_URL, class: link_classes) { t(".contact_support") }

--- a/config/locales/legal.en.yml
+++ b/config/locales/legal.en.yml
@@ -29,9 +29,9 @@ en:
         an admin has enabled.'
       basis_h: Legal bases
       basis_p: Where the GDPR applies we rely on performance of the service (Art.
-        6(1)(b) — providing the features you or your admins enable) and legitimate
-        interests (Art. 6(1)(f) — operating, securing and debugging the Service).
-        You can object to processing based on legitimate interests — see "Your rights".
+        6(1)(b) - providing the features you or your admins enable) and legitimate
+        interests (Art. 6(1)(f) - operating, securing and debugging the Service).
+        You can object to processing based on legitimate interests; see "Your rights".
       changes_h: Changes
       changes_p: If this policy changes, the new version is published here with an
         updated date; for significant changes we'll try to give notice through the
@@ -45,17 +45,17 @@ en:
         described above. No tracking, no third-party cookies.'
       data_account: 'Dashboard account: when you sign in with Discord we store your
         Discord ID, username, display name and avatar reference. We request only the
-        identify and guilds OAuth scopes — we never receive your email, password or
+        identify and guilds OAuth scopes - we never receive your email, password or
         messages. Your Discord access token is held only in an encrypted session cookie
         in your browser (valid two weeks), never in our database, and is used solely
         to read which servers you manage.'
       data_guild: 'Server configuration: the server''s Discord ID, name, icon reference
         and approximate member count, plus a cached copy of its channels and roles
         (IDs, names, types, colours, positions, permission sets) and their permission
-        overwrites — which can reference member Discord IDs — mirrored from Discord
+        overwrites (which can reference member Discord IDs) mirrored from Discord
         so the dashboard can display and apply your setup. Also which plugins are
         enabled, and the welcome, logging, role-menu and moderation settings admins
-        configure — including any custom scam-keyword list.'
+        configure - including any custom scam-keyword list.'
       data_h: What we store and why
       data_lead: 'We store only what the enabled features need:'
       data_notifications: 'Dashboard notifications: short activity entries (an event
@@ -66,7 +66,7 @@ en:
         30 days. The web server keeps standard technical logs (IP address, timestamp,
         browser type) for security and troubleshooting.'
       data_reminders: 'Reminders: the reminder text you write, your Discord ID, the
-        target channel and server, whether to deliver by DM, and the due time — kept
+        target channel and server, whether to deliver by DM, and the due time - kept
         until delivered or deleted by you with /unremind.'
       deletion_account: Delete your dashboard account and your reminders with the
         "Delete my account" button on your account page.
@@ -77,14 +77,14 @@ en:
       deletion_reminders: Delete individual reminders with /unremind.
       intro_1: This policy explains what the shrkbot Discord bot and its web dashboard
         (together, the "Service") store, why, and the choices you have. It's written
-        to be readable rather than dense — if anything is unclear, contact us.
+        to be readable rather than dense - if anything is unclear, contact us.
       intro_2: The Service is operated by Tim Engelhardt, the data controller under
         the EU General Data Protection Regulation (GDPR).
       messages_h: Message content
       messages_p_1: shrkbot uses Discord's message-content intent so that servers
         can enable automated moderation. When an admin turns that feature on, shrkbot
-        reads new messages — including, using optical character recognition (OCR),
-        text contained in posted images — to check them against the server's rules.
+        reads new messages, including, using optical character recognition (OCR),
+        text contained in posted images, to check them against the server's rules.
         On servers that don't enable moderation, messages aren't processed at all.
       messages_p_2: 'This scanning happens in real time and in memory only: we do
         not store or retain message content, images, or text extracted from images.
@@ -93,7 +93,7 @@ en:
       messages_p_3: If automated moderation acts on a message, shrkbot can post a
         moderation log entry to a channel your admins designate. That entry may include
         the offending message or the text extracted from an image so moderators can
-        review it — it is delivered as an ordinary Discord message and is therefore
+        review it - it is delivered as an ordinary Discord message and is therefore
         stored by Discord in that channel, not retained by shrkbot. A short record
         that an action occurred (without the message content) may also appear in the
         dashboard.
@@ -101,11 +101,11 @@ en:
         welcome messages; the username shown there is rendered into the message and
         not stored.
       messages_p_5: To recognise repeat scam images, shrkbot stores a perceptual hash
-        — a short numeric fingerprint that cannot be turned back into the image —
-        of images a server's moderators explicitly confirm as scams, together with
-        which servers confirmed them. These fingerprints are never linked to the user
-        who posted the image, are deleted when every confirming server has removed
-        the bot, and are pruned automatically after 30 days without a match.
+        (a short numeric fingerprint that cannot be turned back into the image) of
+        images a server's moderators explicitly confirm as scams, together with which
+        servers confirmed them. These fingerprints are never linked to the user who
+        posted the image, are deleted when every confirming server has removed the
+        bot, and are pruned automatically after 30 days without a match.
       not_h: What we don't do
       not_p: We don't sell data, we don't advertise, we don't profile you, we don't
         run analytics, and we don't store your servers' member lists or conversations.
@@ -125,7 +125,7 @@ en:
       rights_h: Your rights
       rights_p: Under the GDPR you have the right to access, correct, delete, restrict
         or object to our use of your personal data, and the right to data portability.
-        You also have the right to complain to a supervisory authority — in Germany,
+        You also have the right to complain to a supervisory authority - in Germany,
         your regional data protection authority. To exercise any of these, contact
         us (see below).
       security_h: Security
@@ -136,14 +136,14 @@ en:
       sharing_h: Who we share data with
       sharing_p: 'Only the infrastructure that runs the Service: Discord itself, through
         its API (your use of Discord is governed by Discord''s own privacy policy),
-        and our hosting provider Hetzner (Helsinki, Finland — within the EEA), where
+        and our hosting provider Hetzner (Helsinki, Finland, within the EEA), where
         the Service and its database run. We may disclose data where required by law.'
       title: Privacy policy
       updated: 'Last updated: July 5th, 2026'
     terms_of_service:
       admin_h: Your responsibilities as a server admin
       admin_p: If you add shrkbot to a server or configure it, you're responsible
-        for how it's used there — including any messages you configure it to send
+        for how it's used there - including any messages you configure it to send
         (such as welcome messages) and any logging you enable. Where you enable features
         that process other members' data, you're responsible for having a proper basis
         to do so and for informing your members as applicable law requires.
@@ -180,9 +180,9 @@ en:
       privacy_post: ", which forms part of these terms."
       privacy_pre: 'Our handling of data is described in our '
       service_h: The service
-      service_p: shrkbot is a general-purpose Discord bot whose features — self-assignable
+      service_p: shrkbot is a general-purpose Discord bot whose features (self-assignable
         roles, reminders, welcome and leave messages, activity logging and automated
-        moderation — are enabled per server and configured through commands and this
+        moderation) are enabled per server and configured through commands and this
         website. The Service is provided free of charge.
       source_h: Open source
       source_p: shrkbot's source code is published under the MIT licence. That licence
@@ -190,7 +190,7 @@ en:
         terms.
       termination_h: Termination
       termination_p: You can stop using the Service at any time by removing shrkbot
-        from your server — which permanently deletes that server's data — or by deleting
+        from your server (which permanently deletes that server's data) or by deleting
         your dashboard account. We may restrict or terminate access for any server
         or user that breaches these terms or that we reasonably believe is misusing
         the Service.

--- a/config/locales/moderation.en.yml
+++ b/config/locales/moderation.en.yml
@@ -3,7 +3,7 @@ en:
   moderation:
     image_scanning:
       buttons:
-        confirmed: Confirmed as a scam by %{actor} — the bot will remember this image.
+        confirmed: Confirmed as a scam by %{actor} - the bot will remember this image.
         dismiss_button: Yes, dismiss
         dismiss_prompt: Dismiss this detection? This tells the bot the image is not
           a scam.
@@ -13,7 +13,7 @@ en:
       flag:
         body: "%{author} posted an image in %{channel}. [Jump to message](%{jump_url})."
         meta:
-          flagged: Flagged for review — no automatic action taken.
+          flagged: Flagged for review - no automatic action taken.
           removed: The message was deleted automatically.
         reasons:
           custom_keywords:
@@ -41,7 +41,7 @@ en:
           body: "%{reporter} reported an image posted by %{author} in %{channel} as
             a scam. The bot will remember it."
           meta:
-            kept: The message was left in place — automatic removal is turned off.
+            kept: The message was left in place - automatic removal is turned off.
             removed: The message was deleted.
           title: Image reported as a scam
         none: That message has no images to report.
@@ -57,7 +57,7 @@ en:
           meta: Deleted as part of the incident above.
           title: Cross-channel spam follow-up removed
         meta:
-          notify_only: Notify-only — no messages were deleted.
+          notify_only: Notify-only - no messages were deleted.
           purge: Messages were deleted.
         title:
           notify_only: Cross-channel spam detected

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -499,7 +499,7 @@ en:
         show:
           description: Detects the same message blasted across multiple channels within
             seconds and purges it before it spreads. Matching is fingerprint-based
-            — message content is never stored.
+            - message content is never stored.
           group_locked_reason: Enable the Server Shield group first - its master switch
             is off.
           no_role_callout_body: Every Moderation sub-plugin needs the shared staff

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -83,11 +83,13 @@ the control in place plus a toast — no page reload (the dashboard's plugin-ena
 and `force_dm_reminders` toggles). **Field** (no `url:`) renders just the switch to
 sit inside a larger form that saves explicitly.
 
-For a control that needs a "why" on hover (a locked toggle, later a
-disabled-with-reason select option), wrap it in `Components::Tooltip` rather than
-a native `title`: it fades in instantly with our surfaces and fonts, where the
-native tooltip is slow, tiny, and system-font. The reminders dashboard row uses
-it on its always-on (locked) toggle.
+**Every tooltip uses `Components::Tooltip` — never a native `title`.** Whenever a
+control needs a "why" on hover (a locked toggle, a disabled-with-reason select
+option), wrap it in the component: it fades in instantly with our surfaces and
+fonts, where the native tooltip is slow, tiny, and system-font. The reminders
+dashboard row uses it on its always-on (locked) toggle. The one exception is the
+assignable-role picker, whose tooltip sits inside a native `<select>` dropdown
+where the component can't render — that stays a native `title`.
 
 That split is the save model: standalone settings save instantly; **the plugin
 config pages do not auto-save** — they batch all edits behind an explicit save


### PR DESCRIPTION
Two small, unrelated bits bundled per request.

## 1. Tooltip convention (docs)

`docs/design-system.md`: promote the soft "prefer `Components::Tooltip` over native `title`" note to a firm rule — **every tooltip uses the component**. Documents the one exception (the assignable-role picker, whose tooltip sits inside a native `<select>` where the component can't render).

## 2. Strip em-dashes from user-facing copy

Em-dashes read as an AI tell. Removed all 24 from user-facing copy (privacy policy, terms, moderation messages, web dashboard, the legal-page contact line):
- plain dash where a dash is the right punctuation;
- parentheses for parenthetical asides;
- a comma/semicolon where those read better.

**No wording changes** — punctuation only. A vocabulary/rhetorical AI-ism sweep (seamless, robust, leverage, "not just X but Y", smart quotes, CTA filler, etc.) turned up nothing; em-dashes were the only tell.

Left alone: one em-dash in a `bin/bot` **log** line (developer-facing, not website copy) and the en-dash in the imprint address (`c/o flexdienst – #21478`, formatting as provided).

## Verification
- `rspec` 1683/0, `standardrb`, `active_record_doctor`, `undercover` clean
- `i18n-tasks missing` + `check-normalized` clean (locales re-normalized)

🤖 Generated with [Claude Code](https://claude.com/claude-code)