### PR TITLE
Name the dashboard domain layer "server", not "guild"

### DIFF
--- a/app/components/plugin_shell.rb
+++ b/app/components/plugin_shell.rb
@@ -10,9 +10,9 @@ class Components::PluginShell < Components::Base
   def view_template(&block)
     render Components::AppShell.new(
       user: @user,
-      current_server: switcher&.guild,
+      current_server: switcher&.server,
       current_server_id: @server_configuration.discord_id,
-      servers: switcher&.configured_guilds || [],
+      servers: switcher&.configured_servers || [],
       plugin_counts: switcher&.plugin_counts || {},
       sidebar: Components::PluginSidebar.new(server_configuration: @server_configuration, active_key: @active_key)
     ), &block

--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -9,11 +9,11 @@ class ServersController < ApplicationController
   rescue_from Bot::Discord::UserGuilds::Unauthorized, with: :reauthenticate
 
   def index
-    manageable = ManageableGuilds.for(session[:discord_token])
+    manageable = ManageableServers.for(session[:discord_token])
     session.delete(:reauth_attempted)
     configured = ServerConfiguration.configured_ids_among(manageable.map(&:id))
     remember_manageable_servers(configured)
-    present, absent = manageable.partition { |guild| configured.include?(guild.id) }
+    present, absent = manageable.partition { |server| configured.include?(server.id) }
 
     render Views::Servers::Index.new(
       present:,
@@ -25,11 +25,11 @@ class ServersController < ApplicationController
 
   def show
     render Views::Servers::Show.new(
-      guild: @guild,
+      server: @server,
       server_configuration: @server_configuration,
       plugins: PluginStatus.rows(@server_configuration),
       user: current_user,
-      servers: @configured_guilds,
+      servers: @configured_servers,
       plugin_counts: @plugin_counts
     )
   end
@@ -45,9 +45,9 @@ class ServersController < ApplicationController
     return redirect_to(servers_path, alert: t("servers.not_found")) unless result
 
     remember_manageable_servers(result.configured_ids)
-    @guild = result.guild
+    @server = result.server
     @server_configuration = result.server_configuration
-    @configured_guilds = result.configured_guilds
+    @configured_servers = result.configured_servers
     @plugin_counts = result.plugin_counts
   end
 

--- a/app/presenters/cached_dashboard.rb
+++ b/app/presenters/cached_dashboard.rb
@@ -14,12 +14,12 @@ class CachedDashboard
     @configs = configs
   end
 
-  def guild
-    configured_guilds.find { |guild| guild.id == server_configuration.discord_id }
+  def server
+    configured_servers.find { |server| server.id == server_configuration.discord_id }
   end
 
-  def configured_guilds
-    @configured_guilds ||= @configs.sort_by { |config| -config.member_count.to_i }.map { |config| CachedGuild.from(config) }
+  def configured_servers
+    @configured_servers ||= @configs.sort_by { |config| -config.member_count.to_i }.map { |config| CachedGuild.from(config) }
   end
 
   def plugin_counts

--- a/app/presenters/manageable_servers.rb
+++ b/app/presenters/manageable_servers.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-class ManageableGuilds
+class ManageableServers
   def self.for(discord_token)
     Bot::Discord::UserGuilds.call(discord_token)
       .select(&:manageable?)
-      .sort_by { |guild| -guild.member_count.to_i }
+      .sort_by { |server| -server.member_count.to_i }
   end
 end

--- a/app/presenters/server_dashboard.rb
+++ b/app/presenters/server_dashboard.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ServerDashboard
-  Result = Data.define(:guild, :server_configuration, :configured_guilds, :plugin_counts, :configured_ids)
+  Result = Data.define(:server, :server_configuration, :configured_servers, :plugin_counts, :configured_ids)
 
   def self.resolve(discord_token:, target_id:, cached_ids:)
     new(discord_token:, target_id:, cached_ids:).resolve
@@ -24,16 +24,16 @@ class ServerDashboard
   private
 
   def live
-    manageable = ManageableGuilds.for(@discord_token)
-    guild = manageable.find { |candidate| candidate.id == @target_id }
-    config = ServerConfiguration.find_by(discord_id: @target_id) if guild
-    return unless guild && config
+    manageable = ManageableServers.for(@discord_token)
+    server = manageable.find { |candidate| candidate.id == @target_id }
+    config = ServerConfiguration.find_by(discord_id: @target_id) if server
+    return unless server && config
 
     ids = ServerConfiguration.configured_ids_among(manageable.map(&:id))
     Result.new(
-      guild:,
+      server:,
       server_configuration: config,
-      configured_guilds: manageable.select { |candidate| ids.include?(candidate.id) },
+      configured_servers: manageable.select { |candidate| ids.include?(candidate.id) },
       plugin_counts: PluginActivation.enabled_counts_for(ids),
       configured_ids: ids
     )
@@ -44,9 +44,9 @@ class ServerDashboard
     return unless dashboard
 
     Result.new(
-      guild: dashboard.guild,
+      server: dashboard.server,
       server_configuration: dashboard.server_configuration,
-      configured_guilds: dashboard.configured_guilds,
+      configured_servers: dashboard.configured_servers,
       plugin_counts: dashboard.plugin_counts,
       configured_ids: @cached_ids
     )

--- a/app/views/servers/index.rb
+++ b/app/views/servers/index.rb
@@ -36,37 +36,37 @@ class Views::Servers::Index < Views::Base
 
   def server_grid
     div(class: "grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3") do
-      @present.each { |guild| present_card(guild) }
-      @absent.each { |guild| invite_card(guild) }
+      @present.each { |server| present_card(server) }
+      @absent.each { |server| invite_card(server) }
     end
   end
 
-  def present_card(guild)
-    render Components::Card.new(href: server_path(guild.id), lift: true, class: "flex flex-col gap-3") do
-      identity(guild)
-      plugins_badge(@plugin_counts[guild.id].to_i)
+  def present_card(server)
+    render Components::Card.new(href: server_path(server.id), lift: true, class: "flex flex-col gap-3") do
+      identity(server)
+      plugins_badge(@plugin_counts[server.id].to_i)
     end
   end
 
-  def invite_card(guild)
+  def invite_card(server)
     render Components::Card.new(dashed: true, class: "flex flex-col gap-3") do
-      identity(guild, muted: true)
-      invite_button(invite_url(guild))
+      identity(server, muted: true)
+      invite_button(invite_url(server))
     end
   end
 
-  def identity(guild, muted: false)
+  def identity(server, muted: false)
     div(class: "flex items-start gap-3") do
-      avatar(guild, muted:)
+      avatar(server, muted:)
       div(class: "min-w-0") do
-        p(class: "text-sm font-semibold line-clamp-2") { guild.name }
-        p(class: "text-xs text-text-secondary") { member_label(guild) } if guild.member_count
+        p(class: "text-sm font-semibold line-clamp-2") { server.name }
+        p(class: "text-xs text-text-secondary") { member_label(server) } if server.member_count
       end
     end
   end
 
-  def avatar(guild, muted: false)
-    render Components::ServerAvatar.new(server: guild, size: :lg, tone: :sunken, dim: muted)
+  def avatar(server, muted: false)
+    render Components::ServerAvatar.new(server:, size: :lg, tone: :sunken, dim: muted)
   end
 
   def plugins_badge(count)
@@ -75,8 +75,8 @@ class Views::Servers::Index < Views::Base
     end
   end
 
-  def member_label(guild)
-    t(".members", count: guild.member_count, formatted: guild.member_count.to_fs(:delimited))
+  def member_label(server)
+    t(".members", count: server.member_count, formatted: server.member_count.to_fs(:delimited))
   end
 
   def invite_button(url)
@@ -112,7 +112,7 @@ class Views::Servers::Index < Views::Base
     Bot::Config.invite_url
   end
 
-  def invite_url(guild)
-    "#{generic_invite_url}&guild_id=#{guild.id}&disable_guild_select=true"
+  def invite_url(server)
+    "#{generic_invite_url}&guild_id=#{server.id}&disable_guild_select=true"
   end
 end

--- a/app/views/servers/show.rb
+++ b/app/views/servers/show.rb
@@ -3,8 +3,8 @@
 class Views::Servers::Show < Views::Base
   include Components::PluginNav
 
-  def initialize(guild:, server_configuration:, plugins:, user:, servers: [], plugin_counts: {})
-    @guild = guild
+  def initialize(server:, server_configuration:, plugins:, user:, servers: [], plugin_counts: {})
+    @server = server
     @server_configuration = server_configuration
     @plugins = plugins
     @user = user
@@ -13,12 +13,12 @@ class Views::Servers::Show < Views::Base
   end
 
   def view_template
-    render Components::AppShell.new(user: @user, current_server: @guild, servers: @servers, plugin_counts: @plugin_counts) do
+    render Components::AppShell.new(user: @user, current_server: @server, servers: @servers, plugin_counts: @plugin_counts) do
       div(class: "mx-auto max-w-3xl px-6 py-8") do
         render Components::Breadcrumb.new(
           [
             {label: t(".breadcrumb_servers"), href: servers_path},
-            {label: @guild.name}
+            {label: @server.name}
           ]
         )
         server_header
@@ -33,14 +33,14 @@ class Views::Servers::Show < Views::Base
     div(class: "mb-6 flex items-center gap-4") do
       avatar
       div do
-        h1(class: "font-display text-2xl font-bold tracking-tight") { @guild.name }
+        h1(class: "font-display text-2xl font-bold tracking-tight") { @server.name }
         p(class: "text-sm text-text-secondary") { meta_line }
       end
     end
   end
 
   def avatar
-    render Components::ServerAvatar.new(server: @guild, size: :xl)
+    render Components::ServerAvatar.new(server: @server, size: :xl)
   end
 
   def meta_line
@@ -50,7 +50,7 @@ class Views::Servers::Show < Views::Base
       roles: t(".roles", count: @server_configuration.server_roles.count)
     )
     parts = []
