### PR TITLE
Add reek/flay/prosopite analysis; fix plugin-status N+1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,28 @@ jobs:
       - name: Scan for security vulnerabilities in JavaScript dependencies
         run: bin/importmap audit
 
+  smells:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      # Advisory SRP/DRY signal; findings are input for human judgment, not a
+      # gate. continue-on-error keeps a non-zero exit from failing the check.
+      - name: Report code smells
+        continue-on-error: true
+        run: bundle exec reek app/ lib/
+
+      - name: Report structural duplication
+        continue-on-error: true
+        run: bundle exec flay app/ lib/
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.reek.yml
+++ b/.reek.yml
@@ -1,0 +1,13 @@
+# Advisory only (non-blocking CI). Tuned to this project's conventions: reek
+# runs against business logic, not the Phlex view DSL, and smells that fight the
+# house style are disabled here rather than annotated per-occurrence.
+detectors:
+  # Modules are intentionally undocumented; naming and structure self-explain.
+  IrresponsibleModule:
+    enabled: false
+
+exclude_paths:
+  # Phlex templates are statement-heavy call chains by design; reek's method
+  # smells don't map onto a view DSL.
+  - app/views
+  - app/components

--- a/Gemfile
+++ b/Gemfile
@@ -88,6 +88,14 @@ group :development, :test do
   gem "simplecov-lcov", require: false
 
   gem "undercover", "0.8.5", require: false
+
+  # Advisory code-smell + structural-duplication analysis (SRP/DRY signal); non-blocking
+  gem "reek", require: false
+  gem "flay", require: false
+
+  # N+1 query detection in the test suite (raises on offending specs)
+  gem "prosopite", require: false
+  gem "pg_query", require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,35 @@ GEM
       dotenv (= 3.2.0)
       railties (>= 6.1)
     drb (2.2.3)
+    dry-configurable (1.4.0)
+      dry-core (~> 1.0)
+      zeitwerk (~> 2.6)
+    dry-core (1.2.0)
+      concurrent-ruby (~> 1.0)
+      logger
+      zeitwerk (~> 2.6)
+    dry-inflector (1.3.1)
+    dry-initializer (3.2.0)
+    dry-logic (1.6.0)
+      bigdecimal
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.1)
+      zeitwerk (~> 2.6)
+    dry-schema (1.16.0)
+      concurrent-ruby (~> 1.0)
+      dry-configurable (~> 1.0, >= 1.0.1)
+      dry-core (~> 1.1)
+      dry-initializer (~> 3.2)
+      dry-logic (~> 1.6)
+      dry-types (~> 1.9, >= 1.9.1)
+      zeitwerk (~> 2.6)
+    dry-types (1.9.1)
+      bigdecimal (>= 3.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.0)
+      dry-inflector (~> 1.0)
+      dry-logic (~> 1.4)
+      zeitwerk (~> 2.6)
     ed25519 (1.4.0)
     erb (6.0.4)
     erubi (1.13.1)
