### PR TITLE
Serialize bot processes with a Redis leader lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ refactors, tooling, and CI changes are omitted; see the git history for those.
 
 This project follows [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+
+### Fixed
+- The bot no longer responds twice to commands and events while a deploy is in flight. Only one bot process is active at a time; expect a few seconds of unresponsiveness at deploy cutover instead. ([#XXX](https://github.com/badBlackShark/shrkbot/pull/XXX))
+
 ## [3.1.0] - 2026-07-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project follows [Semantic Versioning](https://semver.org).
 ## [Unreleased]
 
 ### Fixed
-- The bot no longer responds twice to commands and events while a deploy is in flight. Only one bot process is active at a time; expect a few seconds of unresponsiveness at deploy cutover instead. ([#XXX](https://github.com/badBlackShark/shrkbot/pull/XXX))
+- The bot no longer responds twice to commands and events while a deploy is in flight. Only one bot process is active at a time; expect a few seconds of unresponsiveness at deploy cutover instead. ([#148](https://github.com/badBlackShark/shrkbot/pull/148))
 
 ## [3.1.0] - 2026-07-11
 

--- a/app/bot/leader_lock.rb
+++ b/app/bot/leader_lock.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Bot
+  class LeaderLock
+    KEY = "shrkbot:bot:leader"
+    TTL_MS = 6_000
+    TICK_SECONDS = 1
+
+    RENEW = <<~LUA
+      if redis.call("get", KEYS[1]) == ARGV[1] then
+        return redis.call("pexpire", KEYS[1], ARGV[2])
+      end
+      return 0
+    LUA
+
+    RELEASE = <<~LUA
+      if redis.call("get", KEYS[1]) == ARGV[1] then
+        return redis.call("del", KEYS[1])
+      end
+      return 0
+    LUA
+
+    def initialize
+      @redis = Redis.new(url: Config.redis_url)
+      @id = "#{Socket.gethostname}-#{Process.pid}-#{SecureRandom.hex(4)}"
+    end
+
+    def acquire
+      sleep(TICK_SECONDS) until try_acquire
+      @renewer = Thread.new { renew_loop }
+    end
+
+    def release
+      @renewer&.kill
+      Redis.new(url: Config.redis_url).eval(RELEASE, keys: [KEY], argv: [@id])
+    rescue Redis::BaseError => e
+      Rails.logger.warn("[leader_lock] release failed: #{e.class}: #{e.message}")
+    end
+
+    private
+
+    def try_acquire
+      @redis.set(KEY, @id, nx: true, px: TTL_MS)
+    rescue Redis::BaseError
+      false
+    end
+
+    def renew_loop
+      loop do
+        sleep(TICK_SECONDS)
+        renew
+      end
+    end
+
+    def renew
+      return if @redis.eval(RENEW, keys: [KEY], argv: [@id, TTL_MS]) == 1
+      Rails.logger.warn("[leader_lock] lock lost — reacquired: #{try_acquire ? "yes" : "no"}")
+    rescue Redis::BaseError => e
+      Rails.logger.warn("[leader_lock] renew failed: #{e.class}: #{e.message}")
+    end
+  end
+end

--- a/bin/bot
+++ b/bin/bot
@@ -45,16 +45,32 @@ bots.each_with_index do |bot, index|
   bot.server_delete { refresh_presence.call }
 end
 
+leader_lock = nil
 if Bot::Config.redis_url
+  leader_lock = Bot::LeaderLock.new
+  Rails.logger.info("[bot] waiting for leader lock…")
+  leader_lock.acquire
+  Rails.logger.info("[bot] leader lock acquired")
   Bot::ConfigSubscriber.new(bots.first).start
   Rails.logger.info("[bot] config subscriber listening on #{Bot::ConfigBus::CHANNEL}")
 else
-  Rails.logger.warn("[bot] REDIS_URL not set — config subscriber disabled")
+  Rails.logger.warn("[bot] REDIS_URL not set — leader lock and config subscriber disabled")
 end
+
+shutdown = Queue.new
+%w[TERM INT].each { |sig| Signal.trap(sig) { shutdown << sig } }
 
 bots.each_with_index do |bot, index|
   sleep(5) unless index.zero?
   Rails.logger.info("[bot] shard #{index + 1}/#{shard_count} connecting…")
   bot.run(true)
 end
-bots.each(&:join)
+
+Thread.new do
+  bots.each(&:join)
+  shutdown << :halted
+end
+reason = shutdown.pop
+Rails.logger.info("[bot] shutting down (#{reason})")
+bots.each(&:stop) unless reason == :halted
+leader_lock&.release

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@ Discord interactions and events.
 One Docker image, multiple services off it:
 
 - **web** (Puma) — the config website / admin UI and Discord OAuth2 login. ActiveRecord CRUD.
-- **bot** (`bin/bot`) — the discordrb gateway connection. Long-lived, blocking. Must be its own process: discordrb is gateway-based, and booting it from a Puma worker would open one gateway connection per cluster worker (duplicate events). Every bot container blocks on a Redis leader lock (`Bot::LeaderLock`, key `shrkbot:bot:leader`) before connecting to the gateway, so overlapping containers during a Kamal deploy never answer the same event twice. On shutdown the gateway stops first, then the lock is released, giving the waiting successor a clean handover. A crashed leader is covered by the 6 s TTL. The lock is fail-open: a Redis outage never silences a bot that is already running, it only gates a fresh startup (the renewal thread is advisory and re-acquires on loss). Handover latency grows with shard count — five seconds per additional shard — because each shard connect is staggered to respect Discord's IDENTIFY rate limit; if that ever becomes a problem the upgrade path is a warm standby that connects early and gates dispatch in software.
+- **bot** (`bin/bot`) — the discordrb gateway connection. Long-lived, blocking. Must be its own process: discordrb is gateway-based, and booting it from a Puma worker would open one gateway connection per cluster worker (duplicate events). At most one bot process is connected at a time — see [Bot leadership](#bot-leadership-single-active-process).
 - **jobs** (`bin/jobs`) — Solid Queue worker for background and scheduled work (reminder delivery).
 - **postgres** — source of truth.
 - **redis** — config-change pub/sub (web → bot); see [Config propagation](#config-propagation).
@@ -397,6 +397,45 @@ at boot; `Bot::OwnerBroadcast.call(bots:, …)` unions every shard's servers, de
 across shards, and DMs through any one bot (DMs are REST, so the shard doesn't
 matter). This works because all shards share one process — no cross-process
 coordination needed.
+
+## Bot leadership (single active process)
+
+During a Kamal deploy the old and new bot containers overlap for the new one's
+entire boot, and both would answer every event. kamal-proxy can't help — it only
+drains inbound HTTP and has no concept of the outbound gateway WebSocket — so
+exclusion lives in the app: every bot process blocks on a Redis leader lock
+(`Bot::LeaderLock`, key `shrkbot:bot:leader`, 6 s TTL renewed every second)
+**before** connecting to the gateway. At most one process is ever connected, so
+nothing downstream needs gating and READY-time work (server reconciliation,
+command setup, onboarding) runs with full fidelity on every takeover.
+
+Two orderings are load-bearing:
+
+- Signal traps install **after** acquire. A SIGTERM while still waiting for the
+  lock hits Ruby's default handler and kills the lock-less waiter — nothing to
+  clean up.
+- On shutdown the gateway stops **before** the lock is released. The successor
+  can't act before its own READY, so overlap is structurally impossible.
+
+A leader that dies without releasing (SIGKILL, crash) is covered by the TTL.
+The lock is fail-open: renewal errors log and re-acquire but never demote a
+serving bot — a Redis outage must not mute the bot. The worst case (a deploy
+overlap and a Redis outage at the same time) degrades to the pre-lock
+behaviour, brief doubles. Don't reuse this primitive where mutual exclusion is
+correctness-critical.
+
+The chosen trade is **silence over doubles** at cutover: a few seconds of
+unresponsiveness (failed interactions are visible and retryable) instead of
+double command executions, double punishments and double DMs (irreversible).
+The gap is disconnect + reconnect + READY, so it grows with server count and
+especially with shard count (5 s IDENTIFY stagger per shard). Measure it as the
+log delta between the old process's "shutting down" and the new one's "all N
+shard(s) up". When it exceeds roughly 10 s, the upgrade is a warm standby:
+every process connects immediately and the lock gates dispatch instead of
+connection, shrinking handover to about a second. That costs promotion hooks —
+a standby's READY fires while it isn't leader, so reconciliation, command setup
+and onboarding must re-run on promotion — and per-shard-group locks once shards
+split across processes.
 
 ## REST vs gateway token
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@ Discord interactions and events.
 One Docker image, multiple services off it:
 
 - **web** (Puma) — the config website / admin UI and Discord OAuth2 login. ActiveRecord CRUD.
-- **bot** (`bin/bot`) — the discordrb gateway connection. Long-lived, blocking. Must be its own process: discordrb is gateway-based, and booting it from a Puma worker would open one gateway connection per cluster worker (duplicate events).
+- **bot** (`bin/bot`) — the discordrb gateway connection. Long-lived, blocking. Must be its own process: discordrb is gateway-based, and booting it from a Puma worker would open one gateway connection per cluster worker (duplicate events). Every bot container blocks on a Redis leader lock (`Bot::LeaderLock`, key `shrkbot:bot:leader`) before connecting to the gateway, so overlapping containers during a Kamal deploy never answer the same event twice. On shutdown the gateway stops first, then the lock is released, giving the waiting successor a clean handover. A crashed leader is covered by the 6 s TTL. The lock is fail-open: a Redis outage never silences a bot that is already running, it only gates a fresh startup (the renewal thread is advisory and re-acquires on loss). Handover latency grows with shard count — five seconds per additional shard — because each shard connect is staggered to respect Discord's IDENTIFY rate limit; if that ever becomes a problem the upgrade path is a warm standby that connects early and gates dispatch in software.
 - **jobs** (`bin/jobs`) — Solid Queue worker for background and scheduled work (reminder delivery).
 - **postgres** — source of truth.
 - **redis** — config-change pub/sub (web → bot); see [Config propagation](#config-propagation).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -119,6 +119,8 @@ is set on the web role only, so the three processes don't race).
 bin/kamal deploy
 ```
 
+During a deploy the new bot container boots and waits for the leader lock before connecting to Discord. Expect a few seconds of bot unresponsiveness at cutover — the old container releases the lock on SIGTERM and only then does the new one connect — rather than both containers answering events simultaneously.
+
 ## Ops cheatsheet
 
 ```sh

--- a/spec/bot/leader_lock_spec.rb
+++ b/spec/bot/leader_lock_spec.rb
@@ -1,0 +1,186 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Bot::LeaderLock do
+  subject(:lock) { described_class.new }
+
+  let(:redis) { instance_double(Redis) }
+  let(:renewer) { instance_double(Thread) }
+
+  before do
+    allow(Bot::Config).to receive(:redis_url).and_return("redis://localhost:6379")
+    allow(Redis).to receive(:new).and_return(redis)
+    allow(Thread).to receive(:new).and_return(renewer)
+  end
+
+  describe "#acquire" do
+    context "when the key is immediately available" do
+      before do
+        allow(redis).to receive(:set).and_return(true)
+      end
+
+      it "sets the key with nx: true and px: TTL_MS" do
+        lock.acquire
+
+        expect(redis).to have_received(:set).with(
+          described_class::KEY,
+          anything,
+          nx: true,
+          px: described_class::TTL_MS
+        )
+      end
+
+      it "starts a renewal thread" do
+        lock.acquire
+
+        expect(Thread).to have_received(:new)
+      end
+    end
+
+    context "when the key is held (set returns false twice, then truthy)" do
+      let(:attempts) { [] }
+
+      before do
+        allow(lock).to receive(:sleep)
+        allow(redis).to receive(:set) do
+          attempts << :attempt
+          attempts.size >= 3
+        end
+      end
+
+      it "sleeps TICK between attempts and retries until success" do
+        lock.acquire
+
+        expect(attempts.size).to eq(3)
+        expect(lock).to have_received(:sleep).with(described_class::TICK_SECONDS).exactly(2).times
+      end
+    end
+
+    context "when Redis raises Redis::BaseError once, then succeeds" do
+      let(:attempts) { [] }
+
+      before do
+        allow(lock).to receive(:sleep)
+        allow(redis).to receive(:set) do
+          attempts << :attempt
+          raise Redis::BaseError, "down" if attempts.size == 1
+          true
+        end
+      end
+
+      it "treats the error as not-acquired, keeps retrying, does not raise" do
+        expect { lock.acquire }.not_to raise_error
+        expect(attempts.size).to eq(2)
+      end
+    end
+  end
+
+  describe "renewal tick" do
+    let(:release_redis) { instance_double(Redis) }
+
+    before do
+      allow(redis).to receive(:set).and_return(true)
+      allow(Redis).to receive(:new).and_return(redis, release_redis)
+    end
+
+    context "when eval returns 1 (lock held)" do
+      before do
+        allow(Thread).to receive(:new).and_yield.and_return(renewer)
+        allow(lock).to receive(:sleep).with(described_class::TICK_SECONDS).and_invoke(
+          ->(_) {},
+          ->(_) { raise StopIteration }
+        )
+        allow(redis).to receive(:eval).and_return(1)
+      end
+
+      it "renews via the RENEW Lua script with correct keys and argv" do
+        lock.acquire
+
+        expect(redis).to have_received(:eval).with(
+          described_class::RENEW,
+          keys: [described_class::KEY],
+          argv: [anything, described_class::TTL_MS]
+        )
+      end
+    end
+
+    context "when eval returns 0 (lock lost)" do
+      before do
+        allow(Thread).to receive(:new).and_yield.and_return(renewer)
+        allow(lock).to receive(:sleep).with(described_class::TICK_SECONDS).and_invoke(
+          ->(_) {},
+          ->(_) { raise StopIteration }
+        )
+        allow(redis).to receive(:eval).and_return(0)
+        allow(redis).to receive(:set).and_return(true)
+        allow(Rails.logger).to receive(:warn)
+      end
+
+      it "attempts re-acquire and logs a warning" do
+        lock.acquire
+
+        expect(Rails.logger).to have_received(:warn).with(a_string_including("lock lost"))
+        expect(redis).to have_received(:set).with(
+          described_class::KEY,
+          anything,
+          nx: true,
+          px: described_class::TTL_MS
+        ).at_least(:twice)
+      end
+    end
+
+    context "when eval raises Redis::BaseError" do
+      before do
+        allow(Thread).to receive(:new).and_yield.and_return(renewer)
+        allow(lock).to receive(:sleep).with(described_class::TICK_SECONDS).and_invoke(
+          ->(_) {},
+          ->(_) { raise StopIteration }
+        )
+        allow(redis).to receive(:eval).and_raise(Redis::BaseError, "connection lost")
+        allow(Rails.logger).to receive(:warn)
+      end
+
+      it "logs a warning and does not raise" do
+        expect { lock.acquire }.not_to raise_error
+        expect(Rails.logger).to have_received(:warn).with(a_string_including("renew failed"))
+      end
+    end
+  end
+
+  describe "#release" do
+    let(:release_redis) { instance_double(Redis) }
+
+    before do
+      allow(redis).to receive(:set).and_return(true)
+      allow(Redis).to receive(:new).and_return(redis, release_redis)
+      allow(renewer).to receive(:kill)
+      lock.acquire
+    end
+
+    it "kills the renewer thread and runs the RELEASE Lua script" do
+      allow(release_redis).to receive(:eval)
+
+      lock.release
+
+      expect(renewer).to have_received(:kill)
+      expect(release_redis).to have_received(:eval).with(
+        described_class::RELEASE,
+        keys: [described_class::KEY],
+        argv: [anything]
+      )
+    end
+
+    context "when Redis raises on release" do
+      before do
+        allow(release_redis).to receive(:eval).and_raise(Redis::BaseError, "down")
+        allow(Rails.logger).to receive(:warn)
+      end
+
+      it "logs a warning and does not raise" do
+        expect { lock.release }.not_to raise_error
+        expect(Rails.logger).to have_received(:warn).with(a_string_including("release failed"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem

During a Kamal deploy the old and new bot containers overlap for the duration of the new one's boot (Rails eager load + gateway connect, ~20-30s), and both answer every command and event — users get double responses. No Kamal setting fixes this: kamal-proxy only drains inbound HTTP and has no concept of the bot's outbound gateway WebSocket.

## Fix

`Bot::LeaderLock` — every `bin/bot` process blocks on a Redis lock (key `shrkbot:bot:leader`, 6s TTL, renewed every second by a background thread) **before** connecting to the gateway. At most one process is ever connected, so gating individual handlers is unnecessary and READY-time work (`ServerReconciliation`, `CommandSetup`, onboarding) keeps full fidelity on every takeover.

Shutdown ordering (load-bearing):
- Signal traps are installed **after** acquire — a SIGTERM while still waiting for the lock uses Ruby's default handler and just kills the lock-less waiter.
- On SIGTERM/SIGINT the gateway stops **first**, then the lock is released. The successor can't act before its own READY, so there is zero overlap; handover gap is a few seconds instead of doubled responses.
- A leader that dies without releasing (SIGKILL, crash) is covered by the TTL: successor waits at most 6s extra.

The lock is fail-open: renewal errors are logged and re-acquired, never demote a serving bot — a Redis blip must not mute the bot. Its worst case (brief double during a deploy overlap *and* a simultaneous Redis outage) is today's status quo.

The config-bus subscriber now starts only after the lock is held, which also stops overlapping containers from double-running config-bus messages (previously both processes were subscribed during the overlap).

## Notes

- Handover gap grows with shard count (5s IDENTIFY stagger per shard). With `SHARD_COUNT=1` this is ~3-5s; if it ever hurts, the documented upgrade path is a warm standby that connects early and gates dispatch.
- Docs updated (`architecture.md`, `deployment.md`) + changelog entry.

## Testing

- `bundle exec rspec` — 1705 examples, 0 failures (new `spec/bot/leader_lock_spec.rb` covers acquire/retry/renew/lost-lock/release, Redis mocked per existing convention)
- `bundle exec standardrb`, `rake active_record_doctor`, `undercover --compare origin/main` — all green
- Live two-process handover (graceful + `kill -9`) needs the real gateway — sandbox has no Discord network, so that's a manual step

🤖 Generated with [Claude Code](https://claude.com/claude-code)