### PR TITLE
Refresh landing page: provenance footer, hero copy, version badge

### DIFF
--- a/app/bot/commands/info.rb
+++ b/app/bot/commands/info.rb
@@ -54,7 +54,7 @@ module Bot
       def header
         "### #{event.bot.profile.username}\n" \
           "I was written in [Ruby](https://www.ruby-lang.org/) by [badBlackShark](https://github.com/badBlackShark/).\n" \
-          "My code lives [here](https://github.com/badBlackShark/shrkbot). Want me on your server? [Invite me!](#{Config.invite_url})"
+          "My code lives [here](#{ReleaseInfo::REPO_URL}). Want me on your server? [Invite me!](#{Config.invite_url})"
       end
 
       def credits

--- a/app/components/app_shell.rb
+++ b/app/components/app_shell.rb
@@ -35,14 +35,13 @@ class Components::AppShell < Components::Base
   private
 
   def footer_bar
-    footer(class: "border-t border-border-default px-6 py-4") do
-      render Components::LegalLinks.new
-    end
+    render Components::SiteFooter.new
   end
 
   def top_bar
     header(class: "app-bar z-30 flex h-16 flex-none items-center gap-3 px-5") do
       wordmark
+      render Components::VersionBadge.new
       server_switcher if @current_server
       div(class: "flex-1")
       notification_frame

--- a/app/components/public_shell.rb
+++ b/app/components/public_shell.rb
@@ -4,8 +4,6 @@ class Components::PublicShell < Components::Base
   include Phlex::Rails::Helpers::ButtonTo
   include Phlex::Rails::Helpers::ImageTag
 
-  REPO_URL = "https://github.com/badBlackShark/shrkbot"
-
   def initialize(user: nil)
     @user = user
   end
@@ -14,7 +12,7 @@ class Components::PublicShell < Components::Base
     div(class: "flex min-h-screen flex-col") do
       header_bar
       main(class: "flex-1") { yield }
-      footer_bar
+      render Components::SiteFooter.new
     end
   end
 
@@ -26,6 +24,7 @@ class Components::PublicShell < Components::Base
       span(class: "font-display text-lg font-bold tracking-tight") do
         render Components::Wordmark.new
       end
+      render Components::VersionBadge.new
       div(class: "flex-1")
       render Components::ThemeToggle.new
       @user ? dashboard_link : sign_in_button
@@ -48,19 +47,6 @@ class Components::PublicShell < Components::Base
     ) do
       render Components::Icon.new("sign-in", class: "size-4")
       span { t(".sign_in") }
-    end
-  end
-
-  def footer_bar
-    footer(class: "border-t border-border-default px-6 py-8 text-center text-xs text-text-muted") do
-      plain t(".footer_pre")
-      a(href: REPO_URL, class: "underline transition-colors hover:text-text-secondary") { t(".footer_link") }
-      plain t(".footer_mid")
-      span(class: "text-accent-2-text") { "♥" }
-      plain t(".footer_post")
-      div(class: "mt-3") do
-        render Components::LegalLinks.new
-      end
     end
   end
 end

--- a/app/components/site_footer.rb
+++ b/app/components/site_footer.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class Components::SiteFooter < Components::Base
+  def view_template
+    footer(class: "border-t border-border-default px-6 py-8 text-center text-xs text-text-muted") do
+      plain t(".pre")
+      a(href: ReleaseInfo::REPO_URL, class: "underline transition-colors hover:text-text-secondary") { t(".link") }
+      plain t(".mid")
+      span(class: "text-accent-2-text") { "♥" }
+      plain t(".post")
+      div(class: "mt-3") do
+        render Components::LegalLinks.new
+      end
+    end
+  end
+end

--- a/app/components/tooltip.rb
+++ b/app/components/tooltip.rb
@@ -1,19 +1,25 @@
 # frozen_string_literal: true
 
 class Components::Tooltip < Components::Base
-  BUBBLE = "pointer-events-none absolute bottom-full right-0 z-20 mb-2 w-max max-w-64 rounded-md " \
+  PLACEMENTS = {
+    up: "bottom-full mb-2",
+    down: "top-full mt-2"
+  }.freeze
+
+  BUBBLE = "pointer-events-none absolute right-0 z-20 w-max max-w-64 rounded-md " \
     "border border-border-default bg-surface-card px-3 py-2 text-xs font-medium leading-snug text-text-secondary shadow-lg " \
     "invisible opacity-0 transition-opacity motion-safe:duration-[120ms] " \
     "group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100"
 
