### PR TITLE
Make the moderation new-account cutoff configurable

### DIFF
--- a/app/components/moderation/account_age_card.rb
+++ b/app/components/moderation/account_age_card.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class Components::Moderation::AccountAgeCard < Components::Base
+  def initialize(new_account_age_days:)
+    @new_account_age_days = new_account_age_days
+  end
+
+  def view_template
+    render Components::Card.new do
+      div(class: "flex items-center justify-between gap-4") do
+        div(class: "max-w-md") do
+          label(class: "text-sm font-semibold") { t(".label") }
+          p(class: "mt-1.5 text-xs text-text-muted") { t(".help") }
+        end
+        render Components::NumberStepper.new(
+          name: "moderation[new_account_age_days]",
+          value: @new_account_age_days,
+          min: 1,
+          max: 365,
+          default: 30,
+          unit: t(".days_unit")
+        )
+      end
+    end
+  end
+end

--- a/app/components/moderation/overview_form.rb
+++ b/app/components/moderation/overview_form.rb
@@ -18,6 +18,9 @@ class Components::Moderation::OverviewForm < Components::Base
         staff_permission_warning: @context.staff_permission_warning?
       )
       render Components::Moderation::StaffPingCard.new(ping_staff: @context.ping_staff)
+      render Components::Moderation::AccountAgeCard.new(
+        new_account_age_days: @context.new_account_age_days
+      )
       render Components::Moderation::SubPluginDirectory.new(
         server_configuration: @config,
         context: @context

--- a/app/controllers/servers/moderation_controller.rb
+++ b/app/controllers/servers/moderation_controller.rb
@@ -19,15 +19,16 @@ class Servers::ModerationController < ApplicationController
       server_configuration: @server_configuration,
       staff_role_id: moderation_params[:staff_role_id],
       enabled: moderation_params[:enabled],
-      ping_staff: moderation_params[:ping_staff]
+      ping_staff: moderation_params[:ping_staff],
+      new_account_age_days: moderation_params[:new_account_age_days]
     )
-    respond_with_configuration(result, error_keys: [:enabled, :staff_role_id])
+    respond_with_configuration(result, error_keys: [:enabled, :staff_role_id, :new_account_age_days])
   end
 
   private
 
   def moderation_params
-    params.expect(moderation: [:staff_role_id, :enabled, :ping_staff])
+    params.expect(moderation: [:staff_role_id, :enabled, :ping_staff, :new_account_age_days])
   end
 
   def build_context

--- a/app/models/moderation/settings.rb
+++ b/app/models/moderation/settings.rb
@@ -5,5 +5,8 @@ module Moderation
     self.table_name = "moderation_settings"
 
     belongs_to :server_configuration
+
+    validates :new_account_age_days,
+      numericality: {only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 365}
   end
 end

--- a/app/operations/moderation/configure.rb
+++ b/app/operations/moderation/configure.rb
@@ -5,16 +5,18 @@ module Ops
     class Configure < ApplicationOperation
       include Ops::PluginConfiguration
 
-      receives :server_configuration, :staff_role_id, :enabled, :ping_staff
+      receives :server_configuration, :staff_role_id, :enabled, :ping_staff, :new_account_age_days
 
       def call
         settings = server_configuration.moderation_settings
         settings.assign_attributes(staff_role_id: staff_role_id.presence)
         settings.ping_staff = ping_staff unless ping_staff.nil?
+        settings.new_account_age_days = new_account_age_days if new_account_age_days.present?
         activation = staged_activation
 
         return logging_guard_failure(activation) if enabling? && !logging_ready?
         return staff_role_clear_failure(activation) if staff_role_id.blank? && sub_plugin_enabled?
+        return account_age_failure(settings, activation) unless settings.valid?
 
         settings.save!
         activation.save!
@@ -40,6 +42,11 @@ module Ops
       def staff_role_clear_failure(activation)
         activation.errors.add(:staff_role_id, I18n.t("operations.moderation.staff_role_in_use"))
         failure(activation.errors[:staff_role_id], value: activation)
+      end
+
+      def account_age_failure(settings, activation)
+        activation.errors.add(:new_account_age_days, settings.errors[:new_account_age_days].first)
+        failure(activation.errors[:new_account_age_days], value: activation)
       end
 
       def plugin_key

