### PR TITLE
Scan Discord-CDN image links pasted as message content

### DIFF
--- a/app/plugins/moderation/events/image_scan.rb
+++ b/app/plugins/moderation/events/image_scan.rb
@@ -5,9 +5,11 @@ module Moderation
     on :message
 
     def handle
+      message = event.message
       ImageScanning::EnqueueScan.call(
         event:,
-        images: ImageScanning::ScannableImages.attachments(event.message)
+        images: ImageScanning::ScannableImages.attachments(message) +
+          ImageScanning::ScannableImages.content_links(message)
       )
     end
   end

--- a/app/plugins/moderation/image_scanning.rb
+++ b/app/plugins/moderation/image_scanning.rb
@@ -3,5 +3,7 @@
 module Moderation
   module ImageScanning
     CONTENT_TYPES = %w[image/png image/jpeg image/webp].freeze
+    IMAGE_EXTENSIONS = %w[.png .jpg .jpeg .webp].freeze
+    DISCORD_CDN_HOSTS = %w[cdn.discordapp.com media.discordapp.net].freeze
   end
 end

--- a/app/plugins/moderation/image_scanning/scannable_images.rb
+++ b/app/plugins/moderation/image_scanning/scannable_images.rb
@@ -14,6 +14,13 @@ module Moderation
         new(message).embeds
       end
 
+      def self.content_links(message)
+        new(message).content_links
+      end
+
+      URL_PATTERN = %r{https?://\S+}
+      TRAILING_PUNCTUATION = /[.,!?;:)\]>]+\z/
+
       def initialize(message)
         @message = message
       end
@@ -33,9 +40,28 @@ module Moderation
           .map(&:proxy_url)
       end
 
+      def content_links
+        message.content.to_s.scan(URL_PATTERN)
+          .filter_map { |raw| discord_cdn_image_url(raw) }
+          .first(MAX)
+      end
+
       private
 
       attr_reader :message
+
+      def discord_cdn_image_url(raw)
+        url = raw.sub(TRAILING_PUNCTUATION, "")
+        uri = URI.parse(url)
+        return unless uri.is_a?(URI::HTTPS)
+        return unless uri.port == 443
+        return unless DISCORD_CDN_HOSTS.include?(uri.host)
+        return unless IMAGE_EXTENSIONS.include?(File.extname(uri.path).downcase)
+
+        url
+      rescue URI::InvalidURIError
+        nil
+      end
     end
   end
 end

--- a/spec/plugins/moderation/events/image_scan_spec.rb
+++ b/spec/plugins/moderation/events/image_scan_spec.rb
@@ -7,10 +7,12 @@ RSpec.describe Moderation::ImageScan do
 
   let(:message) { double("message") }
   let(:event) { double("event", message:) }
-  let(:image_urls) { ["https://cdn/x.png"] }
+  let(:attachment_urls) { ["https://cdn/x.png"] }
+  let(:content_link_urls) { ["https://cdn.discordapp.com/attachments/1/2/img.png"] }
 
   before do
-    allow(Moderation::ImageScanning::ScannableImages).to receive(:attachments).with(message).and_return(image_urls)
+    allow(Moderation::ImageScanning::ScannableImages).to receive(:attachments).with(message).and_return(attachment_urls)
+    allow(Moderation::ImageScanning::ScannableImages).to receive(:content_links).with(message).and_return(content_link_urls)
     allow(Moderation::ImageScanning::EnqueueScan).to receive(:call)
   end
 
@@ -18,10 +20,10 @@ RSpec.describe Moderation::ImageScan do
     expect(described_class.discord_events).to include(:message)
   end
 
-  it "delegates to EnqueueScan with attachment URLs" do
+  it "delegates to EnqueueScan with attachment URLs and content link URLs combined" do
     expect(Moderation::ImageScanning::EnqueueScan).to receive(:call).with(
       event:,
-      images: image_urls
+      images: attachment_urls + content_link_urls
     )
     handle
   end

--- a/spec/plugins/moderation/image_scanning/scannable_images_spec.rb
+++ b/spec/plugins/moderation/image_scanning/scannable_images_spec.rb
@@ -52,6 +52,117 @@ RSpec.describe Moderation::ImageScanning::ScannableImages do
     end
   end
 