@@ -147,11 +176,34 @@ GEM
     ffi (1.17.4-arm64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
     ffi (1.17.4-x86_64-linux-musl)
+    flay (2.14.4)
+      erubi (~> 1.10)
+      path_expander (~> 2.0)
+      prism (~> 1.7)
+      sexp_processor (~> 4.0)
     fugit (1.12.2)
       et-orbi (~> 1.4)
       raabro (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    google-protobuf (4.35.1)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-aarch64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-aarch64-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-arm64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-x86_64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-x86_64-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
     hashie (5.1.0)
       logger
     highline (3.1.2)
@@ -291,12 +343,15 @@ GEM
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
+    path_expander (2.0.1)
     pg (1.6.3)
     pg (1.6.3-aarch64-linux)
     pg (1.6.3-aarch64-linux-musl)
     pg (1.6.3-arm64-darwin)
     pg (1.6.3-x86_64-linux)
     pg (1.6.3-x86_64-linux-musl)
+    pg_query (6.2.2)
+      google-protobuf (>= 3.25.3)
     phlex (2.4.1)
       refract (~> 1.0)
       zeitwerk (~> 2.7)
@@ -316,6 +371,7 @@ GEM
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
       rack
+    prosopite (2.2.0)
     psych (5.4.0)
       date
       stringio
@@ -382,6 +438,12 @@ GEM
       redis-client (>= 0.22.0)
     redis-client (0.30.0)
       connection_pool
+    reek (6.5.0)
+      dry-schema (~> 1.13)
+      logger (~> 1.6)
+      parser (~> 3.3.0)
+      rainbow (>= 2.0, < 4.0)
+      rexml (~> 3.1)
     refract (1.1.0)
       prism
       zeitwerk
@@ -393,6 +455,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
+    rexml (3.4.4)
     rspec-core (3.13.6)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.5)
@@ -435,6 +498,7 @@ GEM
     ruby-progressbar (1.13.0)
     rugged (1.9.0)
     securerandom (0.4.1)
+    sexp_processor (4.17.5)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -556,6 +620,7 @@ DEPENDENCIES
   discordrb!
   dotenv-rails
   factory_bot_rails
+  flay
   i18n-tasks
   image_processing (~> 2.0)
   importmap-rails
@@ -564,12 +629,15 @@ DEPENDENCIES
   omniauth-discord
   omniauth-rails_csrf_protection
   pg (~> 1.1)
+  pg_query
   phlex-rails
   phosphor_icons
   propshaft
+  prosopite
   puma (>= 5.0)
   rails (~> 8.1.3)
   redis
+  reek
   rspec-rails
   ruby-lsp
   simplecov
@@ -624,6 +692,13 @@ CHECKSUMS
   dotenv (3.2.0) sha256=e375b83121ea7ca4ce20f214740076129ab8514cd81378161f11c03853fe619d
   dotenv-rails (3.2.0) sha256=657e25554ba622ffc95d8c4f1670286510f47f2edda9f68293c3f661b303beab
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
+  dry-configurable (1.4.0) sha256=e35d1b5f3c081753ef361f564919db79000f32cfa6f20ee3a3ba5921b41b73ce
+  dry-core (1.2.0) sha256=0cc5a7da88df397f153947eeeae42e876e999c1e30900f3c536fb173854e96a1
+  dry-inflector (1.3.1) sha256=7fb0c2bb04f67638f25c52e7ba39ab435d922a3a5c3cd196120f63accb682dcc
+  dry-initializer (3.2.0) sha256=37d59798f912dc0a1efe14a4db4a9306989007b302dcd5f25d0a2a20c166c4e3
+  dry-logic (1.6.0) sha256=da6fedbc0f90fc41f9b0cc7e6f05f5d529d1efaef6c8dcc8e0733f685745cea2
+  dry-schema (1.16.0) sha256=cd3aaeabc0f1af66ec82a29096d4c4fb92a0a58b9dae29a22b1bbceb78985727
+  dry-types (1.9.1) sha256=baebeecdb9f8395d6c9d227b62011279440943e3ef2468fe8ccc1ba11467f178
   ed25519 (1.4.0) sha256=16e97f5198689a154247169f3453ef4cfd3f7a47481fde0ae33206cdfdcac506
   erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
@@ -640,8 +715,15 @@ CHECKSUMS
   ffi (1.17.4-arm64-darwin) sha256=19071aaf1419251b0a46852abf960e77330a3b334d13a4ab51d58b31a937001b
   ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d
   ffi (1.17.4-x86_64-linux-musl) sha256=3fdf9888483de005f8ef8d1cf2d3b20d86626af206cbf780f6a6a12439a9c49e
+  flay (2.14.4) sha256=a62d96a51d1da185aa41ba95b696966df9f7d1d91a457709277f24515895de77
   fugit (1.12.2) sha256=643f2bf28db263bd400cbf8e0dd8b76b2c9b94bdb130e12d2394de04d9c20e5e
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
+  google-protobuf (4.35.1) sha256=a3a6471331d918f58dfa4d014a8f6286f0af2cf4840216bde52fcf2ea3fe3726
+  google-protobuf (4.35.1-aarch64-linux-gnu) sha256=50ca44d0eeff3f8475e630a1accdd974256f3510694d574e2c9d6119ea8bc9e1
+  google-protobuf (4.35.1-aarch64-linux-musl) sha256=d5c65cef6bd6498a9e5ed5f88cf6cf7e341c10b0a005e32137d5d1a2b6e8c18a
+  google-protobuf (4.35.1-arm64-darwin) sha256=d9c957df04fa89c749fa9a72a7b383eb4296efc9b2303dc6fd6fbe39c698ad6b
+  google-protobuf (4.35.1-x86_64-linux-gnu) sha256=c786439087512a3fbd199e9897d265b855f951d4027e218ea55e858d45969edd
+  google-protobuf (4.35.1-x86_64-linux-musl) sha256=91890eb0002934a339fdb7d77a147c46b7474b6799db27872b747b905837f744
   hashie (5.1.0) sha256=c266471896f323c446ea8207f8ffac985d2718df0a0ba98651a3057096ca3870
   highline (3.1.2) sha256=67cbd34d19f6ef11a7ee1d82ffab5d36dfd5b3be861f450fc1716c7125f4bb4a
   http-accept (1.7.0) sha256=c626860682bfbb3b46462f8c39cd470fd7b0584f61b3cc9df5b2e9eb9972a126
@@ -697,12 +779,14 @@ CHECKSUMS
   ox (2.14.27) sha256=5e84f06124ee82e8178dfa4dd7fa2c10ec01d45c1be466ee7d1e4ec98d3b9b9c
   parallel (2.1.0) sha256=b35258865c2e31134c5ecb708beaaf6772adf9d5efae28e93e99260877b09356
   parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
+  path_expander (2.0.1) sha256=2de201164bff4719cc4d0b3767286e9977cc832a59c4d70abab571ec86cb41e4
   pg (1.6.3) sha256=1388d0563e13d2758c1089e35e973a3249e955c659592d10e5b77c468f628a99
   pg (1.6.3-aarch64-linux) sha256=0698ad563e02383c27510b76bf7d4cd2de19cd1d16a5013f375dd473e4be72ea
   pg (1.6.3-aarch64-linux-musl) sha256=06a75f4ea04b05140146f2a10550b8e0d9f006a79cdaf8b5b130cde40e3ecc2c
   pg (1.6.3-arm64-darwin) sha256=7240330b572e6355d7c75a7de535edb5dfcbd6295d9c7777df4d9dddfb8c0e5f
   pg (1.6.3-x86_64-linux) sha256=5d9e188c8f7a0295d162b7b88a768d8452a899977d44f3274d1946d67920ae8d
   pg (1.6.3-x86_64-linux-musl) sha256=9c9c90d98c72f78eb04c0f55e9618fe55d1512128e411035fe229ff427864009
+  pg_query (6.2.2) sha256=316c194160ccfac8af9a7aff55cdc5b2d13bdd8bd8734976c6bddc477e779b6f
   phlex (2.4.1) sha256=e596717fbfe38b5271840266758779ebe75092e02629f0c170287e6290a70b12
   phlex-rails (2.4.0) sha256=2bcddbd488681acb25753bab1887d3ac150e644244ff8ba307f2171a4d0195f5
   phosphor_icons (0.3.0) sha256=72a1358bad3056fd00e1fc6da8c942e764e37625b22717e692639b42c12653f4
@@ -710,6 +794,7 @@ CHECKSUMS
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
   propshaft (1.3.2) sha256=1d56a3e56a92c21bfc29caf07406b5386b00d4c47ddf357cf989a5a234b1389e
+  prosopite (2.2.0) sha256=14affaa3ff0ff15abe8f6ae2951de0984dc6da5df1c42333692d2c0789d08b91
   psych (5.4.0) sha256=14f72d69a611af663d7d70e4a7b67d9eb1f3ae9f8d916b478961d5a0075ba5b7
   puma (8.0.2) sha256=c8ed871dfbbe66448ea9ffd46692342d9804d4071522b52b5331b7b6e7b686fb
   raabro (1.4.0) sha256=d4fa9ff5172391edb92b242eed8be802d1934b1464061ae5e70d80962c5da882
@@ -730,10 +815,12 @@ CHECKSUMS
   rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
   redis (5.4.1) sha256=b5e675b57ad22b15c9bcc765d5ac26f60b675408af916d31527af9bd5a81faae
   redis-client (0.30.0) sha256=743f11ed42f0a41a0341554087b077479fec7e2d47a7c123fd90a12c0db5e477
+  reek (6.5.0) sha256=d26d3a492773b2bbc228888067a21afe33ac07954a17dbd64cdeae42c4c69be1
   refract (1.1.0) sha256=ee3b9627e39f7692831101e2fedd73e0d09a592ff5d5c05f171d14211fc7a9c7
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
   rest-client (2.1.0) sha256=35a6400bdb14fae28596618e312776c158f7ebbb0ccad752ff4fa142bf2747e3
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
   rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
   rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836
   rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
@@ -746,6 +833,7 @@ CHECKSUMS
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   rugged (1.9.0) sha256=7faaa912c5888d6e348d20fa31209b6409f1574346b1b80e309dbc7e8d63efac
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
+  sexp_processor (4.17.5) sha256=ae2b48ba98353d5d465ce8759836b7a05f2e12c5879fcd14d7815b026de32f0e
   simplecov (0.22.0) sha256=fe2622c7834ff23b98066bb0a854284b2729a569ac659f82621fc22ef36213a5
   simplecov-html (0.13.2) sha256=bd0b8e54e7c2d7685927e8d6286466359b6f16b18cb0df47b508e8d73c777246
   simplecov-lcov (0.9.0) sha256=7a77a31e200a595ed4b0249493056efd0c920601f53d2ef135ca34ee796346cd

--- a/app/models/plugin_catalog.rb
+++ b/app/models/plugin_catalog.rb
@@ -10,8 +10,8 @@ class PluginCatalog
       !channel_setting.nil?
     end
 
-    def prerequisites_met?(server_configuration)
-      return false unless required_plugins_enabled?(server_configuration)
+    def prerequisites_met?(server_configuration, enabled_keys: nil)
+      return false unless required_plugins_enabled?(server_configuration, enabled_keys)
       return false unless channel_met?(server_configuration)
       return false unless prerequisite.nil? || prerequisite.call(server_configuration)
 
@@ -20,10 +20,12 @@ class PluginCatalog
 
     private
 
-    def required_plugins_enabled?(server_configuration)
-      [requires_plugin, parent].compact.all? do |key|
-        server_configuration.plugins.enabled.exists?(key:)
-      end
+    def required_plugins_enabled?(server_configuration, enabled_keys)
+      required = [requires_plugin, parent].compact
+      return true if required.empty?
+
+      keys = enabled_keys || server_configuration.enabled_plugin_keys
+      required.all? { |key| keys.include?(key) }
     end
 
     def channel_met?(server_configuration)

--- a/app/models/server_configuration.rb
+++ b/app/models/server_configuration.rb
@@ -26,4 +26,8 @@ class ServerConfiguration < ApplicationRecord
   def icon_url
     Bot::Discord::CdnUrl.guild_icon(discord_id, icon_hash)
   end
+
+  def enabled_plugin_keys
+    plugins.enabled.pluck(:key).map(&:to_sym).to_set
+  end
 end

--- a/app/presenters/moderation/overview_context.rb
+++ b/app/presenters/moderation/overview_context.rb
@@ -14,11 +14,11 @@ module Moderation
     end
 
     def group_enabled?
-      @config.plugins.enabled.exists?(key: :moderation)
+      enabled_keys.include?(:moderation)
     end
 
     def logging_ready?
-      @config.plugins.enabled.exists?(key: :logging) &&
+      enabled_keys.include?(:logging) &&
         @config.logging_setting&.channel_id.present?
     end
 
@@ -55,8 +55,8 @@ module Moderation
           key:,
           name: definition.name,
           description: definition.description,
-          enabled: @config.plugins.enabled.exists?(key:),
-          configured: definition.prerequisites_met?(@config),
+          enabled: enabled_keys.include?(key),
+          configured: definition.prerequisites_met?(@config, enabled_keys:),
           settings:
         )
       end