--- a/app/plugins/moderation/events/image_scan.rb
+++ b/app/plugins/moderation/events/image_scan.rb
@@ -13,7 +13,8 @@ module Moderation
       settings = ImageScanning::Settings.active_for(event.server.id)
       return unless settings
 
-      staff_role_id = settings.server_configuration.moderation_settings.staff_role_id
+      moderation_settings = settings.server_configuration.moderation_settings
+      staff_role_id = moderation_settings.staff_role_id
       return if Exemption.exempt?(member: event.author, server: event.server, staff_role_id:)
 
       attachments = eligible_attachments
@@ -22,7 +23,7 @@ module Moderation
       signals = ImageScanning::Signals.call(author: event.author, content: event.message.content, server_id: event.server.id)
 
       attachments.each do |attachment|
-        context = context_for(attachment, settings, signals)
+        context = context_for(attachment, settings, signals, moderation_settings.new_account_age_days)
         ImageScanning::ScanQueue.enqueue(-> { ImageScanning::ScanProcessor.call(context) })
       end
     end
@@ -35,7 +36,7 @@ module Moderation
         .first(MAX_ATTACHMENTS)
     end
 
-    def context_for(attachment, settings, signals)
+    def context_for(attachment, settings, signals, new_account_age_days)
       ImageScanning::ScanContext.new(
         bot: event.bot,
         server: event.server,
@@ -44,6 +45,7 @@ module Moderation
         message_id: event.message.id,
         attachment_url: attachment.url,
         signals:,
+        new_account_age_days:,
         settings:
       )
     end

--- a/app/plugins/moderation/image_scanning/classifier.rb
+++ b/app/plugins/moderation/image_scanning/classifier.rb
@@ -8,14 +8,13 @@ module Moderation
         "standard" => {flag: 3, remove: 6},
         "strict" => {flag: 2, remove: 4.5}
       }.freeze
-      NEW_ACCOUNT_DAYS = 7
       KEYWORD_WEIGHT = 2
       OWN_CONFIRMED_RISK = 6
       FUZZY_RATIO = 0.2
 
       module_function
 
-      def call(ocr_text:, hash_state:, signals:, settings:)
+      def call(ocr_text:, hash_state:, signals:, settings:, new_account_age_days:)
         canon = Canonicalizer.call(ocr_text)
 
         reasons = scam_rule_reasons(canon) + keyword_reasons(canon, settings)
@@ -24,7 +23,7 @@ module Moderation
         hash_reason = hash_reason(hash_state)
         reasons << hash_reason if hash_reason
 
-        reasons.concat(amplifier_reasons(signals))
+        reasons.concat(amplifier_reasons(signals, new_account_age_days))
         risk = reasons.sum(&:weight)
 
         keyword_gate = reasons.any? { |reason| reason.key == :custom_keywords }
@@ -69,9 +68,9 @@ module Moderation
         [Reason.new(key: :custom_keywords, weight: KEYWORD_WEIGHT * hits, detail: hits)]
       end
 
-      def amplifier_reasons(signals)
+      def amplifier_reasons(signals, new_account_age_days)
         reasons = []
-        if signals[:account_age_days] < NEW_ACCOUNT_DAYS
+        if signals[:account_age_days] < new_account_age_days
           reasons << Reason.new(key: :new_account, weight: 2, detail: signals[:account_age_days].floor)
         end
         reasons << Reason.new(key: :has_link, weight: 1) if signals[:has_link]

--- a/app/plugins/moderation/image_scanning/scan_context.rb
+++ b/app/plugins/moderation/image_scanning/scan_context.rb
@@ -10,6 +10,7 @@ module Moderation
       :message_id,
       :attachment_url,
       :signals,
+      :new_account_age_days,
       :settings
     )
   end

--- a/app/plugins/moderation/image_scanning/scan_processor.rb
+++ b/app/plugins/moderation/image_scanning/scan_processor.rb
@@ -19,7 +19,8 @@ module Moderation
           ocr_text:,
           hash_state: state,
           signals: context.signals,
-          settings: context.settings
+          settings: context.settings,
+          new_account_age_days: context.new_account_age_days
         )
         VerdictExecutor.call(verdict:, context:, phash: hex, hash_state: state, image_bytes: bytes)
       rescue Ocr::Error => e

--- a/app/presenters/moderation/overview_context.rb
+++ b/app/presenters/moderation/overview_context.rb
@@ -30,6 +30,10 @@ module Moderation
       @config.moderation_settings&.ping_staff
     end
 
