### PR TITLE
Fingerprint spam attachments by content hash

### DIFF
--- a/app/plugins/moderation/attachment_download.rb
+++ b/app/plugins/moderation/attachment_download.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "net/http"
+require "uri"
+
+module Moderation
+  module AttachmentDownload
+    Error = Class.new(StandardError)
+
+    module_function
+
+    def call(url)
+      uri = URI(url)
+      Net::HTTP.start(
+        uri.host,
+        uri.port,
+        use_ssl: uri.scheme == "https",
+        open_timeout: 5,
+        read_timeout: 30
+      ) do |http|
+        response = http.get(uri)
+        unless response.code.to_i.between?(200, 299)
+          raise Error, "download failed: #{response.code}"
+        end
+
+        response.body
+      end
+    rescue Net::OpenTimeout, Net::ReadTimeout, SocketError => e
+      raise Error, e.message
+    end
+  end
+end

--- a/app/plugins/moderation/events/spam_guard.rb
+++ b/app/plugins/moderation/events/spam_guard.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
+require "digest"
+
 module Moderation
   class SpamGuard < Bot::BaseEvent
     on :message
 
     CONTENT_PREVIEW_LIMIT = 800
+    MAX_FINGERPRINT_BYTES = 10 * 1024 * 1024
+    MAX_HASHED_ATTACHMENTS = 3
 
     def handle
       return if event.from_bot? || event.message.webhook? || event.channel.pm?
@@ -38,11 +42,27 @@ module Moderation
         result << "blank"
       end
 
-      event.message.attachments.each do |attachment|
-        result << "a:#{attachment.filename}:#{attachment.size}"
-      end
-
+      result.concat(attachment_fingerprints)
       result
+    end
+
+    def attachment_fingerprints
+      attachments = event.message.attachments
+      hashed = attachments.first(MAX_HASHED_ATTACHMENTS).map { |a| attachment_fingerprint(a) }
+      metadata = attachments.drop(MAX_HASHED_ATTACHMENTS).map { |a| filename_fingerprint(a) }
+      hashed + metadata
+    end
+
+    def attachment_fingerprint(attachment)
+      return filename_fingerprint(attachment) if attachment.size > MAX_FINGERPRINT_BYTES
+
+      "a:#{Digest::SHA256.hexdigest(AttachmentDownload.call(attachment.url))}"
+    rescue AttachmentDownload::Error
+      filename_fingerprint(attachment)
+    end
+
+    def filename_fingerprint(attachment)
+      "a:#{attachment.filename}:#{attachment.size}"
     end
 
     def detect(settings)

--- a/app/plugins/moderation/image_scanning/image_download.rb
+++ b/app/plugins/moderation/image_scanning/image_download.rb
@@ -1,30 +1,13 @@
 # frozen_string_literal: true
 
-require "net/http"
-require "uri"
-
 module Moderation
   module ImageScanning
     module ImageDownload
       module_function
 
       def call(url)
-        uri = URI(url)
-        Net::HTTP.start(
-          uri.host,
-          uri.port,
-          use_ssl: uri.scheme == "https",
-          open_timeout: 5,
-          read_timeout: 30
-        ) do |http|
-          response = http.get(uri)
-          unless response.code.to_i.between?(200, 299)
-            raise Ocr::Error, "attachment download failed: #{response.code}"
-          end
-
-          response.body
-        end
-      rescue Net::OpenTimeout, Net::ReadTimeout, SocketError => e
+        AttachmentDownload.call(url)
+      rescue AttachmentDownload::Error => e
         raise Ocr::Error, e.message
       end
     end

--- a/spec/plugins/moderation/attachment_download_spec.rb
+++ b/spec/plugins/moderation/attachment_download_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Moderation::AttachmentDownload do
+  subject(:download) { described_class.call("https://cdn/x.png") }
+
+  let(:http) { double("http") }
+  let(:response) { double("response", code: "200", body: "bytes") }
+
+  before do
+    allow(Net::HTTP).to receive(:start) { |*_args, &block| block.call(http) }
+    allow(http).to receive(:get).and_return(response)
+  end
+
+  context "when the download succeeds" do
+    it "returns the response body" do
+      expect(download).to eq("bytes")
+    end
+  end
+
+  context "when the download returns a non-success status" do
+    let(:response) { double("response", code: "404", body: "") }
+
+    it "raises an AttachmentDownload::Error" do
+      expect { download }.to raise_error(Moderation::AttachmentDownload::Error, /404/)
+    end
+  end
+
+  context "when the connection fails" do
+    before do
+      allow(Net::HTTP).to receive(:start).and_raise(SocketError, "no dns")
+    end
+
+    it "raises an AttachmentDownload::Error" do
+      expect { download }.to raise_error(Moderation::AttachmentDownload::Error, "no dns")
+    end
+  end
+end