+  describe ".content_links" do
+    subject(:result) { described_class.content_links(message) }
+
+    let(:cdn_url) { "https://cdn.discordapp.com/attachments/123/456/scan.png?ex=abc&is=def&hm=xyz" }
+    let(:message) { double("message", content: "check this out #{cdn_url}") }
+
+    it "returns Discord CDN png link with signed query preserved" do
+      expect(result).to eq([cdn_url])
+    end
+
+    context "when link is on media.discordapp.net" do
+      let(:media_url) { "https://media.discordapp.net/attachments/1/2/img.jpg" }
+      let(:message) { double("message", content: media_url) }
+
+      it "returns it" do
+        expect(result).to eq([media_url])
+      end
+    end
+
+    context "when host looks like Discord CDN but has extra suffix (subdomain takeover attempt)" do
+      let(:message) { double("message", content: "https://cdn.discordapp.com.evil.com/x.png") }
+
+      it "skips it" do
+        expect(result).to be_empty
+      end
+    end
+
+    context "when host is a non-Discord domain" do
+      let(:message) { double("message", content: "https://evil.com/x.png") }
+
+      it "skips it" do
+        expect(result).to be_empty
+      end
+    end
+
+    context "when image extension is not in the allowlist" do
+      let(:message) { double("message", content: "https://cdn.discordapp.com/a/file.pdf") }
+
+      it "skips it" do
+        expect(result).to be_empty
+      end
+    end
+
+    context "when link uses http instead of https" do
+      let(:message) { double("message", content: "http://cdn.discordapp.com/attachments/1/2/img.png") }
+
+      it "skips it" do
+        expect(result).to be_empty
+      end
+    end
+
+    context "when content contains a malformed URL" do
+      let(:message) { double("message", content: "https://cdn.discordapp.com/[bad") }
+
+      it "skips it without raising" do
+        expect(result).to be_empty
+      end
+    end
+
+    context "when content is mixed text and a valid link" do
+      let(:message) { double("message", content: "hey look at this #{cdn_url} pretty cool right") }
+
+      it "extracts just the link" do
+        expect(result).to eq([cdn_url])
+      end
+    end
+
+    context "when there are more than MAX valid links" do
+      let(:urls) do
+        Array.new(5) { |i| "https://cdn.discordapp.com/attachments/#{i}/#{i}/img#{i}.png" }
+      end
+      let(:message) { double("message", content: urls.join(" ")) }
+
+      it "caps at 3" do
+        expect(result.length).to eq(3)
+      end
+    end
+
+    context "when the link uses a non-standard port" do
+      let(:message) { double("message", content: "https://cdn.discordapp.com:8443/attachments/1/2/x.png") }
+
+      it "skips it" do
+        expect(result).to be_empty
+      end
+    end
+
+    context "when a valid link ends a sentence with trailing punctuation" do
+      let(:message) { double("message", content: "see #{cdn_url}.") }
+
+      it "strips the punctuation and returns the link" do
+        expect(result).to eq([cdn_url])
+      end
+    end
+
+    context "when content is nil" do
+      let(:message) { double("message", content: nil) }
+
+      it "returns empty array" do
+        expect(result).to eq([])
+      end
+    end
+
+    context "when content is empty string" do
+      let(:message) { double("message", content: "") }
+
+      it "returns empty array" do
+        expect(result).to eq([])
+      end
+    end
+  end
+
   describe ".embeds" do
     subject(:result) { described_class.embeds(message) }
 


### PR DESCRIPTION
## What

Closes the "paste the link instead of attaching" evasion. A scammer uploads a scam image, copies its `cdn.discordapp.com/attachments/…png?ex=&is=&hm=` link, and pastes the **link as message text**. That message has no attachment, and Discord does not unfurl its own signed CDN links into an embed — so neither `ImageScan` (attachments) nor `EmbedScan` (embeds) ever saw it.

New source: `ScannableImages.content_links` extracts URLs from message content and scans those hosted on Discord's own CDN, at message-create, through the existing OCR/phash pipeline.

## Security (this is the crux — it's an SSRF surface)

The URL comes from user content, so fetching it is an SSRF risk. Fetching is gated to Discord-owned hosts only:
- **https only** (`URI::HTTPS`)
- **exact-match host allowlist** — `cdn.discordapp.com` / `media.discordapp.net` via `include?(uri.host)`, never `end_with?` (so `cdn.discordapp.com.evil.com` and `…@evil.com` are rejected)
- **port 443** (Discord CDN never serves elsewhere; defence-in-depth)
- **image extension** off `uri.path` (query excluded)
- `URI::InvalidURIError` rescued → skipped

`cdn.discordapp.com` = origin attachment CDN; `media.discordapp.net` = Discord's media proxy/thumbnail host (where embed `proxy_url` values resolve). Both Discord-owned = same trust as an attachment. **External / non-Discord image links are deliberately out of scope** — those normally generate a link-preview embed and are already covered by `EmbedScan` via `proxy_url`. The bot never issues HTTP at attacker-controlled origins.

The signed query (`?ex=&is=&hm=`) is preserved in the returned URL — it's required to fetch.

## Privacy
No new stored data (content is already read for Signals; links scanned in-memory like every other image, zero retention). No migration, no locale, no dependency.

## Deferred
- Content links added by a later **edit** (MESSAGE_UPDATE) aren't scanned — content links are read at create only.

## Tests
`ScannableImages.content_links` — CDN png/jpg returned with query preserved; look-alike host (`cdn.discordapp.com.evil.com`), non-Discord host, non-image extension, http, non-standard port, malformed URL all skipped; trailing sentence punctuation stripped; mixed prose; MAX cap; nil/empty content. Delegation spec updated to assert attachments ++ content_links. Full suite green (1770), standardrb / active_record_doctor / undercover clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)