@@ -66,6 +66,12 @@ module Moderation
       return unless @config.logging_setting&.channel_id
 
       @config.server_channels.find_by(discord_id: @config.logging_setting.channel_id)&.name
+    end
+
+    private
+
+    def enabled_keys
+      @enabled_keys ||= @config.enabled_plugin_keys
     end
   end
 end

--- a/app/presenters/moderation/sub_plugin_context.rb
+++ b/app/presenters/moderation/sub_plugin_context.rb
@@ -8,7 +8,7 @@ module Moderation
     end
 
     def group_enabled?
-      @config.plugins.enabled.exists?(key: :moderation)
+      enabled_keys.include?(:moderation)
     end
 
     def staff_role_present?
@@ -16,7 +16,7 @@ module Moderation
     end
 
     def plugin_enabled?
-      @config.plugins.enabled.exists?(key: @plugin_key)
+      enabled_keys.include?(@plugin_key)
     end
 
     def settings
@@ -25,6 +25,12 @@ module Moderation
       else
         @config.image_scanning_settings
       end
+    end
+
+    private
+
+    def enabled_keys
+      @enabled_keys ||= @config.enabled_plugin_keys
     end
   end
 end

--- a/app/presenters/plugin_status.rb
+++ b/app/presenters/plugin_status.rb
@@ -13,11 +13,12 @@ class PluginStatus
 
   def self.rows(server_configuration)
     activations = server_configuration.plugin_activations.includes(:plugin).index_by { |activation| activation.plugin.key }