-  def initialize(text:)
+  def initialize(text:, placement: :up)
     @text = text
+    @placement = PLACEMENTS.fetch(placement)
   end
 
   def view_template(&block)
     span(class: "group relative inline-flex flex-none") do
       yield
-      span(role: "tooltip", class: BUBBLE) { @text }
+      span(role: "tooltip", class: "#{BUBBLE} #{@placement}") { @text }
     end
   end
 end

--- a/app/components/version_badge.rb
+++ b/app/components/version_badge.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class Components::VersionBadge < Components::Base
+  def view_template
+    release = ReleaseInfo.current
+    return unless release
+
+    render Components::Tooltip.new(text: t(".released", date: release.released_on.strftime("%d. %b, %Y")), placement: :down) do
+      a(
+        href: release.release_url,
+        target: "_blank",
+        rel: "noopener",
+        aria_label: t(".label", version: release.number),
+        class: "transition-opacity hover:opacity-80"
+      ) do
+        render Components::Badge.new(variant: :neutral) { "v#{release.number}" }
+      end
+    end
+  end
+end

--- a/app/presenters/release_info.rb
+++ b/app/presenters/release_info.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class ReleaseInfo
+  REPO_URL = "https://github.com/badBlackShark/shrkbot"
+  CHANGELOG = Rails.root.join("CHANGELOG.md")
+  ENTRY = /^## \[(\d+\.\d+\.\d+)\] - (\d{4}-\d{2}-\d{2})/
+
+  def self.current
+    @current ||= CHANGELOG.exist? ? from_changelog(CHANGELOG.read) : nil
+  end
+
+  def self.from_changelog(text)
+    match = text.match(ENTRY)
+    return unless match
+
+    new(number: match[1], released_on: Date.parse(match[2]))
+  end
+  private_class_method :from_changelog
+
+  attr_reader :number, :released_on
+
+  def initialize(number:, released_on:)
+    @number = number
+    @released_on = released_on
+  end
+
+  def release_url
+    "#{REPO_URL}/releases/tag/#{number}"
+  end
+end

--- a/app/views/home.rb
+++ b/app/views/home.rb
@@ -17,12 +17,12 @@ class Views::Home < Views::Base
   def hero
     section(class: "mx-auto flex max-w-4xl flex-col items-center gap-12 px-6 py-20 sm:flex-row") do
       div(class: "flex-1") do
-        p(class: "mb-3 text-[11px] font-semibold uppercase tracking-widest text-eyebrow") { t(".eyebrow") }
         h1(class: "mb-4 font-display text-4xl font-bold leading-tight tracking-tight") do
-          plain t(".headline")
+          span(class: "[font-size:larger]") { render Components::Wordmark.new }
           br
-          plain t(".headline_end")
-          span(class: "text-text-muted") { " #{t(".headline_muted")}" }
+          plain t(".tagline")
+          br
+          span(class: "text-accent-2-text") { t(".tagline_accent") }
         end
         p(class: "mb-8 max-w-md text-lg leading-relaxed text-text-secondary") { t(".lede") }
         div(class: "flex flex-wrap gap-3") do
