### PR TITLE
Fix curated reek smells: param clumps and repeated set-loading

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -1,10 +1,77 @@
 # Advisory only (non-blocking CI). Tuned to this project's conventions: reek
 # runs against business logic, not the Phlex view DSL, and smells that fight the
-# house style are disabled here rather than annotated per-occurrence.
+# house style are disabled here rather than annotated per-occurrence. Findings
+# that survive judgment get fixed; adjudicated false positives get excluded here
+# with a reason — the config is the rejection ledger (curated pass 2026-07-11).
 detectors:
   # Modules are intentionally undocumented; naming and structure self-explain.
   IrresponsibleModule:
     enabled: false
+
+  # Calling a method twice beats reflexive memoization here (memoizing can be
+  # actively wrong — see enabled_plugin_keys); ~107 hits, none actionable.
+  DuplicateMethodCall:
+    enabled: false
+
+  # Fires on locals referenced twice inside cohesive methods; the real
+  # move-this-logic cases are the convention review's job.
+  FeatureEnvy:
+    enabled: false
+
+  # Guard-clause style (find_by then return unless) is the house pattern;
+  # defensive-coding judgment decides which nils are real, not a detector.
+  NilCheck:
+    enabled: false
+
+  # Flags interface-consistency instance methods (ApplicationOperation#ok/
+  # failure, with_connection) and stateless helpers that belong where they are.
+  UtilityFunction:
+    enabled: false
+
+  # Cannot see Rails before_action-assigned ivars or macro-defined state
+  # (controllers, BaseCommand class-level DSL, the ops receives macro).
+  InstanceVariableAssumption:
+    enabled: false
+
+  # rescue => e, discard _, and loop/matrix indices are idiomatic; other
+  # single-letter names still flag as rename nudges.
+  UncommunicativeVariableName:
+    accept:
+      - e
+      - _
+      - i
+      - j
+      - k
+      - m
+      - n
+
+  # Classes holding their entry parameters as state (the DataClump fix reek
+  # itself asks for) legitimately reach 5; 6+ still flags. BaseCommand's ivars
+  # are the read-or-set macro DSL, not instance state.
+  TooManyInstanceVariables:
+    max_instance_variables: 5
+    exclude:
+      - "Bot::BaseCommand"
+
+  # Ops orchestration and event handlers run 6-8 statements by design; only
+  # genuinely fat methods (9+) are worth a look.
+  TooManyStatements:
+    max_statements: 8
+
+  # Keyword APIs and value-object initializers legitimately reach 5 params —
+  # the params ARE the data. 6+ still flags; adjudicated keyword surfaces below.
+  LongParameterList:
+    max_params: 5
+    exclude:
+      - "Moderation::ImageScanning::Classifier#decide" # 6 kwargs, internal, transposition-proof
+      - "PluginCatalog::Definition#initialize" # value-object init
+      - "Bot::ActivityLog#post" # generic log-entry keyword API, mostly defaulted
+
+  # Read-or-set class macros (command_name(value = nil)) are the sanctioned
+  # style; the repeated `if value` IS the macro.
+  RepeatedConditional:
+    exclude:
+      - "Bot::BaseCommand"
 
 exclude_paths:
   # Phlex templates are statement-heavy call chains by design; reek's method

--- a/app/bot/config/config_subscriber.rb
+++ b/app/bot/config/config_subscriber.rb
@@ -59,17 +59,15 @@ module Bot
     end
 
     def repost_roles(set_id)
-      set = Roles::Set.find_by(id: set_id)
-      return unless set
-
-      report(Ops::Roles::Messages::Repost.call(bot:, role_set: set), source: "roles_repost")
+      with_set(set_id, source: "roles_repost") do |set|
+        Ops::Roles::Messages::Repost.call(bot:, role_set: set)
+      end
     end
 
     def post_roles(set_id)
-      set = Roles::Set.find_by(id: set_id)
-      return unless set
-
-      report(Ops::Roles::Messages::Post.call(bot:, role_set: set), source: "roles_post")
+      with_set(set_id, source: "roles_post") do |set|
+        Ops::Roles::Messages::Post.call(bot:, role_set: set)
+      end
     end
 
     def delete_message(channel_id, message_id)
@@ -80,10 +78,16 @@ module Bot
     end
 
     def remove_menu(set_id)
+      with_set(set_id, source: "roles_menu_remove") do |set|
+        Ops::Roles::Messages::Remove.call(bot:, role_set: set)
+      end
+    end
+
+    def with_set(set_id, source:)
       set = Roles::Set.find_by(id: set_id)
       return unless set
 
-      report(Ops::Roles::Messages::Remove.call(bot:, role_set: set), source: "roles_menu_remove")
+      report(yield(set), source:)
     end
 
     def report(result, source:)