+    enabled_keys = server_configuration.enabled_plugin_keys
     catalog_rows = PluginCatalog.all.map do |definition|
       Row.new(
         key: definition.key,
         enabled: activations[definition.key]&.enabled? || false,
-        configured: definition.prerequisites_met?(server_configuration)
+        configured: definition.prerequisites_met?(server_configuration, enabled_keys:)
       )
     end
     catalog_rows + ALWAYS_ON
@@ -28,7 +29,7 @@ class PluginStatus
     Row.new(
       key: plugin.key,
       enabled: activation&.enabled? || false,
-      configured: PluginCatalog.find(plugin.key).prerequisites_met?(server_configuration)
+      configured: PluginCatalog.find(plugin.key).prerequisites_met?(server_configuration, enabled_keys: server_configuration.enabled_plugin_keys)
     )
   end
 end

--- a/spec/models/plugin_catalog_spec.rb
+++ b/spec/models/plugin_catalog_spec.rb
@@ -98,18 +98,13 @@ RSpec.describe PluginCatalog do
       subject(:check) { requiring_definition.prerequisites_met?(config) }
 
       context "when required plugin is not enabled" do
-        let(:config) { double(plugins: double(enabled: double(exists?: false))) }
+        let(:config) { double(enabled_plugin_keys: Set[]) }
 
         it { is_expected.to be(false) }
       end
 
       context "when required plugin is enabled" do
