### PR TITLE
Fix backend N+1 queries in sync/config operations; enforce prosopite globally

### DIFF
--- a/app/models/roles/assignable_role.rb
+++ b/app/models/roles/assignable_role.rb
@@ -4,7 +4,7 @@ module Roles
   class AssignableRole < ApplicationRecord
     self.table_name = "assignable_roles"
 
-    belongs_to :role_set, class_name: "Roles::Set"
+    belongs_to :role_set, class_name: "Roles::Set", inverse_of: :assignable_roles
 
     validates :role_id, presence: true, uniqueness: {scope: :role_set_id}
   end

--- a/app/models/roles/set.rb
+++ b/app/models/roles/set.rb
@@ -4,9 +4,9 @@ module Roles
   class Set < ApplicationRecord
     self.table_name = "role_sets"
 
-    belongs_to :role_setting, class_name: "Roles::Settings"
+    belongs_to :role_setting, class_name: "Roles::Settings", inverse_of: :role_sets
     has_many :assignable_roles, -> { order(:position) }, class_name: "Roles::AssignableRole",
-      foreign_key: "role_set_id", dependent: :delete_all
+      foreign_key: "role_set_id", inverse_of: :role_set, dependent: :delete_all
 
     validates :name, presence: true
     validates :selection_mode, presence: true

--- a/app/models/roles/settings.rb
+++ b/app/models/roles/settings.rb
@@ -6,6 +6,6 @@ module Roles
 
     belongs_to :server_configuration
     has_many :role_sets, -> { order(:position) }, class_name: "Roles::Set",
-      foreign_key: "role_setting_id", dependent: :destroy
+      foreign_key: "role_setting_id", inverse_of: :role_setting, dependent: :destroy
   end
 end

--- a/app/operations/roles/configure.rb
+++ b/app/operations/roles/configure.rb
@@ -31,8 +31,9 @@ module Ops
       private
 
       def reconcile_sets(setting)
+        existing_sets = setting.role_sets.includes(:assignable_roles).index_by(&:id)
         kept = role_sets.reject { |attrs| truthy?(attrs[:_destroy]) }.filter_map do |attrs|
-          set = find_or_build_set(setting, attrs)
+          set = find_or_build_set(setting, attrs, existing_sets)
           next unless set
 
           old_channel = set.channel_override || @old_default_channel_id
@@ -63,19 +64,19 @@ module Ops
         doomed.destroy_all
       end
 
-      def find_or_build_set(setting, attrs)
-        return setting.role_sets.find_by(id: attrs[:id]) if attrs[:id].present?
+      def find_or_build_set(setting, attrs, existing_sets)
+        return existing_sets[attrs[:id]] if attrs[:id].present?
 
         setting.role_sets.new(position: next_position)
       end
 
       def reconcile_roles(set, role_ids)
-        existing = set.assignable_roles.index_by { |role| role.role_id }
+        existing = set.assignable_roles.loaded? ? set.assignable_roles.index_by(&:role_id) : {}
         role_ids.each_with_index do |role_id, index|
           role = existing[role_id] || set.assignable_roles.new(role_id:)
           role.update!(position: index)
         end
-        set.assignable_roles.where.not(role_id: role_ids).destroy_all
+        set.assignable_roles.where.not(role_id: role_ids).destroy_all if existing.any?
       end
 
       def assignable_ids(attrs)

--- a/app/operations/server_configuration/ensure.rb
+++ b/app/operations/server_configuration/ensure.rb
@@ -22,8 +22,9 @@ module Ops
       private
 
       def ensure_activations(config)
-        Plugin.find_each do |plugin|
-          PluginActivation.find_or_create_by!(server_configuration: config, plugin:) { |a| a.enabled = false }
+        existing_plugin_ids = config.plugin_activations.pluck(:plugin_id)
+        Plugin.where.not(id: existing_plugin_ids).find_each do |plugin|
+          PluginActivation.create!(server_configuration: config, plugin:, enabled: false)
         end
       end
 

--- a/app/operations/server_configuration/server_channels/sync.rb
+++ b/app/operations/server_configuration/server_channels/sync.rb
@@ -7,15 +7,16 @@ module Ops
         receives :server_configuration, :channels
 
         def call
-          channels.each { |data| sync_channel(data) }
+          existing = server_configuration.server_channels.includes(:channel_overwrites).index_by(&:discord_id)
+          channels.each { |data| sync_channel(data, existing) }
           server_configuration.server_channels.where.not(discord_id: channels.map { |c| c[:discord_id] }).destroy_all
           ok(server_configuration.server_channels.reload)
         end
 
         private
 