--- a/app/plugins/moderation/events/member_ban_log.rb
+++ b/app/plugins/moderation/events/member_ban_log.rb
@@ -14,7 +14,7 @@ module Moderation
     def entry
       attribution = MemberLog::AuditLogLookup.attribution(event.server, action: :member_ban_add, target_id: event.user.id)
       MemberLog::ActivityEntry.build(
-        :member_banned,
+        event_key: :member_banned,
         target: event.user,
         moderator: attribution&.moderator,
         reason: attribution&.reason

--- a/app/plugins/moderation/events/member_kick_log.rb
+++ b/app/plugins/moderation/events/member_kick_log.rb
@@ -13,7 +13,7 @@ module Moderation
 
     def entry
       MemberLog::ActivityEntry.build(
-        :member_kicked,
+        event_key: :member_kicked,
         target: event.user,
         moderator: attribution.moderator,
         reason: attribution.reason

--- a/app/plugins/moderation/events/member_timeout_log.rb
+++ b/app/plugins/moderation/events/member_timeout_log.rb
@@ -13,7 +13,7 @@ module Moderation
 
     def entry
       MemberLog::ActivityEntry.build(
-        :member_timed_out,
+        event_key: :member_timed_out,
         target: member,
         moderator: attribution.moderator,
         reason: attribution.reason,

--- a/app/plugins/moderation/image_scanning/classifier.rb
+++ b/app/plugins/moderation/image_scanning/classifier.rb
@@ -30,12 +30,12 @@ module Moderation
         keyword_gate = reasons.any? { |reason| reason.key == :custom_keywords }
         content_signal = ocr_score > 0 || hash_state != :none
         thresholds = THRESHOLDS.fetch(settings.sensitivity)
-        action = decide(risk, ocr_score, hash_state, content_signal, keyword_gate, thresholds)
+        action = decide(risk:, ocr_score:, hash_state:, content_signal:, keyword_gate:, thresholds:)
 
         Verdict.new(action:, risk:, reasons:)
       end
 
-      def decide(risk, ocr_score, hash_state, content_signal, keyword_gate, thresholds)
+      def decide(risk:, ocr_score:, hash_state:, content_signal:, keyword_gate:, thresholds:)
         return :allow unless content_signal
 
         action =

--- a/app/plugins/moderation/image_scanning/verdict_executor.rb
+++ b/app/plugins/moderation/image_scanning/verdict_executor.rb
@@ -4,27 +4,41 @@ require "uri"
 
 module Moderation
   module ImageScanning
-    module VerdictExecutor
-      module_function
+    class VerdictExecutor
+      def self.call(verdict:, context:, phash:, hash_state:, image_bytes: nil)
+        new(verdict:, context:, phash:, hash_state:, image_bytes:).call
+      end
 
-      def call(verdict:, context:, phash:, hash_state:, image_bytes: nil)
+      def initialize(verdict:, context:, phash:, hash_state:, image_bytes:)
+        @verdict = verdict
+        @context = context
+        @phash = phash
+        @hash_state = hash_state
+        @image_bytes = image_bytes
+      end
+
+      def call
         case verdict.action
         when :flag_for_review
-          flag(verdict, context, phash, image_bytes:, removed: false)
+          flag(removed: false)
         when :remove
-          delete_message(context) if context.settings.action_delete?
-          punish(context, hash_state)
-          flag(verdict, context, phash, image_bytes:, removed: true)
+          delete_message if context.settings.action_delete?
+          punish
+          flag(removed: true)
         end
       end
 
-      def delete_message(context)
+      private
+
+      attr_reader :verdict, :context, :phash, :hash_state, :image_bytes
+
+      def delete_message
         context.bot.channel(context.channel_id)&.delete_message(context.message_id)
       rescue => e
         Rails.logger.warn("[Moderation::ImageScanning::VerdictExecutor] delete failed in ##{context.channel_id}: #{e.class}: #{e.message}")
       end
 
-      def punish(context, hash_state)
+      def punish
         settings = context.settings
         confirmed = hash_state == :own_confirmed
         punishment = confirmed ? settings.confirmed_punishment : settings.punishment
@@ -39,7 +53,7 @@ module Moderation
         )
       end
 
-      def flag(verdict, context, phash, image_bytes:, removed:)
+      def flag(removed:)
         config = context.settings.server_configuration
         settings = config.moderation_settings
         staff_role_id = settings.staff_role_id
@@ -55,16 +69,16 @@ module Moderation
             "moderation.image_scanning.flag.body",
             author: "<@#{context.member.id}>",
             channel: "<##{context.channel_id}>",
-            jump_url: jump_url(context)
-          ) + "\n" + risk_line(verdict, context, state) + "\n" + reason_lines(verdict),
+            jump_url:
+          ) + "\n" + risk_line(state) + "\n" + reason_lines,
           meta: I18n.t("moderation.image_scanning.flag.meta.#{state}"),
           image:,