-    parts << t(".members", count: @guild.member_count, formatted: @guild.member_count.to_fs(:delimited)) if @guild.member_count
+    parts << t(".members", count: @server.member_count, formatted: @server.member_count.to_fs(:delimited)) if @server.member_count
     parts << synced
     parts.join(" · ")
   end
@@ -58,8 +58,8 @@ class Views::Servers::Show < Views::Base
   def plugins_section
     p(class: "mb-3 text-[11px] font-semibold uppercase tracking-widest text-eyebrow") { t(".plugins") }
     div(class: "flex flex-col gap-3") do
-      @plugins.select { |row| plugin_config_path(@guild.id, row.key) && !PluginCatalog.sub_plugin?(row.key) }.each do |row|
-        render Components::PluginRow.new(server_id: @guild.id, key: row.key, enabled: row.enabled, configured: row.configured, locked: row.locked)
+      @plugins.select { |row| plugin_config_path(@server.id, row.key) && !PluginCatalog.sub_plugin?(row.key) }.each do |row|
+        render Components::PluginRow.new(server_id: @server.id, key: row.key, enabled: row.enabled, configured: row.configured, locked: row.locked)
       end
     end
   end

--- a/spec/presenters/cached_dashboard_spec.rb
+++ b/spec/presenters/cached_dashboard_spec.rb
@@ -44,34 +44,34 @@ RSpec.describe CachedDashboard do
     end
   end
 