--- a/spec/plugins/moderation/events/spam_guard_spec.rb
+++ b/spec/plugins/moderation/events/spam_guard_spec.rb
@@ -263,14 +263,90 @@ RSpec.describe Moderation::SpamGuard do
   end
 
   context "when the same attachment is posted across channels" do
-    let(:attachment) { double("attachment", filename: "scam.png", size: 1024) }
+    let(:attachment) { double("attachment", filename: "scam.png", size: 1024, url: "https://cdn/scam.png") }
+
+    before do
+      allow(bot).to receive(:channel).and_return(double("ch", delete_message: nil))
+      allow(Bot::Discord::Components).to receive(:send_to)
+      allow(Moderation::AttachmentDownload).to receive(:call).and_return("IMG")
+    end
+
+    it "fingerprints attachments and triggers on the threshold" do
+      expect(Bot::Discord::Components).to receive(:send_to)
+
+      simulate_message(channel_id: 1, message_id: 1, content: "", attachments: [attachment])
+      simulate_message(channel_id: 2, message_id: 2, content: "", attachments: [attachment])
+      simulate_message(channel_id: 3, message_id: 3, content: "", attachments: [attachment])
+    end
+  end
+
+  context "when the same bytes are posted under randomized filenames" do
+    let(:attachment1) { double("attachment1", filename: "abc123.png", size: 1024, url: "https://cdn/file.png") }
+    let(:attachment2) { double("attachment2", filename: "xyz789.png", size: 1024, url: "https://cdn/file.png") }
+    let(:attachment3) { double("attachment3", filename: "qwe456.png", size: 1024, url: "https://cdn/file.png") }
+
+    before do
+      allow(bot).to receive(:channel).and_return(double("ch", delete_message: nil))
+      allow(Bot::Discord::Components).to receive(:send_to)
+      allow(Moderation::AttachmentDownload).to receive(:call).and_return("same bytes")
+    end
+
+    it "produces the same SHA256 fingerprint and triggers on the threshold" do
+      expect(Bot::Discord::Components).to receive(:send_to)
+
+      simulate_message(channel_id: 1, message_id: 1, content: "", attachments: [attachment1])
+      simulate_message(channel_id: 2, message_id: 2, content: "", attachments: [attachment2])
+      simulate_message(channel_id: 3, message_id: 3, content: "", attachments: [attachment3])
+    end
+  end
+
+  context "when a message has more than MAX_HASHED_ATTACHMENTS attachments" do
+    let(:attachments) do
+      Array.new(4) { |i| double("attachment#{i}", filename: "f#{i}.png", size: 1024, url: "https://cdn/#{i}.png") }
+    end
+
+    before do
+      allow(bot).to receive(:channel).and_return(double("ch", delete_message: nil))
+      allow(Bot::Discord::Components).to receive(:send_to)
+      allow(Moderation::AttachmentDownload).to receive(:call).and_return("bytes")
+    end
+
+    it "downloads only the first three and filename-fingerprints the rest" do
+      expect(Moderation::AttachmentDownload).to receive(:call).exactly(3).times
+
+      simulate_message(channel_id: 1, message_id: 1, content: "", attachments:)
+    end
+  end
+
+  context "when the attachment download fails" do
+    let(:attachment) { double("attachment", filename: "scam.png", size: 1024, url: "https://cdn/scam.png") }
+
+    before do
+      allow(bot).to receive(:channel).and_return(double("ch", delete_message: nil))
+      allow(Bot::Discord::Components).to receive(:send_to)
+      allow(Moderation::AttachmentDownload).to receive(:call).and_raise(Moderation::AttachmentDownload::Error)
+    end
+
+    it "falls back to filename+size fingerprint and still triggers on the threshold" do
+      expect(Bot::Discord::Components).to receive(:send_to)
+
+      simulate_message(channel_id: 1, message_id: 1, content: "", attachments: [attachment])
+      simulate_message(channel_id: 2, message_id: 2, content: "", attachments: [attachment])
+      simulate_message(channel_id: 3, message_id: 3, content: "", attachments: [attachment])
+    end
+  end
+
+  context "when the attachment exceeds MAX_FINGERPRINT_BYTES" do
+    let(:oversize) { 11 * 1024 * 1024 }
+    let(:attachment) { double("attachment", filename: "big.png", size: oversize, url: "https://cdn/big.png") }
 
     before do
       allow(bot).to receive(:channel).and_return(double("ch", delete_message: nil))
       allow(Bot::Discord::Components).to receive(:send_to)
     end
 
