### PR TITLE
Surface spam-guard validation failures to the user

### DIFF
--- a/app/components/moderation/spam_protection_form.rb
+++ b/app/components/moderation/spam_protection_form.rb
@@ -42,6 +42,7 @@ class Components::Moderation::SpamProtectionForm < Components::Base
           name: "spam_protection[channel_threshold]",
           value: @settings.channel_threshold,
           min: 2,
+          max: 500,
           default: 4,
           unit: t(".detection.trigger_threshold.channels_unit")
         )
@@ -52,6 +53,7 @@ class Components::Moderation::SpamProtectionForm < Components::Base
           name: "spam_protection[window_seconds]",
           value: @settings.window_seconds,
           min: 1,
+          max: 60,
           default: 15,
           unit: t(".detection.trigger_threshold.seconds_unit")
         )

--- a/app/controllers/concerns/configures_plugin.rb
+++ b/app/controllers/concerns/configures_plugin.rb
@@ -13,6 +13,7 @@ module ConfiguresPlugin
     activation = result.value
     @enabled = activation.enabled?
     @enable_error = error_keys.filter_map { |key| activation.errors[key].first }.first
+    @enable_error ||= result.errors.to_sentence.presence if result.failure?
     @toast = {level: "notice", message: saved_message} if result.success?
     respond_to do |format|
       format.turbo_stream { render status: result.success? ? :ok : :unprocessable_content }

--- a/spec/components/moderation/spam_protection_form_spec.rb
+++ b/spec/components/moderation/spam_protection_form_spec.rb
@@ -35,6 +35,14 @@ RSpec.describe Components::Moderation::SpamProtectionForm do
     expect(html).to include('name="spam_protection[window_seconds]"')
   end
 
+  it "caps the threshold stepper at the server-side maximum for native validation" do
+    expect(html).to include('max="500"')
+  end
+
+  it "caps the window seconds stepper at the server-side maximum for native validation" do
+    expect(html).to include('max="60"')
+  end
+
   it "renders the similarity range slider with correct field name" do
     expect(html).to include('name="spam_protection[similarity]"')
   end

--- a/spec/requests/spam_protection_config_spec.rb
+++ b/spec/requests/spam_protection_config_spec.rb
@@ -105,6 +105,25 @@ RSpec.describe "Spam protection config", type: :request do
           expect(response.body).to include("saved")
         end
 
+        it "surfaces the validation message when a value exceeds its maximum" do
+          patch server_spam_protection_path(guild.id),
+            params: {spam_protection: {channel_threshold: 3, window_seconds: 99, similarity: 0.9,
+                                       match_symbol_only_messages: "0", action: "purge", punishment: "none",
+                                       timeout_seconds: 3600, enabled: "0"}},
+            **turbo
+          expect(response).to have_http_status(:unprocessable_content)
+          expect(response.body).to include("must be less than or equal to 60")
+        end
+
+        it "persists nothing when a value is out of range" do
+          patch server_spam_protection_path(guild.id),
+            params: {spam_protection: {channel_threshold: 3, window_seconds: 99, similarity: 0.9,
+                                       match_symbol_only_messages: "0", action: "purge", punishment: "none",
+                                       timeout_seconds: 3600, enabled: "0"}},
+            **turbo
+          expect(config.spam_protection_settings.reload.window_seconds).not_to eq(99)
+        end
+
         it "returns 422 when enabling with no staff role" do
           config.moderation_settings.update!(staff_role_id: nil)
           create(:plugin_activation, server_configuration: config, plugin: spam_plugin, enabled: false)


### PR DESCRIPTION
## Symptom

On the Cross-Channel Spam Guard config, setting **seconds to anything over 60** made the save silently fail — no message, no clue why. Everywhere else (e.g. the account-age field), the browser gives native feedback.

## Cause — two gaps

1. **No native validation.** The `window_seconds` and `channel_threshold` steppers passed no `max:` to `NumberStepper`, so no HTML `max` attribute rendered and the browser had nothing to validate against. Fields that *do* set `max` validate natively — hence the inconsistency.
2. **No server-side message either.** The op fails gracefully (no 500), attaching validation errors to `settings`. But `respond_with_configuration` only reads `activation.errors[:enabled]`, so field-level errors on `settings` never reached `@enable_error` — the turbo re-render showed nothing.

## Fix

- Give both steppers their server-side maxima (`channel_threshold` 500, `window_seconds` 60) so native validation fires immediately, matching the rest of the UI.
- In `respond_with_configuration`, fall back to the operation's own error messages when no activation-level error key matches. A rejected save now always surfaces its reason — for **every** plugin config form, and as a backstop for forged requests / JS-off that skip the browser.

## Tests

- Form spec: both steppers render their `max`.
- Request spec: an out-of-range `window_seconds` returns 422, surfaces "must be less than or equal to 60", and persists nothing.

All gates green locally: rspec (1742), standardrb, undercover. No model/schema/locale changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)