-  describe "#guild" do
-    subject(:guild) do
+  describe "#server" do
+    subject(:server) do
       described_class.for(
         discord_id:,
         manageable_ids: [discord_id, other_id]
-      ).guild
+      ).server
     end
 
     it "returns a CachedGuild for the target server" do
-      expect(guild).to be_a(CachedGuild)
-      expect(guild.id).to eq(discord_id)
+      expect(server).to be_a(CachedGuild)
+      expect(server.id).to eq(discord_id)
     end
   end
 
-  describe "#configured_guilds" do
-    subject(:guilds) do
+  describe "#configured_servers" do
+    subject(:servers) do
       described_class.for(
         discord_id:,
         manageable_ids: [discord_id, other_id]
-      ).configured_guilds
+      ).configured_servers
     end
 
     it "returns CachedGuild instances for each manageable config" do
-      expect(guilds).to all(be_a(CachedGuild))
+      expect(servers).to all(be_a(CachedGuild))
     end
 
-    it "orders guilds by member_count descending" do
-      expect(guilds.map(&:id)).to eq([other_id, discord_id])
+    it "orders servers by member_count descending" do
+      expect(servers.map(&:id)).to eq([other_id, discord_id])
     end
   end
 

--- a/spec/presenters/manageable_servers_spec.rb
+++ b/spec/presenters/manageable_servers_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ManageableGuilds do
+RSpec.describe ManageableServers do
   describe ".for" do
     subject(:guilds) { described_class.for("tok") }
 