@@ -36,7 +36,7 @@ class Views::Home < Views::Base
             span { t(".add_to_server") }
           end
           a(
-            href: Components::PublicShell::REPO_URL,
+            href: ReleaseInfo::REPO_URL,
             target: "_blank",
             rel: "noopener",
             class: Components::Button.css(variant: :secondary, size: :xl, extra: "text-sm")

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -254,10 +254,6 @@ en:
       plugins: Plugins
     public_shell:
       dashboard: Dashboard
-      footer_link: free and open source
-      footer_mid: ". Made with "
-      footer_post: " by badBlackShark."
-      footer_pre: 'shrkbot is '
       sign_in: Sign in with Discord
     reminders:
       config_form:
@@ -305,8 +301,17 @@ en:
       discarded: Changes discarded
       save: Save
       unsaved: Unsaved changes
+    site_footer:
+      link: free and open source
+      mid: ". Made with "
+      post: " by badBlackShark in Germany 🇩🇪, hosted in Finland
+        🇫🇮."
+      pre: 'shrkbot is '
     theme_toggle:
       toggle_theme: Toggle dark mode
+    version_badge:
+      label: shrkbot %{version} release notes
+      released: Released %{date}
     welcomes:
       config_form:
         channel:
@@ -386,13 +391,10 @@ en:
           title: Owner settings
     home:
       add_to_server: Sign in to add shrkbot to your servers
-      eyebrow: Free & open source
-      headline: You pick the parts.
-      headline_end: shrkbot
-      headline_muted: does the rest.
-      lede: 'shrkbot is your server''s mechanic: a modular Discord bot that keeps
-        exactly the plugins you want running, nothing more, nothing less. Configure
-        everything from one dashboard.'
+      lede: 'shrkbot provides tools where Discord doesn''t, and gets out of your way
+        otherwise. Your members'' privacy is a priority and a guarantee: moderation
+        happens in memory, your messages are never stored. Manage everything from
+        one dashboard, and let shrkbot handle the rest.'
       more_plugins: More plugins are on the way.
       plugins:
         logging: 'Record moderation events to a private staff channel: role changes,
@@ -405,6 +407,8 @@ en:
         welcomes: Greet new members with a custom message, and say goodbye when they
           leave.
       plugins_eyebrow: Example plugins
+      tagline: A mechanical assistant for your Discord server.
+      tagline_accent: With teeth when needed.
       view_source: View on GitHub
     reauth:
       body: Your Discord sign-in expired. Please stand by - we're refreshing it for

--- a/spec/components/site_footer_spec.rb
+++ b/spec/components/site_footer_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::SiteFooter do
+  include_context "component view context"
+
+  subject(:html) { described_class.new.render_in(view_context) }
+
+  it "links to the source repository" do
+    expect(html).to include("href=\"#{ReleaseInfo::REPO_URL}\"")
+    expect(html).to include("free and open source")
+  end
+
+  it "states where shrkbot is developed and hosted" do
+    expect(html).to include("Germany 🇩🇪")
+    expect(html).to include("hosted in Finland 🇫🇮")
+  end
+
+  it "renders the legal links" do
+    expect(html).to include("Privacy policy")
+    expect(html).to include("Imprint")
+  end
+end

--- a/spec/components/tooltip_spec.rb
+++ b/spec/components/tooltip_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::Tooltip do
+  subject(:html) { described_class.new(text: "Latest release", placement:).call { "trigger" } }
+
+  context "with the default upward placement" do
+    let(:placement) { :up }
+
+    it "anchors the bubble above the trigger" do
+      expect(html).to include("bottom-full")
+    end
+  end
+
+  context "with downward placement" do
+    let(:placement) { :down }
+
+    it "anchors the bubble below the trigger" do
+      expect(html).to include("top-full")
+    end
+  end
+end

--- a/spec/components/version_badge_spec.rb
+++ b/spec/components/version_badge_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::VersionBadge do
+  include_context "component view context"
+
+  subject(:html) { described_class.new.render_in(view_context) }
+
+  context "when a release is available" do
+    before do
+      allow(ReleaseInfo).to receive(:current).and_return(
+        ReleaseInfo.new(number: "3.1.0", released_on: Date.new(2026, 7, 11))
+      )
+    end
+
+    it "shows the version number" do
+      expect(html).to include("v3.1.0")
+    end
+
+    it "links to the release notes" do
+      expect(html).to include("href=\"https://github.com/badBlackShark/shrkbot/releases/tag/3.1.0\"")
+    end
+
+    it "labels the link for screen readers" do
+      expect(html).to include("3.1.0 release notes")
+    end
+
+    it "shows the release date in a downward tooltip" do
+      expect(html).to include("Released 11. Jul, 2026")
+      expect(html).to include("top-full")
+    end
+  end
+
+  context "when no release is available" do
+    before { allow(ReleaseInfo).to receive(:current).and_return(nil) }
+
+    it "renders nothing" do
+      expect(html).to eq("")
+    end
+  end
+end

--- a/spec/presenters/release_info_spec.rb
+++ b/spec/presenters/release_info_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ReleaseInfo do
+  describe ".current" do
+    subject(:release) { described_class.current }
+
+    before { described_class.instance_variable_set(:@current, nil) }
+
+    context "with released and unreleased sections in the changelog" do
+      let(:changelog) do
+        <<~MD
+          ## [Unreleased]
+          ### Fixed
+          - pending stuff
+          ## [3.1.0] - 2026-07-11
+          ### Added
+          - shipped stuff
+        MD
+      end
+
+      before do
+        allow(described_class::CHANGELOG).to receive_messages(exist?: true, read: changelog)
+      end
+
+      it "reads the latest released version, skipping Unreleased" do
+        expect(release.number).to eq("3.1.0")
+      end
+
+      it "reads the release date" do
+        expect(release.released_on).to eq(Date.new(2026, 7, 11))
+      end
+    end
+
+    context "with no released entry" do
+      before do
+        allow(described_class::CHANGELOG).to receive_messages(exist?: true, read: "## [Unreleased]\n- nothing yet\n")
+      end
+
+      it "returns nil" do
+        expect(release).to be_nil
+      end
+    end
+
+    context "when the changelog is missing" do
+      before { allow(described_class::CHANGELOG).to receive(:exist?).and_return(false) }
+
+      it "returns nil" do
+        expect(release).to be_nil
+      end
+    end
+  end
+
+  describe "#release_url" do
+    subject(:release) { described_class.new(number: "3.1.0", released_on: Date.new(2026, 7, 11)) }
+
+    it "links to the GitHub release tag" do
+      expect(release.release_url).to eq("https://github.com/badBlackShark/shrkbot/releases/tag/3.1.0")
+    end
+  end
+end

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -11,10 +11,11 @@ RSpec.describe "Home", type: :request do
     expect(response).to have_http_status(:ok)
   end
 
-  it "shows the hero headline" do
+  it "shows the hero tagline" do
     home
 
-    expect(response.body).to include("You pick the parts.")
+    expect(response.body).to include("A mechanical assistant for your Discord server.")
+    expect(response.body).to include("With teeth when needed.")
   end
 
   it "uses the brand display type for the wordmark" do
@@ -33,6 +34,15 @@ RSpec.describe "Home", type: :request do
     home
 
     expect(response.body).to include('href="https://github.com/badBlackShark/shrkbot"')
+  end
+
+  it "shows the version badge linking to a release" do
+    allow(ReleaseInfo).to receive(:current).and_return(
+      ReleaseInfo.new(number: "3.1.0", released_on: Date.new(2026, 7, 11))
+    )
+    home
+
+    expect(response.body).to include("/releases/tag/3.1.0")
   end
 
   it "renders the four plugin cards" do


### PR DESCRIPTION
Three landing-page changes, one PR.

## 1. Provenance footer, everywhere
The two divergent footers (public shell had OSS credit; app shell had bare legal links) are consolidated into a shared `Components::SiteFooter`, rendered by both shells so every page gets the same footer. Copy now carries a provenance line:

> shrkbot is free and open source. Made with ♥ by badBlackShark in Germany 🇩🇪, hosted in Finland 🇫🇮.

(Flag emoji degrade to letter-pairs on some Windows/Chrome setups — cosmetic, no layout impact.)

## 2. Hero copy refresh
- Renders the **wordmark** (enlarged via `font-size: larger`), then a tagline + a copper accent line ("With teeth when needed.").
- Tightened lede; dropped the now-redundant "Free & open source" eyebrow (footer says it).
- **Privacy claim scoped to messages** — the pitch draft said "nothing is ever stored", which contradicts the privacy policy (confirmed scam-image fingerprints, plus account/config data, *are* stored). Now reads "your messages are never stored", which is defensible line-by-line against `legal.en.yml`.

## 3. Header version badge
- A `v3.1.0` pill in the header of every page, linking to the GitHub release notes, with the **release date in a tooltip** ("Released 11. Jul, 2026").
- Version **derives from `CHANGELOG.md`** (new `ReleaseInfo` presenter) — no version constant to bump, tracks releases automatically.
- `Components::Tooltip` gained a `placement:` (up/down) so the header tooltip opens downward instead of clipping above the top bar. Placement is a param, not runtime clip-detection: the direction is known at author time, so a JS-measuring auto-flip would add cost to recover information we already have. Anchor-positioning auto-flip is the future upgrade when browser support is reliable.

## Boyscout
- Consolidated the repo URL onto `ReleaseInfo::REPO_URL` (was duplicated across the footer, the home view-source button, and the bot's `/info` command).

## Testing
All local gates green: `rspec` (1721 examples), `standardrb`, `active_record_doctor`, `undercover --compare origin/main`, `i18n-tasks missing`/`check-normalized`. New specs for `ReleaseInfo`, `Components::SiteFooter`, `Components::VersionBadge`, `Components::Tooltip` (placement), plus updated home request spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)