### PR TITLE
Inherit general punishment for confirmed-scam images

### DIFF
--- a/app/components/moderation/image_scanning_form.rb
+++ b/app/components/moderation/image_scanning_form.rb
@@ -150,7 +150,8 @@ class Components::Moderation::ImageScanningForm < Components::Base
       render Components::Moderation::PunishmentControl.new(
         name: "image_scanning[confirmed_punishment]",
         value: @settings.confirmed_punishment,
-        timeout_seconds: @settings.confirmed_timeout_seconds
+        timeout_seconds: @settings.confirmed_timeout_seconds,
+        none_label: t(".response.confirmed_punishment.inherit")
       )
       p(class: "text-xs text-text-muted mt-1.5") { t(".response.confirmed_punishment.help") }
     end

--- a/app/components/moderation/punishment_control.rb
+++ b/app/components/moderation/punishment_control.rb
@@ -14,10 +14,11 @@ class Components::Moderation::PunishmentControl < Components::Base
     {seconds: 2_419_200, label: "28 days"}
   ].freeze
 
-  def initialize(name:, value:, timeout_seconds:)
+  def initialize(name:, value:, timeout_seconds:, none_label: nil)
     @name = name
     @value = value.to_s
     @timeout_seconds = timeout_seconds
+    @none_label = none_label
   end
 
   def view_template
@@ -26,7 +27,7 @@ class Components::Moderation::PunishmentControl < Components::Base
         name: @name,
         value: @value,
         options: [
-          {value: "none", label: t("components.moderation.punishment_control.none")},
+          {value: "none", label: @none_label || t("components.moderation.punishment_control.none")},
           {value: "timeout", label: t("components.moderation.punishment_control.timeout")},
           {value: "kick", label: t("components.moderation.punishment_control.kick")},
           {value: "ban", label: t("components.moderation.punishment_control.ban")}

--- a/app/plugins/moderation/image_scanning/verdict_executor.rb
+++ b/app/plugins/moderation/image_scanning/verdict_executor.rb
@@ -40,15 +40,15 @@ module Moderation
 
       def punish
         settings = context.settings
-        confirmed = hash_state == :own_confirmed
-        punishment = confirmed ? settings.confirmed_punishment : settings.punishment
+        escalate = hash_state == :own_confirmed && settings.confirmed_punishment != "none"
+        punishment = escalate ? settings.confirmed_punishment : settings.punishment
         return if punishment == "none"
 
         Punisher.call(
           member: context.member,
           server: context.server,
           punishment:,
-          timeout_seconds: confirmed ? settings.confirmed_timeout_seconds : settings.timeout_seconds,
+          timeout_seconds: escalate ? settings.confirmed_timeout_seconds : settings.timeout_seconds,
           reason: I18n.t("moderation.image_scanning.punishment.reason")
         )
       end

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -117,8 +117,10 @@ en:
             help: Flag only leaves the image up and pings staff to review it.
             label: When a scam is detected
           confirmed_punishment:
-            help: Overrides the punishment above for images a moderator has confirmed
-              as scam on this server. Confirmations from other servers don't count.
+            help: Sets the punishment for images a moderator has confirmed as scam
+              on this server, overriding the general punishment above. Leave on "Same
+              as above" to reuse it. Confirmations from other servers don't count.
+            inherit: Same as above
             label: If confirmed as a scam on this server
           punishment:
             label: Also punish the sender

--- a/spec/components/moderation/punishment_control_spec.rb
+++ b/spec/components/moderation/punishment_control_spec.rb
@@ -85,5 +85,21 @@ RSpec.describe Components::Moderation::PunishmentControl do
     it "derives the confirmed timeout field name" do
       expect(html).to include('name="image_scanning[confirmed_timeout_seconds]"')
     end
+
+    context "with a custom none_label" do
+      subject(:html) do
+        described_class.new(
+          name: "image_scanning[confirmed_punishment]",
+          value: "none",
+          timeout_seconds: 3600,
+          none_label: "Same as above"
+        ).render_in(view_context)
+      end
+
+      it "renders the override label in place of None" do
+        expect(html).to include("Same as above")
+        expect(html).not_to include(">None<")
+      end
+    end
   end
 end

--- a/spec/plugins/moderation/image_scanning/verdict_executor_spec.rb
+++ b/spec/plugins/moderation/image_scanning/verdict_executor_spec.rb
@@ -306,9 +306,25 @@ RSpec.describe Moderation::ImageScanning::VerdictExecutor do
       let(:hash_state) { :own_confirmed }
       let(:confirmed_punishment) { "none" }
 
-      it "does not invoke the punisher even though the general punishment is set" do
-        expect(Moderation::Punisher).not_to receive(:call)
+      it "inherits the general punishment rather than skipping it" do
         execute
+
+        expect(Moderation::Punisher).to have_received(:call).with(
+          member:,
+          server:,
+          punishment: "timeout",
+          timeout_seconds: 300,
+          reason: I18n.t("moderation.image_scanning.punishment.reason")
+        )
+      end
+
+      context "when the general punishment is also 'none'" do
+        let(:punishment) { "none" }
+
+        it "does not invoke the punisher" do
+          expect(Moderation::Punisher).not_to receive(:call)
+          execute
+        end
       end
     end
 


### PR DESCRIPTION
Found while reviewing the 3.1.0 changelog copy.

## Problem

`confirmed_punishment` defaults to `none`. `VerdictExecutor#punish` treated `own_confirmed` hashes as *always* using the confirmed tier, so the default made confirmed scams punishment-free even when the general punishment was set:

```ruby
confirmed = hash_state == :own_confirmed
punishment = confirmed ? settings.confirmed_punishment : settings.punishment
return if punishment == "none"
```

General `ban` + default confirmed `none` = a mod-verified scam image goes unpunished, softer than an unverified heuristic hit. Backwards, and itʼs the out-of-the-box default until a mod opts in.

## Fix

`none` on the confirmed tier now means **inherit the general punishment**, not "no punishment". An explicit confirmed tier still overrides in either direction (mod choice; no cap — matches the power-user stance). No migration: the column is post-3.0.0 and unreleased, so no stored data changes meaning.

- `VerdictExecutor#punish`: escalate only when `own_confirmed` **and** an explicit confirmed tier is set; otherwise fall through to the general punishment/duration.
- `PunishmentControl` gains a `none_label:` override; the confirmed control renders it as **Same as above**.
- Help copy rewritten to describe the override + inherit behaviour.

Considered "always take the more severe of the two" instead — rejected: it silently ignores an explicitly-milder confirmed setting (paternalism) and needs an awkward tie-break on equal tiers. Inheriting on the default closes the actual hole without a cap.

## Tests

Flipped the `own_confirmed` + `confirmed none` spec (was asserting the bug) to expect the general tier; added a both-none no-punish case and a component `none_label` case.

## Gates

rspec 1696/0, standardrb, active_record_doctor, undercover (clean), i18n-tasks missing + normalized — all green locally.