+    def new_account_age_days
+      @config.moderation_settings&.new_account_age_days
+    end
+
     def staff_role_present?
       staff_role_id.present?
     end

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -68,6 +68,12 @@ en:
           toggle_all: Toggle all
           toggle_all_label: Toggle all %{plugin} events
     moderation:
+      account_age_card:
+        days_unit: days
+        help: How recently a Discord account must have been created to count as new.
+          New accounts draw extra scrutiny across every Moderation sub-plugin. Anywhere
+          from 1 to 365 days.
+        label: New account age
       image_scanning_form:
         consent:
           body: Deletion is on by default, and detection is automated and imperfect.

--- a/db/migrate/20260712115205_add_new_account_age_days_to_moderation_settings.rb
+++ b/db/migrate/20260712115205_add_new_account_age_days_to_moderation_settings.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddNewAccountAgeDaysToModerationSettings < ActiveRecord::Migration[8.1]
+  def change
+    add_column :moderation_settings, :new_account_age_days, :integer, null: false, default: 30
+
+    add_check_constraint :moderation_settings,
+      "new_account_age_days >= 1 AND new_account_age_days <= 365",
+      name: "moderation_settings_new_account_age_days_check"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_11_125937) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_12_115205) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -79,11 +79,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_11_125937) do
 
   create_table "moderation_settings", id: :string, default: -> { "('mds_'::text || gen_random_uuid())" }, force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.integer "new_account_age_days", default: 30, null: false
     t.boolean "ping_staff", default: true, null: false
     t.string "server_configuration_id", null: false
     t.bigint "staff_role_id"
     t.datetime "updated_at", null: false
     t.index ["server_configuration_id"], name: "index_moderation_settings_on_server_configuration_id", unique: true
+    t.check_constraint "new_account_age_days >= 1 AND new_account_age_days <= 365", name: "moderation_settings_new_account_age_days_check"
   end
 
   create_table "notifications", id: :string, default: -> { "('ntf_'::text || gen_random_uuid())" }, force: :cascade do |t|

--- a/spec/components/moderation/account_age_card_spec.rb
+++ b/spec/components/moderation/account_age_card_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::Moderation::AccountAgeCard do
+  include_context "component view context"
+
+  subject(:html) { described_class.new(new_account_age_days:).render_in(view_context) }
+
+  let(:new_account_age_days) { 30 }
+
+  it "renders the stepper with the correct field name" do
+    expect(html).to include('name="moderation[new_account_age_days]"')
+  end
+
+  it "renders the label and help text" do
+    expect(html).to include("New account age")
+    expect(html).to include("How recently a Discord account")
+  end
+
+  it "renders the configured value" do
+    expect(html).to include('value="30"')
+  end
+
+  context "with a custom value" do
+    let(:new_account_age_days) { 90 }
+
+    it "renders that value" do
+      expect(html).to include('value="90"')
+    end
+  end
+end

--- a/spec/components/moderation/overview_form_spec.rb
+++ b/spec/components/moderation/overview_form_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Components::Moderation::OverviewForm do
       Moderation::OverviewContext,
       staff_role_id: nil,
       ping_staff: true,
+      new_account_age_days: 30,
       staff_role_present?: false,
       permission_warning?: false,
       staff_permission_warning?: false,
@@ -31,6 +32,10 @@ RSpec.describe Components::Moderation::OverviewForm do
 
   it "renders the staff ping toggle" do
     expect(html).to include("moderation[ping_staff]")
+  end
+
+  it "renders the account age stepper" do
+    expect(html).to include("moderation[new_account_age_days]")
   end
 
   it "renders no enable_error callout by default" do

--- a/spec/models/moderation/settings_spec.rb
+++ b/spec/models/moderation/settings_spec.rb
@@ -16,4 +16,44 @@ RSpec.describe Moderation::Settings do
   it "persists via the factory" do
     expect { create(:moderation_settings) }.to change(described_class, :count).by(1)
   end
+
+  describe "new_account_age_days validation" do
+    subject(:settings) { build(:moderation_settings, new_account_age_days:) }
+
+    context "at the lower bound" do
+      let(:new_account_age_days) { 1 }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "at the default" do
+      let(:new_account_age_days) { 30 }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "at the upper bound" do
+      let(:new_account_age_days) { 365 }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "below the lower bound" do
+      let(:new_account_age_days) { 0 }
+
+      it "is invalid with an error on the field" do
+        expect(settings).not_to be_valid
+        expect(settings.errors[:new_account_age_days]).to be_present
+      end
+    end
+
+    context "above the upper bound" do
+      let(:new_account_age_days) { 366 }
+
+      it "is invalid with an error on the field" do
+        expect(settings).not_to be_valid
+        expect(settings.errors[:new_account_age_days]).to be_present
+      end
+    end
+  end
 end