-        let(:enabled_scope) do
-          scope = double
-          allow(scope).to receive(:exists?).with(key: :logging).and_return(true)
-          scope
-        end
-        let(:config) { double(plugins: double(enabled: enabled_scope)) }
+        let(:config) { double(enabled_plugin_keys: Set[:logging]) }
 
         it { is_expected.to be(true) }
       end
@@ -123,18 +118,13 @@ RSpec.describe PluginCatalog do
       subject(:check) { child_definition.prerequisites_met?(config) }
 
       context "when parent plugin is not enabled" do
-        let(:config) { double(plugins: double(enabled: double(exists?: false))) }
+        let(:config) { double(enabled_plugin_keys: Set[]) }
 
         it { is_expected.to be(false) }
       end
 
       context "when parent plugin is enabled" do
-        let(:enabled_scope) do
-          scope = double
-          allow(scope).to receive(:exists?).with(key: :moderation).and_return(true)
-          scope
-        end
-        let(:config) { double(plugins: double(enabled: enabled_scope)) }
+        let(:config) { double(enabled_plugin_keys: Set[:moderation]) }
 
         it { is_expected.to be(true) }
       end
@@ -282,11 +272,7 @@ RSpec.describe PluginCatalog do
   end
 
   describe "moderation prerequisite predicates" do
-    let(:enabled_scope) { double }
-
-    before do
-      allow(enabled_scope).to receive(:exists?).and_return(true)
-    end
+    let(:enabled_keys) { Set[:logging, :moderation] }
 
     describe ":moderation prerequisite" do
       subject(:check) { PluginCatalog.find(:moderation).prerequisites_met?(config) }
@@ -294,7 +280,7 @@ RSpec.describe PluginCatalog do
       context "when logging enabled but no logging channel" do
         let(:config) do
           double(
-            plugins: double(enabled: enabled_scope),
+            enabled_plugin_keys: enabled_keys,
             logging_setting: double(channel_id: nil)
           )
         end
@@ -305,7 +291,7 @@ RSpec.describe PluginCatalog do
       context "when logging enabled with a logging channel" do
         let(:config) do
           double(
-            plugins: double(enabled: enabled_scope),
+            enabled_plugin_keys: enabled_keys,
             logging_setting: double(channel_id: 999)
           )
         end
@@ -320,7 +306,7 @@ RSpec.describe PluginCatalog do
       context "when group enabled but no staff role" do
         let(:config) do
           double(
-            plugins: double(enabled: enabled_scope),
+            enabled_plugin_keys: enabled_keys,
             moderation_settings: double(staff_role_id: nil)
           )
         end