-        def sync_channel(data)
-          channel = server_configuration.server_channels.find_or_initialize_by(discord_id: data[:discord_id])
+        def sync_channel(data, existing)
+          channel = existing[data[:discord_id]] || server_configuration.server_channels.build(discord_id: data[:discord_id])
           channel.update!(
             name: data[:name],
             channel_type: data[:channel_type],
@@ -26,11 +27,12 @@ module Ops
         end
 
         def sync_overwrites(channel, overwrites)
+          existing = channel.channel_overwrites.loaded? ? channel.channel_overwrites.index_by(&:target_id) : {}
           overwrites.each do |data|
-            overwrite = channel.channel_overwrites.find_or_initialize_by(target_id: data[:target_id])
+            overwrite = existing[data[:target_id]] || channel.channel_overwrites.build(target_id: data[:target_id])
             overwrite.update!(target_type: data[:target_type], allow: data[:allow], deny: data[:deny])
           end
-          channel.channel_overwrites.where.not(target_id: overwrites.map { |o| o[:target_id] }).delete_all
+          channel.channel_overwrites.where.not(target_id: overwrites.map { |o| o[:target_id] }).delete_all if existing.any?
         end
       end
     end

--- a/app/operations/server_configuration/server_roles/sync.rb
+++ b/app/operations/server_configuration/server_roles/sync.rb
@@ -7,8 +7,9 @@ module Ops
         receives :server_configuration, :roles, :bot_role_position
 
         def call
+          existing = server_configuration.server_roles.index_by(&:discord_id)
           roles.each do |data|
-            role = server_configuration.server_roles.find_or_initialize_by(discord_id: data[:discord_id])
+            role = existing[data[:discord_id]] || server_configuration.server_roles.build(discord_id: data[:discord_id])
             role.update!(name: data[:name], position: data[:position], managed: data[:managed], color: data[:color] || 0, permissions: data[:permissions] || 0)
           end
           server_configuration.server_roles.where.not(discord_id: roles.map { |r| r[:discord_id] }).delete_all

--- a/app/plugins/moderation/sub_plugin_settings.rb
+++ b/app/plugins/moderation/sub_plugin_settings.rb
@@ -9,8 +9,8 @@ module Moderation
         config = ServerConfiguration.find_by(discord_id:)
         return unless config
 
-        enabled = config.plugins.enabled
-        return unless enabled.exists?(key: :moderation) && enabled.exists?(key: plugin_key)
+        enabled = config.enabled_plugin_keys
+        return unless enabled.include?(:moderation) && enabled.include?(plugin_key)
 
         yield config
       end

--- a/app/presenters/authorized_notifications.rb
+++ b/app/presenters/authorized_notifications.rb
@@ -13,7 +13,7 @@ class AuthorizedNotifications
       config = ServerConfiguration.find_by(discord_id: @server_id)
       return [] unless config
 
-      [[config, scoped.where(server_configuration: config).to_a]]
+      [[config, scoped.where(server_configuration: config).includes(:server_configuration).to_a]]
     else
       configs = ServerConfiguration
         .where(discord_id: @manageable_ids)

--- a/spec/support/prosopite.rb
+++ b/spec/support/prosopite.rb
@@ -2,13 +2,12 @@
 
 require "prosopite"
 
-# Scoped to request specs while the backend N+1 backlog is burned down.
 RSpec.configure do |config|
-  config.before(:each, type: :request) do
+  config.before(:each) do
     Prosopite.scan
   end
 
-  config.after(:each, type: :request) do
+  config.after(:each) do
     Prosopite.finish
   end
 end


### PR DESCRIPTION
## What

Kills the backend N+1 queries prosopite surfaced (the backlog deferred in #142), and flips prosopite from request-spec-scoped to **global enforcement** now that the backlog is clear.

## The N+1s

Each sync/config operation issued one query per iterated record — `find_or_initialize_by` / `find_by` / `exists?` inside a loop:

| Operation | Was | Now |
|-----------|-----|-----|
| `ServerRoles::Sync` | `find_or_initialize_by(discord_id:)` per role | preload `index_by(&:discord_id)`, look up in memory |
| `ServerChannels::Sync` (+ nested overwrites) | `find_or_initialize_by` per channel/overwrite | preload with `includes(:channel_overwrites)`, in-memory lookup |
| `Roles::Configure` | `find_by(id:)` per set + per-set role load | preload `role_sets.includes(:assignable_roles)` |
| `ServerConfiguration::Ensure` | `find_or_create_by!` per plugin | compute missing plugins in one query, insert only those |
| `Moderation::SubPluginSettings` | two `exists?` checks | one `enabled_plugin_keys` set |
| `AuthorizedNotifications#groups` | server-scoped branch lacked eager-load | `includes(:server_configuration)` |

For newly-built parents, the association read/cleanup is guarded on `loaded?` / presence so a fresh record never re-queries.

## Root-cause bonus: `inverse_of`

The last two N+1s (new role sets reloading their parent set + setting by id) were caused by the `Roles::Settings`/`Set`/`AssignableRole` associations using custom `class_name`/`foreign_key`, which blocks Rails' inverse inference. Added `inverse_of` on both sides — saving a new child now reuses the in-memory parent instead of reloading it.

## Enforcement

`spec/support/prosopite.rb` now scans **every** spec, not just request specs. Any new N+1 anywhere fails CI.

## Gates
rspec (1684, 0 failures), standardrb, active_record_doctor, undercover — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)