-          components: buttons(phash),
+          components: buttons,
           allowed_mentions: {parse: [], roles: StaffPing.allowed_roles(staff_role_id, ping:)}
         )
       end
 
-      def buttons(phash)
+      def buttons
         [
           Bot::Discord::Components.action_row(
             [
@@ -83,11 +97,11 @@ module Moderation
         ]
       end
 
-      def jump_url(context)
+      def jump_url
         "https://discord.com/channels/#{context.server.id}/#{context.channel_id}/#{context.message_id}"
       end
 
-      def risk_line(verdict, context, state)
+      def risk_line(state)
         threshold_key = (state == "removed") ? :remove : :flag
         threshold = Classifier::THRESHOLDS.fetch(context.settings.sensitivity)[threshold_key]
         I18n.t(
@@ -102,7 +116,7 @@ module Moderation
         (rounded % 1).zero? ? rounded.to_i : rounded
       end
 
-      def reason_lines(verdict)
+      def reason_lines
         verdict.reasons.map { |reason| reason_line(reason) }.join("\n")
       end
 
@@ -125,9 +139,6 @@ module Moderation
           I18n.t("moderation.image_scanning.flag.reasons.#{reason.key}")
         end
       end
-
-      private_class_method :delete_message, :punish, :flag, :buttons, :jump_url,
-        :risk_line, :format_number, :reason_lines, :reason_line, :reason_text
     end
   end
 end

--- a/app/plugins/moderation/member_log/activity_entry.rb
+++ b/app/plugins/moderation/member_log/activity_entry.rb
@@ -2,28 +2,42 @@
 
 module Moderation
   module MemberLog
-    module ActivityEntry
-      module_function
+    class ActivityEntry
+      def self.build(event_key:, target:, moderator:, reason:, timeout_until: nil)
+        new(event_key:, target:, moderator:, reason:, timeout_until:).build
+      end
 
-      def build(event_key, target:, moderator:, reason:, timeout_until: nil)
+      def initialize(event_key:, target:, moderator:, reason:, timeout_until:)
+        @event_key = event_key
+        @target = target
+        @moderator = moderator
+        @reason = reason
+        @timeout_until = timeout_until
+      end
+
+      def build
         {
           title: I18n.t("activity_log.moderation.title.#{event_key}", locale: :en, raise: true),
-          body: body(event_key, target, moderator, reason, timeout_until),
+          body:,
           meta: I18n.t("activity_log.moderation.source", locale: :en, raise: true)
         }
       end
 
-      def body(event_key, target, moderator, reason, timeout_until)
-        [action_line(event_key, target, moderator, timeout_until), reason_line(reason)].join("\n")
+      private
+
+      attr_reader :event_key, :target, :moderator, :reason, :timeout_until
+
+      def body
+        [action_line, reason_line].join("\n")
       end
 
-      def action_line(event_key, target, moderator, timeout_until)
-        interpolations = {target: user_label(target), moderator: moderator_label(moderator), locale: :en, raise: true}
+      def action_line
+        interpolations = {target: user_label(target), moderator: moderator_label, locale: :en, raise: true}
         interpolations[:until] = "<t:#{timeout_until.to_i}:f>" if timeout_until
         I18n.t("activity_log.moderation.#{event_key}", **interpolations)
       end
 
-      def moderator_label(moderator)
+      def moderator_label
         return I18n.t("activity_log.moderation.unknown_moderator", locale: :en, raise: true) unless moderator
 
         user_label(moderator)
@@ -33,13 +47,11 @@ module Moderation
         "#{user.mention} (#{user.username})"
       end
 
-      def reason_line(reason)
+      def reason_line
         return I18n.t("activity_log.moderation.no_reason", locale: :en, raise: true) if reason.blank?
 
         I18n.t("activity_log.moderation.reason", reason:, locale: :en, raise: true)
       end
-
-      private_class_method :body, :action_line, :moderator_label, :user_label, :reason_line
     end
   end
 end

--- a/spec/plugins/moderation/events/member_ban_log_spec.rb
+++ b/spec/plugins/moderation/events/member_ban_log_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Moderation::MemberBanLog do
 
     it "still posts with nil moderator and reason" do
       allow(Moderation::MemberLog::ActivityEntry).to receive(:build).with(
-        :member_banned,
+        event_key: :member_banned,
         target: user,
         moderator: nil,
         reason: nil

--- a/spec/plugins/moderation/member_log/activity_entry_spec.rb
+++ b/spec/plugins/moderation/member_log/activity_entry_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Moderation::MemberLog::ActivityEntry do
   let(:reason) { "rule violation" }
 
   context "ban entry" do
-    subject(:result) { described_class.build(:member_banned, target:, moderator:, reason:) }
+    subject(:result) { described_class.build(event_key: :member_banned, target:, moderator:, reason:) }
 
     it "has the correct title" do
       expect(result[:title]).to eq("Member banned")
@@ -40,7 +40,7 @@ RSpec.describe Moderation::MemberLog::ActivityEntry do
   end
 
   context "with nil moderator" do
-    subject(:result) { described_class.build(:member_banned, target:, moderator: nil, reason:) }
+    subject(:result) { described_class.build(event_key: :member_banned, target:, moderator: nil, reason:) }
 
     it "uses unknown moderator label in the body" do
       expect(result[:body]).to include("an unknown moderator")
@@ -48,7 +48,7 @@ RSpec.describe Moderation::MemberLog::ActivityEntry do
   end
 
   context "with nil reason" do
-    subject(:result) { described_class.build(:member_banned, target:, moderator:, reason: nil) }
+    subject(:result) { described_class.build(event_key: :member_banned, target:, moderator:, reason: nil) }
 
     it "uses no reason fallback in the body" do
       expect(result[:body]).to include("No reason was given.")
@@ -56,7 +56,7 @@ RSpec.describe Moderation::MemberLog::ActivityEntry do
   end
 
   context "with blank reason" do
-    subject(:result) { described_class.build(:member_banned, target:, moderator:, reason: "") }
+    subject(:result) { described_class.build(event_key: :member_banned, target:, moderator:, reason: "") }
 
     it "uses no reason fallback in the body" do
       expect(result[:body]).to include("No reason was given.")
@@ -67,7 +67,7 @@ RSpec.describe Moderation::MemberLog::ActivityEntry do
     let(:timeout_until) { Time.at(1_700_000_000) }
 
     subject(:result) do
-      described_class.build(:member_timed_out, target:, moderator:, reason:, timeout_until:)
+      described_class.build(event_key: :member_timed_out, target:, moderator:, reason:, timeout_until:)
     end
 
     it "includes the unix timestamp in discord format" do


### PR DESCRIPTION
Curated pass over the reek backlog (BUILD_PLAN static-analysis section) — the coordinated items only, not count-chasing.

## Fixed
- **`Moderation::MemberLog::ActivityEntry`** (DataClump + 3× LongParameterList): module_function module threading `event_key`/`target`/`moderator`/`reason`/`timeout_until` through every private method → class holding them; `build` entry point unchanged apart from `event_key:` becoming a keyword (matches sibling `Roles::ActivityEntry`'s all-keyword signature).
- **`Moderation::ImageScanning::VerdictExecutor`** (DataClump + 2× LongParameterList): same treatment — `verdict`/`context`/`phash`/`hash_state`/`image_bytes` become instance state; `call` API unchanged, callers untouched.
- **`Bot::ConfigSubscriber`** (RepeatedConditional): three identical load-set-guard-report methods share a `with_set` helper.
- **`Moderation::ImageScanning::Classifier#decide`**: six positional args → keywords; transposition on future edits now fails loudly instead of silently misclassifying.

All behavior-preserving; specs hit the public entry points throughout and pass unchanged except for the `event_key:` keyword at call sites.

## Rejected (recorded in the backlog so it isn't re-litigated)
- `Bot::BaseCommand` RepeatedConditional on `value` — sanctioned read-or-set macro style.
- `Bot::ActivityLog#post` 8 params / `PluginCatalog::Definition#initialize` 7 — keyword APIs / value-object init; the params are the data.
- `SpamTracker#record` (9 params, 17 statements) — concurrency-sensitive core algorithm whose keying V2 item 7 reworks anyway; restructuring now is churn.
- Remaining TooManyStatements stays opportunistic per the backlog note.

Gates: rspec (1694 examples, 0 failures), standardrb, active_record_doctor, undercover vs origin/main — all green.

## Config follow-up (second commit)
The rejections above are detector-class problems, not one-offs — encoded them in `.reek.yml` so raw reek output matches judgment (385 findings → 62). Disabled the detectors that fight house style (DuplicateMethodCall, FeatureEnvy, NilCheck, UtilityFunction, InstanceVariableAssumption); thresholds raised where the house pattern legitimately sits above the default (TooManyStatements 8, LongParameterList 5, TooManyInstanceVariables 5); adjudicated one-off false positives excluded inline with reasons. The config doubles as the rejection ledger. `SpamTracker#record` is now the only LongParameterList hit — deliberately, it's the one real deferred item.