--- a/spec/operations/moderation/configure_spec.rb
+++ b/spec/operations/moderation/configure_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Ops::Moderation::Configure do
       server_configuration: config,
       staff_role_id:,
       enabled:,
-      ping_staff:
+      ping_staff:,
+      new_account_age_days:
     )
   end
 
@@ -18,6 +19,7 @@ RSpec.describe Ops::Moderation::Configure do
   let(:staff_role_id) { 111_222_333 }
   let(:enabled) { "1" }
   let(:ping_staff) { "1" }
+  let(:new_account_age_days) { 30 }
 
   context "when enabling without logging ready (no logging plugin enabled)" do
     it "fails with an error on the enabled field" do
@@ -176,6 +178,43 @@ RSpec.describe Ops::Moderation::Configure do
     it "persists ping_staff as true" do
       result
       expect(config.moderation_settings.reload.ping_staff).to be(true)
+    end
+  end
+
+  context "when setting new_account_age_days to a custom value" do
+    let(:enabled) { "0" }
+    let(:new_account_age_days) { 90 }
+
+    it "persists the new value" do
+      result
+      expect(config.moderation_settings.reload.new_account_age_days).to eq(90)
+    end
+  end
+
+  context "when new_account_age_days is blank" do
+    let(:enabled) { "0" }
+    let(:new_account_age_days) { nil }
+
+    before { settings.update!(new_account_age_days: 45) }
+
+    it "preserves the existing value" do
+      result
+      expect(config.moderation_settings.reload.new_account_age_days).to eq(45)
+    end
+  end
+
+  context "when new_account_age_days is out of range" do
+    let(:enabled) { "0" }
+    let(:new_account_age_days) { 500 }
+
+    it "fails with an error on the field rather than raising" do
+      expect(result).to be_failure
+      expect(result.value.errors[:new_account_age_days]).to be_present
+    end
+
+    it "persists nothing" do
+      result
+      expect(config.moderation_settings.reload.new_account_age_days).to eq(30)
     end
   end
 end

--- a/spec/plugins/moderation/events/image_scan_spec.rb
+++ b/spec/plugins/moderation/events/image_scan_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Moderation::ImageScan do
 
   let(:owner) { double("owner", id: 999) }
   let(:staff_role_id) { nil }
-  let(:moderation_settings) { double("moderation_settings", staff_role_id:) }
+  let(:moderation_settings) { double("moderation_settings", staff_role_id:, new_account_age_days: 30) }
   let(:server_configuration) { double("server_configuration", moderation_settings:) }
   let(:settings) { double("settings", server_configuration:) }
   let(:signals) { {account_age_days: 2, has_link: false, has_role: false} }

--- a/spec/plugins/moderation/image_scanning/classifier_spec.rb
+++ b/spec/plugins/moderation/image_scanning/classifier_spec.rb
@@ -8,12 +8,14 @@ RSpec.describe Moderation::ImageScanning::Classifier do
       ocr_text:,
       hash_state:,
       signals:,
-      settings:
+      settings:,
+      new_account_age_days:
     )
   end
 
   let(:ocr_text) { "" }
   let(:hash_state) { :none }
+  let(:new_account_age_days) { 30 }
   let(:signals) { {account_age_days: 365, has_link: false, has_role: true} }
   let(:sensitivity) { "standard" }
   let(:custom_keywords) { [] }
@@ -176,6 +178,16 @@ RSpec.describe Moderation::ImageScanning::Classifier do
     context "aged account with role and no link" do
       it "adds no amplifier risk" do
         expect(verdict.risk).to eq(2)
+      end
+    end
+
+    context "with a raised new-account cutoff" do
+      let(:new_account_age_days) { 60 }
+      let(:ocr_text) { "promo code withdraw tuzawin" }
+      let(:signals) { {account_age_days: 45, has_link: false, has_role: true} }
+
+      it "treats an account within the cutoff as new" do
+        expect(verdict.reasons.map(&:key)).to include(:new_account)
       end
     end
   end