-    it "fingerprints attachments and triggers on the threshold" do
+    it "does not download and falls back to filename+size fingerprint, still triggering" do
+      expect(Moderation::AttachmentDownload).not_to receive(:call)
       expect(Bot::Discord::Components).to receive(:send_to)
 
       simulate_message(channel_id: 1, message_id: 1, content: "", attachments: [attachment])


### PR DESCRIPTION
## What

Server Shield V2 #6. The spam attachment fingerprint was `"a:#{filename}:#{size}"` — a scammer defeats it by randomizing the filename while re-posting the identical file across channels, so each copy gets a distinct key and never trips the channel threshold. Key on a **SHA256 of the attachment bytes** instead, so renamed-but-identical files collapse to one fingerprint.

## The catch, and how it's bounded

The spam path (`SpamGuard#fingerprints`) was **synchronous and metadata-only** — it never fetched bytes. A content hash needs the bytes, so this adds a download to that path. Bounded:

- **Size-gated** — only attachments `≤ MAX_FINGERPRINT_BYTES` (10 MB) are downloaded; larger ones fall back to filename+size.
- **Count-capped** — only the first `MAX_HASHED_ATTACHMENTS` (3) per message are hashed; the rest keep the filename+size key (preserves today's coverage without unbounded downloads).
- **Fallback** — any download failure *or* oversize returns the old filename+size key, so detection never regresses.
- Downloads run on the per-message discordrb handler thread (each event is threaded), so a slow CDN degrades that one message, never the bot. Known worst case: 3 sequential 30 s read-timeouts = up to ~90 s on that one thread before all three fall back — accepted given the count cap and per-thread isolation.

**SHA256, not phash:** exact byte-match is the right "same file spammed" semantic, works for every file type, needs no sidecar round-trip, and doesn't duplicate the image-scanning phash pipeline (which already catches repeated *images* fuzzily, regardless of filename). This chunk's marginal value is non-image files + catching image rename-spam faster than the async phash verdict. It's defeated by re-encoding (that changes the bytes) — it kills the common *lazy rename*.

## Structure

Rule-of-two: the HTTP byte fetch (was `ImageScanning::ImageDownload`) now has a second consumer, so it's extracted to **`Moderation::AttachmentDownload`** at the plugin's domain level — the two sub-plugins depend on a shared primitive, not on each other. `ImageScanning::ImageDownload` becomes a thin delegator that re-raises `AttachmentDownload::Error` as `Ocr::Error`, so `ScanProcessor`'s rescue contract is untouched (its spec is byte-for-byte unchanged and green).

## Security / privacy

- **No SSRF concern** — `attachment.url` is a Discord-CDN URL from the message's *own* attachments (unlike the user-typed content-links chunk), so no host allowlist is needed.
- **No new stored data** — the SHA256 lives only in the in-memory `SpamTracker` bucket and is evicted within `window_seconds` (≤60 s), the same posture as the existing SimHash content fingerprint. Covered by the existing "in memory only, content discarded" policy clause. No policy edit, no `Ops::Users::Destroy` change, no purge change, no migration, no new dependency.

## Tests
`AttachmentDownload` (success / 404→Error / SocketError→Error). `SpamGuard`: same-file trigger, **randomized-filename same-bytes trigger** (the point of the chunk — three distinct filenames would never trip the old keying), download-failure fallback, oversize fallback (asserts no download), and the count-cap boundary (4 attachments → exactly 3 downloads). Full suite green (1780), standardrb / active_record_doctor / undercover clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)