@@ -331,7 +317,7 @@ RSpec.describe PluginCatalog do
       context "when group enabled with staff role" do
         let(:config) do
           double(
-            plugins: double(enabled: enabled_scope),
+            enabled_plugin_keys: enabled_keys,
             moderation_settings: double(staff_role_id: 123)
           )
         end
@@ -346,7 +332,7 @@ RSpec.describe PluginCatalog do
       context "when group enabled but no staff role" do
         let(:config) do
           double(
-            plugins: double(enabled: enabled_scope),
+            enabled_plugin_keys: enabled_keys,
             moderation_settings: double(staff_role_id: nil)
           )
         end
@@ -357,7 +343,7 @@ RSpec.describe PluginCatalog do
       context "when group enabled with staff role" do
         let(:config) do
           double(
-            plugins: double(enabled: enabled_scope),
+            enabled_plugin_keys: enabled_keys,
             moderation_settings: double(staff_role_id: 456)
           )
         end

--- a/spec/models/server_configuration_spec.rb
+++ b/spec/models/server_configuration_spec.rb
@@ -31,6 +31,24 @@ RSpec.describe ServerConfiguration do
     end
   end
 
+  describe "#enabled_plugin_keys" do
+    subject(:keys) { server.enabled_plugin_keys }
+
+    let(:server) { create(:server_configuration, discord_id: 321) }
+    let(:logging) { create(:plugin, key: "logging", name: "Logging") }
+    let(:roles) { create(:plugin, key: "roles", name: "Roles") }
+
+    before do
+      server.create_logging_setting!(channel_id: 999)
+      create(:plugin_activation, server_configuration: server, plugin: logging, enabled: true)
+      create(:plugin_activation, server_configuration: server, plugin: roles, enabled: false)
+    end
+
+    it "returns the enabled plugin keys as a symbol set" do
+      expect(keys).to eq(Set[:logging])
+    end
+  end
+
   describe "plugin_activations uniqueness" do
     subject(:activation) { server.plugin_activations.build(plugin:) }
 

--- a/spec/support/prosopite.rb
+++ b/spec/support/prosopite.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "prosopite"
+
+# Scoped to request specs while the backend N+1 backlog is burned down.
+RSpec.configure do |config|
+  config.before(:each, type: :request) do
+    Prosopite.scan
+  end
+
+  config.after(:each, type: :request) do
+    Prosopite.finish
+  end
+end
+
+Prosopite.raise = true
+Prosopite.rails_logger = false


### PR DESCRIPTION
## What

Wires three static-analysis tools and fixes the first real bug one of them found.

| Tool | Scans | Wiring |
|------|-------|--------|
| **reek** | code smells (SRP/DRY) | non-blocking CI `smells` job (`continue-on-error`) |
| **flay** | structural duplication | same job |
| **prosopite** | N+1 queries | raises in **request specs** |

Dependabot was already configured — no change.

### reek/flay are advisory
Their raw output (394 tuned / 2944) is mostly noise against Phlex + zero-comment conventions, so the job is non-blocking and `.reek.yml` points reek at business logic (not the view DSL) with house-style-fighting smells disabled. Findings are input for judgment, not a gate.

### prosopite is scoped to request specs
That's the render path where an N+1 is a real user-facing regression, and every feature ships a request spec. Backend N+1s in the sync operations are a separate, coordinated cleanup (tracked out-of-band); enforcement extends to operation specs once that's burned down.

## The N+1 fix

prosopite flagged every plugin config page running **one enabled-check query per plugin** — rendering the plugin rows called `PluginCatalog#prerequisites_met?` per definition, each firing `plugins.enabled.exists?(key:)`.

Fix: resolve the enabled keys once via `ServerConfiguration#enabled_plugin_keys` and pass the set into `prerequisites_met?` at the render call sites; presenters memoize it per render.

**Subtlety:** the keys are resolved *fresh* (not memoized on the model). Creating a plugin activation validates its prerequisites, which reads the set — a model-level memo would be poisoned mid-mutation (enabling `moderation` then a sub-plugin in one flow read a stale set). Memoization lives only in the read-only presenters.

## Not in this PR (fix plan)

reek's SRP subset, flay's duplication clusters (the parallel per-plugin config controllers/views), and the backend sync-operation N+1s are curated into the outstanding-work list rather than fixed here — too broad, and mostly advisory. The point of this PR is the tooling + the one high-value render-path bug.

## Gates
rspec (1684, 0 failures), standardrb, active_record_doctor, undercover — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)