--- a/spec/plugins/moderation/image_scanning/scan_processor_spec.rb
+++ b/spec/plugins/moderation/image_scanning/scan_processor_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Moderation::ImageScanning::ScanProcessor do
       message_id: 4,
       attachment_url: "https://cdn/x.png",
       signals:,
+      new_account_age_days: 30,
       settings:
     )
   end
@@ -47,7 +48,8 @@ RSpec.describe Moderation::ImageScanning::ScanProcessor do
         ocr_text: "won usdt",
         hash_state: :none,
         signals:,
-        settings:
+        settings:,
+        new_account_age_days: 30
       )
       expect(Moderation::ImageScanning::VerdictExecutor).to have_received(:call).with(verdict:, context:, phash: hex, hash_state: :none, image_bytes: "bytes")
     end
@@ -69,7 +71,8 @@ RSpec.describe Moderation::ImageScanning::ScanProcessor do
         ocr_text: "",
         hash_state: :own_confirmed,
         signals:,
-        settings:
+        settings:,
+        new_account_age_days: 30
       )
     end
 
@@ -92,7 +95,8 @@ RSpec.describe Moderation::ImageScanning::ScanProcessor do
         ocr_text: "won usdt",
         hash_state: :foreign_confirmed,
         signals:,
-        settings:
+        settings:,
+        new_account_age_days: 30
       )
     end
 

--- a/spec/plugins/moderation/image_scanning/verdict_executor_spec.rb
+++ b/spec/plugins/moderation/image_scanning/verdict_executor_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe Moderation::ImageScanning::VerdictExecutor do
       message_id:,
       attachment_url:,
       signals: {},
+      new_account_age_days: 30,
       settings:
     )
   end

--- a/spec/presenters/moderation/overview_context_spec.rb
+++ b/spec/presenters/moderation/overview_context_spec.rb
@@ -109,6 +109,24 @@ RSpec.describe Moderation::OverviewContext do
     end
   end
 
+  describe "#new_account_age_days" do
+    context "when set" do
+      before { config.moderation_settings.update!(new_account_age_days: 90) }
+
+      it "returns the configured value" do
+        expect(context.new_account_age_days).to eq(90)
+      end
+    end
+
+    context "when moderation_settings does not exist" do
+      before { config.moderation_settings.destroy! }
+
+      it "returns nil" do
+        expect(described_class.new(config.reload).new_account_age_days).to be_nil
+      end
+    end
+  end
+
   describe "#staff_role_present?" do
     context "when staff_role_id is set" do
       before { config.moderation_settings.update!(staff_role_id: 555) }


### PR DESCRIPTION
## What

The moderation "new account" age threshold was hardcoded at `NEW_ACCOUNT_DAYS = 7` inside the image-scanning classifier. 7 days is too short to catch throwaway scam accounts. This makes the cutoff a per-guild setting and raises the default to **30 days**.

## Where it lives

The cutoff is stored on `moderation_settings` — the **moderation-level, shared** config, not on `image_scanning_settings` — so every current and future moderation sub-plugin reads one value. It's configured on the **Server Shield overview** page next to the staff role, via a number stepper. Range **1–365 days**, default **30** (power-user philosophy: sanity bounds only, honest default).

## How the value flows

- `moderation_settings.new_account_age_days` (integer, `null: false default: 30`, check constraint `1..365`).
- The `ImageScan` event handler already loads `moderation_settings` (for `staff_role_id`); it now reads the cutoff there and threads it through `ScanContext` → `ScanProcessor` → `Classifier`. The classifier no longer owns any constant.
- Model validation mirrors the DB check constraint (active_record_doctor).
- `Ops::Moderation::Configure` surfaces an out-of-range value as a normal validation failure instead of letting `save!` raise a 500 on a forged request.

## Privacy

No new personal data — this is guild-scoped config on `moderation_settings`, already covered by the existing "moderation settings" clause in the privacy policy and purged via the `ServerConfiguration` cascade. No `Ops::Users::Destroy` change needed.

## Tests

Classifier (dynamic cutoff), Configure op (assignment, blank-preserve, out-of-range failure), model validation (bounds), presenter reader, new `AccountAgeCard` component spec, and the touched scan/event/overview specs. All gates green locally: rspec, standardrb, active_record_doctor, undercover, i18n.

🤖 Generated with [Claude Code](https://claude.com/claude-code)