### PR TITLE
Scan first frame of GIF images

### DIFF
--- a/app/plugins/moderation/image_scanning.rb
+++ b/app/plugins/moderation/image_scanning.rb
@@ -2,8 +2,8 @@
 
 module Moderation
   module ImageScanning
-    CONTENT_TYPES = %w[image/png image/jpeg image/webp].freeze
-    IMAGE_EXTENSIONS = %w[.png .jpg .jpeg .webp].freeze
+    CONTENT_TYPES = %w[image/png image/jpeg image/webp image/gif].freeze
+    IMAGE_EXTENSIONS = %w[.png .jpg .jpeg .webp .gif].freeze
     DISCORD_CDN_HOSTS = %w[cdn.discordapp.com media.discordapp.net].freeze
   end
 end

--- a/ocr/tests/test_preprocess.py
+++ b/ocr/tests/test_preprocess.py
@@ -33,6 +33,25 @@ def test_rgba_converted_to_rgb():
     assert out.mode == "RGB"
 
 
+def test_animated_gif_uses_first_frame():
+    # We whitelist image/gif on the Ruby side relying on preprocess() reducing
+    # an animated GIF to frame 0 (convert("RGB") operates on the current frame,
+    # which Image.open positions at 0). Lock that guarantee.
+    frame0 = _solid(120, 120, color=(200, 40, 40))  # red-dominant
+    frame1 = _solid(120, 120, color=(40, 40, 200))  # blue-dominant
+    buf = io.BytesIO()
+    frame0.save(buf, format="GIF", save_all=True, append_images=[frame1])
+    buf.seek(0)
+    img = Image.open(buf)
+    assert img.n_frames == 2
+
+    out = preprocess(img)
+    assert out.mode == "RGB"
+    assert not getattr(out, "is_animated", False)
+    r, _, b = out.getpixel((0, 0))
+    assert r > b
+
+
 def test_exif_orientation_6():
     # Orientation tag 6 = 90° CW rotation; PIL exif_transpose corrects it.
     # Build a non-square image so swapped dims are detectable.

--- a/spec/plugins/moderation/image_scanning/scannable_images_spec.rb
+++ b/spec/plugins/moderation/image_scanning/scannable_images_spec.rb
@@ -50,6 +50,14 @@ RSpec.describe Moderation::ImageScanning::ScannableImages do
         expect(result).to eq(["https://cdn/ok.jpg"])
       end
     end
+
+    context "when attachment is a GIF" do
+      let(:attachments) { [double("att", content_type: "image/gif", size: 1234, url: "https://cdn/anim.gif")] }
+
+      it "includes it" do
+        expect(result).to eq(["https://cdn/anim.gif"])
+      end
+    end
   end
 
   describe ".content_links" do
@@ -130,6 +138,14 @@ RSpec.describe Moderation::ImageScanning::ScannableImages do
       end
     end
 
+    context "when the link is a GIF" do
+      let(:message) { double("message", content: "https://cdn.discordapp.com/attachments/1/2/anim.gif") }
+
+      it "returns it" do
+        expect(result).to eq(["https://cdn.discordapp.com/attachments/1/2/anim.gif"])
+      end
+    end
+
     context "when the link uses a non-standard port" do
       let(:message) { double("message", content: "https://cdn.discordapp.com:8443/attachments/1/2/x.png") }
 
@@ -192,10 +208,18 @@ RSpec.describe Moderation::ImageScanning::ScannableImages do
     end
 
     context "when embed image has non-whitelisted content type" do
-      let(:embed_image) { double("img", proxy_url: "https://media.discordapp.net/x.gif", content_type: "image/gif") }
+      let(:embed_image) { double("img", proxy_url: "https://media.discordapp.net/x.bmp", content_type: "image/bmp") }
 
       it "skips it" do
         expect(result).to be_empty
+      end
+    end
+
+    context "when embed image is a GIF" do
+      let(:embed_image) { double("img", proxy_url: "https://media.discordapp.net/a.gif", content_type: "image/gif") }
+
+      it "returns it" do
+        expect(result).to eq(["https://media.discordapp.net/a.gif"])
       end
     end
 


### PR DESCRIPTION
## What

Server Shield V2 #2 (GIF half). Extends image scanning to `image/gif` attachments and `.gif` Discord-CDN links. A scammer uploading an animated `.gif` with scam text on frame 0 currently slips through — `image/gif` was never in the whitelist.

## Why it's a two-line change

The Python OCR sidecar already loads every image via `PIL.Image.open(BytesIO)` and `preprocess()` calls `img.convert("RGB")` unconditionally. On an animated image that operates on **frame 0** (where `Image.open` positions), so GIFs are already reduced to a single frame at the sidecar. Pillow is already a dependency. No decoder, no new dependency — the only thing rejecting GIFs was the Ruby `CONTENT_TYPES` / `IMAGE_EXTENSIONS` whitelist.

- Ruby: add `image/gif` + `.gif` to the two constants.
- Sidecar: **no code change** — added a `test_preprocess.py` test that builds a 2-frame GIF and asserts `preprocess()` returns a single-frame RGB image matching frame 0, to lock the guarantee we now depend on.

## Scope — native GIF files only

| "GIF" | Delivered as | Covered |
|---|---|---|
| Uploaded `.gif` file | attachment `image/gif` | ✅ |
| `.gif` CDN link | content-link | ✅ |
| Large GIF → MP4 | `video/mp4` | ❌ deferred (video) |
| Tenor/Giphy picker | external-CDN video embed | ❌ deferred (video) |

The common Discord "GIF" (Tenor via `/gif`) arrives as external-CDN video, not a GIF file — that's the deferred video work (needs a decoder + external-embed/SSRF handling + container-size tradeoff). This chunk closes the native-GIF-file vector and lays the content-type plumbing video will reuse.

## Deferred
- Multi-frame scanning (scam on a later frame) — first-frame-only, same accepted tradeoff as the v1 static-only gap.
- Video (MP4 / Tenor / transcoded GIFs).

## Notes
No new stored data, no migration, no locale, no new dependency. Small-change: implemented inline, self-reviewed against conventions, convention-reviewer pass skipped per the ≤50-line exception. **Sidecar test not run locally** — the paddle/PIL env isn't available in the sandbox (live sidecar gates are run separately); the Ruby suite (1773) + standardrb + active_record_doctor + undercover are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)