--- a/spec/presenters/server_dashboard_spec.rb
+++ b/spec/presenters/server_dashboard_spec.rb
@@ -30,16 +30,16 @@ RSpec.describe ServerDashboard do
       allow(Bot::Discord::UserGuilds).to receive(:call).with("tok").and_return([target_guild, other_guild])
     end
 
-    it "returns a Result with the correct guild" do
-      expect(result.guild).to eq(target_guild)
+    it "returns a Result with the correct server" do
+      expect(result.server).to eq(target_guild)
     end
 
     it "returns a Result with the correct server_configuration" do
       expect(result.server_configuration).to eq(config)
     end
 
-    it "returns configured_guilds containing both manageable configured guilds" do
-      expect(result.configured_guilds).to contain_exactly(target_guild, other_guild)
+    it "returns configured_servers containing both manageable configured servers" do
+      expect(result.configured_servers).to contain_exactly(target_guild, other_guild)
     end
 
     it "returns configured_ids for all configured manageable guilds" do


### PR DESCRIPTION
Follow-up to the Guild-vs-Server consistency audit. The audit found the codebase is ~90% principled — **Discord-API layer = Guild, domain/web layer = Server** — with one blurry seam: the web read path referred to the same manageable-server object as `guild` in some spots and `server` in others.

## Change

Rename the **domain-level** identifiers to `server`; leave the raw Discord-API *types* alone.

- `ManageableGuilds` presenter → `ManageableServers` (its whole consumer cluster is already `…ManageableServer…`).
- `ServerDashboard::Result` fields `guild`/`configured_guilds` → `server`/`configured_servers`.
- `CachedDashboard#guild`/`#configured_guilds` → `#server`/`#configured_servers`.
- Controller + view locals `@guild`/`@configured_guilds` → `@server`/`@configured_servers`; `Views::Servers::Show` `guild:` kwarg → `server:`.
- `plugin_shell` switcher accessors follow.

**Kept as-is** (correct by the rule):
- Types `Bot::Discord::Guild` and `CachedGuild` — the raw/duck-typed API objects.
- Discord's own vocabulary: the `guilds` OAuth scope, `guild_id`/`disable_guild_select` invite-URL params, guild-scoped command layer (`register_in :guild`, `GuildCommandSync`).

Net effect: the distinction is now unambiguous — **adapter type = `Guild`, every domain reference to it = `server`**. No behaviour change, no user-facing copy touched.

## Verification
- `rspec` 1683/0, `standardrb`, `active_record_doctor`, `undercover`, `zeitwerk:check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)