### PR TITLE
Persist moderation verdicts

### DIFF
--- a/.active_record_doctor.rb
+++ b/.active_record_doctor.rb
@@ -34,7 +34,9 @@ ActiveRecordDoctor.configure do
       "server_channels.parent_id",
       "server_roles.discord_id",
       "channel_overwrites.target_id",
-      "moderation_settings.staff_role_id"
+      "moderation_settings.staff_role_id",
+      "moderation_verdicts.log_channel_id",
+      "moderation_verdicts.log_message_id"
     ]
 
   # These are NOT NULL with a DB default, so they're never nil — presence is wrong

--- a/app/models/moderation/verdict_record.rb
+++ b/app/models/moderation/verdict_record.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Moderation
+  class VerdictRecord < ApplicationRecord
+    self.table_name = "moderation_verdicts"
+
+    belongs_to :server_configuration
+
+    validates :discord_user_id, presence: true
+    validates :action, presence: true
+    validates :punishment, presence: true
+    string_enum :action, %w[flag_for_review remove]
+    string_enum :punishment, %w[none timeout kick ban], prefix: true
+
+    scope :for_user, ->(discord_user_id) { where(discord_user_id:) }
+    scope :recent, -> { order(created_at: :desc) }
+  end
+end

--- a/app/models/server_configuration.rb
+++ b/app/models/server_configuration.rb
@@ -12,6 +12,7 @@ class ServerConfiguration < ApplicationRecord
   has_one :image_scanning_settings, class_name: "Moderation::ImageScanning::Settings", dependent: :delete
 
   has_many :phash_confirmations, class_name: "Moderation::PhashConfirmation", dependent: :delete_all
+  has_many :verdict_records, class_name: "Moderation::VerdictRecord", dependent: :delete_all
 
   has_many :notifications, dependent: :delete_all
   has_many :server_channels, dependent: :destroy

--- a/app/operations/moderation/verdicts/create.rb
+++ b/app/operations/moderation/verdicts/create.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Ops
+  module Moderation
+    module Verdicts
+      class Create < ApplicationOperation
+        receives :server_configuration, :discord_user_id, :action, :punishment, :phash
+        receives :log_channel_id, default: nil
+        receives :log_message_id, default: nil
+
+        def call
+          record = ::Moderation::VerdictRecord.create!(
+            server_configuration:,
+            discord_user_id:,
+            action:,
+            punishment:,
+            phash:,
+            log_channel_id:,
+            log_message_id:
+          )
+          ok(record)
+        end
+      end
+    end
+  end
+end

--- a/app/operations/moderation/verdicts/prune.rb
+++ b/app/operations/moderation/verdicts/prune.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Ops
+  module Moderation
+    module Verdicts
+      class Prune < ApplicationOperation
+        def call
+          ::Moderation::VerdictRecord.where(created_at: ...30.days.ago).delete_all
+          ok
+        end
+      end
+    end
+  end
+end

--- a/app/operations/users/destroy.rb
+++ b/app/operations/users/destroy.rb
@@ -7,6 +7,7 @@ module Ops
 
       def call
         ::Reminders::Reminder.for_user(user.discord_id).delete_all
+        ::Moderation::VerdictRecord.for_user(user.discord_id).delete_all
         user.destroy!
         ok(user)
       end

--- a/app/plugins/moderation/image_scanning/verdict_executor.rb
+++ b/app/plugins/moderation/image_scanning/verdict_executor.rb
@@ -20,11 +20,13 @@ module Moderation
       def call
         case verdict.action
         when :flag_for_review
-          flag(removed: false)
+          message = flag(removed: false)
+          persist(action: "flag_for_review", punishment: "none", message:)
         when :remove
           delete_message if context.settings.action_delete?
-          punish
-          flag(removed: true)
+          applied = punish
+          message = flag(removed: true)
+          persist(action: "remove", punishment: applied, message:)
         end
       end
 
@@ -42,7 +44,7 @@ module Moderation
         settings = context.settings
         escalate = hash_state == :own_confirmed && settings.confirmed_punishment != "none"
         punishment = escalate ? settings.confirmed_punishment : settings.punishment
-        return if punishment == "none"
+        return "none" if punishment == "none"
 
         Punisher.call(
           member: context.member,
@@ -51,6 +53,7 @@ module Moderation
           timeout_seconds: escalate ? settings.confirmed_timeout_seconds : settings.timeout_seconds,
           reason: I18n.t("moderation.image_scanning.punishment.reason")
         )
+        punishment
       end
 
       def flag(removed:)
@@ -75,6 +78,18 @@ module Moderation
           image:,
           components: buttons,
           allowed_mentions: {parse: [], roles: StaffPing.allowed_roles(staff_role_id, ping:)}
+        )
+      end
+
+      def persist(action:, punishment:, message:)
+        Ops::Moderation::Verdicts::Create.call(
+          server_configuration: context.settings.server_configuration,
+          discord_user_id: context.member.id,
+          action:,
+          punishment:,
+          phash:,
+          log_channel_id: message&.channel&.id,
+          log_message_id: message&.id
         )
       end
 

--- a/app/views/privacy_policy.rb
+++ b/app/views/privacy_policy.rb
@@ -45,6 +45,7 @@ class Views::PrivacyPolicy < Views::Base
       t(".data_guild"),
       t(".data_account"),
       t(".data_reminders"),
+      t(".data_moderation"),
       t(".data_notifications"),
       t(".data_operational")
     )
@@ -80,6 +81,7 @@ class Views::PrivacyPolicy < Views::Base
       t(".retention_guild"),
       t(".retention_reminders"),
       t(".retention_phash"),
+      t(".retention_verdicts"),
       t(".retention_account"),
       t(".retention_infra")
     )

--- a/config/locales/legal.en.yml
+++ b/config/locales/legal.en.yml
@@ -58,6 +58,11 @@ en:
         configure - including any custom scam-keyword list.'
       data_h: What we store and why
       data_lead: 'We store only what the enabled features need:'
+      data_moderation: 'Moderation action records: when automated moderation acts
+        on a message, we store which action was taken, when, the affected user''s
+        Discord ID, the scam-image fingerprint, and the channel and message IDs of
+        the moderator-log entry (so the dashboard can link to it) - never any message
+        content or extracted text.'
       data_notifications: 'Dashboard notifications: short activity entries (an event
         type plus details such as a plugin or channel name) so admins can see recent
         changes.'
@@ -68,8 +73,9 @@ en:
       data_reminders: 'Reminders: the reminder text you write, your Discord ID, the
         target channel and server, whether to deliver by DM, and the due time - kept
         until delivered or deleted by you with /unremind.'
-      deletion_account: Delete your dashboard account and your reminders with the
-        "Delete my account" button on your account page.
+      deletion_account: Delete your dashboard account - along with your reminders
+        and any moderation action records linked to your Discord ID - with the "Delete
+        my account" button on your account page.
       deletion_contact: Or contact us (see below) and we'll take care of it.
       deletion_guild: Remove the bot from a server to delete that server's configuration.
       deletion_h: Deleting your data
@@ -122,6 +128,10 @@ en:
         the bot.'
       retention_reminders: 'Reminders: deleted once delivered, or earlier if you delete
         them.'
+      retention_verdicts: 'Moderation action records (which action, when, the affected
+        user''s Discord ID, and the channel and message IDs of the moderator-log entry
+        - never any message content): pruned 30 days after the action, and deleted
+        when the bot is removed from the server.'
       rights_h: Your rights
       rights_p: Under the GDPR you have the right to access, correct, delete, restrict
         or object to our use of your personal data, and the right to data portability.
@@ -139,7 +149,7 @@ en:
         and our hosting provider Hetzner (Helsinki, Finland, within the EEA), where
         the Service and its database run. We may disclose data where required by law.'
       title: Privacy policy
-      updated: 'Last updated: July 5th, 2026'
+      updated: 'Last updated: July 12th, 2026'
     terms_of_service:
       admin_h: Your responsibilities as a server admin
       admin_p: If you add shrkbot to a server or configure it, you're responsible

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -19,3 +19,6 @@ production:
   moderation_phash_prune:
     command: "Ops::Moderation::Phashes::Prune.call"
     schedule: every day at 5am
+  moderation_verdict_prune:
+    command: "Ops::Moderation::Verdicts::Prune.call"
+    schedule: every day at 5:30am

--- a/db/migrate/20260712173436_create_moderation_verdicts.rb
+++ b/db/migrate/20260712173436_create_moderation_verdicts.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class CreateModerationVerdicts < ActiveRecord::Migration[8.1]
+  def change
+    create_table :moderation_verdicts, id: false do |t|
+      t.string :id, null: false, primary_key: true
+      t.references :server_configuration, null: false, foreign_key: true, type: :string, index: false
+      t.bigint :discord_user_id, null: false
+      t.string :action, null: false
+      t.string :punishment, null: false, default: "none"
+      t.string :phash
+      t.bigint :log_channel_id
+      t.bigint :log_message_id
+      t.datetime :reversed_at
+      t.timestamps
+    end
+
+    reversible do |dir|
+      dir.up do
+        execute "ALTER TABLE moderation_verdicts ALTER COLUMN id SET DEFAULT ('mvr_' || gen_random_uuid())"
+      end
+    end
+
+    add_index :moderation_verdicts, [:server_configuration_id, :created_at]
+    add_index :moderation_verdicts, :discord_user_id
+
+    add_check_constraint :moderation_verdicts, "action IN ('flag_for_review', 'remove')", name: "moderation_verdicts_action_check"
+    add_check_constraint :moderation_verdicts, "punishment IN ('none', 'timeout', 'kick', 'ban')", name: "moderation_verdicts_punishment_check"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_12_115205) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_12_173436) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -86,6 +86,23 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_12_115205) do
     t.datetime "updated_at", null: false
     t.index ["server_configuration_id"], name: "index_moderation_settings_on_server_configuration_id", unique: true
     t.check_constraint "new_account_age_days >= 1 AND new_account_age_days <= 365", name: "moderation_settings_new_account_age_days_check"
+  end
+
+  create_table "moderation_verdicts", id: :string, default: -> { "('mvr_'::text || gen_random_uuid())" }, force: :cascade do |t|
+    t.string "action", null: false
+    t.datetime "created_at", null: false
+    t.bigint "discord_user_id", null: false
+    t.bigint "log_channel_id"
+    t.bigint "log_message_id"
+    t.string "phash"
+    t.string "punishment", default: "none", null: false
+    t.datetime "reversed_at"
+    t.string "server_configuration_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["discord_user_id"], name: "index_moderation_verdicts_on_discord_user_id"
+    t.index ["server_configuration_id", "created_at"], name: "idx_on_server_configuration_id_created_at_47198f0f26"
+    t.check_constraint "action::text = ANY (ARRAY['flag_for_review'::character varying, 'remove'::character varying]::text[])", name: "moderation_verdicts_action_check"
+    t.check_constraint "punishment::text = ANY (ARRAY['none'::character varying, 'timeout'::character varying, 'kick'::character varying, 'ban'::character varying]::text[])", name: "moderation_verdicts_punishment_check"
   end
 
   create_table "notifications", id: :string, default: -> { "('ntf_'::text || gen_random_uuid())" }, force: :cascade do |t|
@@ -375,6 +392,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_12_115205) do
   add_foreign_key "image_scanning_settings", "server_configurations"
   add_foreign_key "logging_settings", "server_configurations"
   add_foreign_key "moderation_settings", "server_configurations"
+  add_foreign_key "moderation_verdicts", "server_configurations"
   add_foreign_key "notifications", "server_configurations"
   add_foreign_key "phash_confirmations", "phashes"
   add_foreign_key "phash_confirmations", "server_configurations"

--- a/spec/bot/activity_log_spec.rb
+++ b/spec/bot/activity_log_spec.rb
@@ -109,6 +109,12 @@ RSpec.describe Bot::ActivityLog do
       end
     end
 
+    it "returns the posted message" do
+      message = double("message")
+      allow(channel).to receive(:send_message).and_return(message)
+      expect(post).to eq(message)
+    end
+
     context "when no logging channel is set" do
       before do
         server_config.logging_setting.update!(channel_id: nil)

--- a/spec/factories/verdict_records.rb
+++ b/spec/factories/verdict_records.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :verdict_record, class: "Moderation::VerdictRecord" do
+    association :server_configuration
+    discord_user_id { 111_222_333_444_555_666 }
+    action { "flag_for_review" }
+    punishment { "none" }
+  end
+end

--- a/spec/models/moderation/verdict_record_spec.rb
+++ b/spec/models/moderation/verdict_record_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Moderation::VerdictRecord do
+  subject(:record) { build(:verdict_record) }
+
+  it "uses the correct table name" do
+    expect(described_class.table_name).to eq("moderation_verdicts")
+  end
+
+  it "persists via the factory" do
+    expect { create(:verdict_record) }.to change(described_class, :count).by(1)
+  end
+
+  it "belongs to a server configuration" do
+    expect(record.server_configuration).to be_a(ServerConfiguration)
+  end
+
+  it "requires a discord_user_id" do
+    record.discord_user_id = nil
+    expect(record).not_to be_valid
+    expect(record.errors[:discord_user_id]).to be_present
+  end
+
+  it "requires an action" do
+    record.action = nil
+    expect(record).not_to be_valid
+    expect(record.errors[:action]).to be_present
+  end
+
+  it "requires a punishment" do
+    record.punishment = nil
+    expect(record).not_to be_valid
+    expect(record.errors[:punishment]).to be_present
+  end
+
+  it "rejects an action outside the allowed set" do
+    record.action = "explode"
+    expect(record).not_to be_valid
+    expect(record.errors[:action]).to be_present
+  end
+
+  it "accepts each allowed action" do
+    described_class.actions.keys.each do |action|
+      record.action = action
+      expect(record).to be_valid
+    end
+  end
+
+  it "rejects a punishment outside the allowed set" do
+    record.punishment = "exile"
+    expect(record).not_to be_valid
+    expect(record.errors[:punishment]).to be_present
+  end
+
+  it "accepts each allowed punishment" do
+    described_class.punishments.keys.each do |punishment|
+      record.punishment = punishment
+      expect(record).to be_valid
+    end
+  end
+
+  describe ".for_user" do
+    subject(:results) { described_class.for_user(discord_user_id) }
+
+    let(:discord_user_id) { 999_888_777 }
+    let!(:matching) { create(:verdict_record, discord_user_id:) }
+    let!(:other) { create(:verdict_record, discord_user_id: 111_222_333) }
+
+    it "returns records for the given discord_user_id" do
+      expect(results).to contain_exactly(matching)
+    end
+  end
+
+  describe ".recent" do
+    subject(:results) { described_class.recent }
+
+    let!(:older) { create(:verdict_record, created_at: 2.days.ago) }
+    let!(:newer) { create(:verdict_record, created_at: 1.day.ago) }
+
+    it "orders by created_at descending" do
+      expect(results.first).to eq(newer)
+      expect(results.last).to eq(older)
+    end
+  end
+end

--- a/spec/models/server_configuration_spec.rb
+++ b/spec/models/server_configuration_spec.rb
@@ -79,6 +79,16 @@ RSpec.describe ServerConfiguration do
     end
   end
 
+  describe "guild purge cascade" do
+    let(:server) { create(:server_configuration, discord_id: 700_000_001) }
+    let!(:verdict) { create(:verdict_record, server_configuration: server) }
+
+    it "deletes verdict_records when the server_configuration is destroyed" do
+      server.destroy!
+      expect(Moderation::VerdictRecord.exists?(verdict.id)).to be(false)
+    end
+  end
+
   describe "#icon_url" do
     subject(:icon_url) { server.icon_url }
 

--- a/spec/operations/moderation/verdicts/create_spec.rb
+++ b/spec/operations/moderation/verdicts/create_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Ops::Moderation::Verdicts::Create do
+  subject(:result) do
+    described_class.call(
+      server_configuration:,
+      discord_user_id: 111_222_333_444,
+      action: "flag_for_review",
+      punishment: "none",
+      phash: "abc123",
+      log_channel_id: 555,
+      log_message_id: 666
+    )
+  end
+
+  let(:server_configuration) { create(:server_configuration) }
+
+  it "creates a verdict record" do
+    expect { result }.to change(Moderation::VerdictRecord, :count).by(1)
+  end
+
+  it "returns success" do
+    expect(result).to be_success
+  end
+
+  it "returns the created record as the value" do
+    expect(result.value).to be_a(Moderation::VerdictRecord)
+  end
+
+  it "sets the correct attributes on the record" do
+    record = result.value
+    expect(record.server_configuration).to eq(server_configuration)
+    expect(record.discord_user_id).to eq(111_222_333_444)
+    expect(record.action).to eq("flag_for_review")
+    expect(record.punishment).to eq("none")
+    expect(record.phash).to eq("abc123")
+    expect(record.log_channel_id).to eq(555)
+    expect(record.log_message_id).to eq(666)
+  end
+
+  context "when log ids are omitted" do
+    subject(:result) do
+      described_class.call(
+        server_configuration:,
+        discord_user_id: 111_222_333_444,
+        action: "flag_for_review",
+        punishment: "none",
+        phash: "abc123"
+      )
+    end
+
+    it "creates a record with nil log ids" do
+      record = result.value
+      expect(record.log_channel_id).to be_nil
+      expect(record.log_message_id).to be_nil
+    end
+  end
+end

--- a/spec/operations/moderation/verdicts/prune_spec.rb
+++ b/spec/operations/moderation/verdicts/prune_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Ops::Moderation::Verdicts::Prune do
+  subject(:result) { described_class.call }
+
+  let!(:old_record) { create(:verdict_record, created_at: 31.days.ago) }
+  let!(:very_old_record) { create(:verdict_record, created_at: 60.days.ago) }
+  let!(:fresh_record) { create(:verdict_record, created_at: 1.day.ago) }
+  let!(:boundary_record) { create(:verdict_record, created_at: 29.days.ago) }
+
+  it "deletes records older than 30 days" do
+    result
+    expect(Moderation::VerdictRecord.exists?(old_record.id)).to be(false)
+    expect(Moderation::VerdictRecord.exists?(very_old_record.id)).to be(false)
+  end
+
+  it "keeps records newer than 30 days" do
+    result
+    expect(Moderation::VerdictRecord.exists?(fresh_record.id)).to be(true)
+    expect(Moderation::VerdictRecord.exists?(boundary_record.id)).to be(true)
+  end
+
+  it "succeeds" do
+    expect(result).to be_success
+  end
+end

--- a/spec/operations/users/destroy_spec.rb
+++ b/spec/operations/users/destroy_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe Ops::Users::Destroy do
   let(:user) { create(:user) }
   let!(:reminder) { create(:reminder, user_id: user.discord_id) }
   let!(:other_reminder) { create(:reminder) }
+  let!(:user_verdict) { create(:verdict_record, discord_user_id: user.discord_id) }
+  let!(:other_verdict) { create(:verdict_record, discord_user_id: 999_888_777_666) }
 
   it "destroys the user" do
     result
@@ -22,6 +24,16 @@ RSpec.describe Ops::Users::Destroy do
   it "leaves other users' reminders untouched" do
     result
     expect(Reminders::Reminder.exists?(other_reminder.id)).to be(true)
+  end
+
+  it "deletes verdict records whose discord_user_id equals the user's discord_id" do
+    result
+    expect(Moderation::VerdictRecord.exists?(user_verdict.id)).to be(false)
+  end
+
+  it "leaves other users' verdict records untouched" do
+    result
+    expect(Moderation::VerdictRecord.exists?(other_verdict.id)).to be(true)
   end
 
   it "returns success" do

--- a/spec/plugins/moderation/image_scanning/verdict_executor_spec.rb
+++ b/spec/plugins/moderation/image_scanning/verdict_executor_spec.rb
@@ -70,15 +70,17 @@ RSpec.describe Moderation::ImageScanning::VerdictExecutor do
   before do
     allow(Bot::ActivityLog).to receive(:post)
     allow(Moderation::Punisher).to receive(:call)
+    allow(Ops::Moderation::Verdicts::Create).to receive(:call)
   end
 
   context "when the action is :allow" do
     let(:action) { :allow }
 
-    it "does not log, delete, or punish" do
+    it "does not log, delete, punish, or persist a verdict" do
       expect(Bot::ActivityLog).not_to receive(:post)
       expect(bot).not_to receive(:channel)
       expect(Moderation::Punisher).not_to receive(:call)
+      expect(Ops::Moderation::Verdicts::Create).not_to receive(:call)
       execute
     end
   end
@@ -377,6 +379,68 @@ RSpec.describe Moderation::ImageScanning::VerdictExecutor do
 
       expect(Bot::ActivityLog).to have_received(:post) do |_config, kwargs|
         expect(kwargs[:body]).not_to start_with("<@&")
+      end
+    end
+  end
+
+  describe "verdict persistence" do
+    let(:log_message) { double("msg", id: 123, channel: double(id: 456)) }
+
+    before do
+      allow(Bot::ActivityLog).to receive(:post).and_return(log_message)
+    end
+
+    context "when the action is :flag_for_review" do
+      let(:action) { :flag_for_review }
+
+      it "persists a verdict record with action flag_for_review and punishment none" do
+        execute
+
+        expect(Ops::Moderation::Verdicts::Create).to have_received(:call).with(
+          server_configuration:,
+          discord_user_id: member_id,
+          action: "flag_for_review",
+          punishment: "none",
+          phash:,
+          log_channel_id: 456,
+          log_message_id: 123
+        )
+      end
+    end
+
+    context "when the action is :remove with punishment kick" do
+      let(:action) { :remove }
+      let(:punishment) { "kick" }
+      let(:settings_action) { "none" }
+
+      it "persists a verdict record with action remove and the applied punishment" do
+        execute
+
+        expect(Ops::Moderation::Verdicts::Create).to have_received(:call).with(
+          server_configuration:,
+          discord_user_id: member_id,
+          action: "remove",
+          punishment: "kick",
+          phash:,
+          log_channel_id: 456,
+          log_message_id: 123
+        )
+      end
+    end
+
+    context "when no log channel is configured" do
+      let(:action) { :flag_for_review }
+
+      before do
+        allow(Bot::ActivityLog).to receive(:post).and_return(nil)
+      end
+
+      it "persists with nil log ids" do
+        execute
+
+        expect(Ops::Moderation::Verdicts::Create).to have_received(:call).with(
+          hash_including(log_channel_id: nil, log_message_id: nil)
+        )
       end
     end
   end


### PR DESCRIPTION
## What

Server Shield V2 #4, **part 1 of 3**. Today moderation verdicts are ephemeral — `VerdictExecutor` deletes the message, punishes, posts a mod-log embed, and forgets (no DB write, no captured message id). This adds the first persisted moderation-action store so PR2 (dashboard) and PR3 (undo) have something to read and act on. **No web UI, no undo in this PR.**

## Data — metadata only

New `moderation_verdicts` table (`Moderation::VerdictRecord`): `action` (flag_for_review/remove), `punishment` (none/timeout/kick/ban — what was applied), `phash` (the scam-image fingerprint hex, same data class as the existing phash store), `discord_user_id` (the acted-on user), `log_channel_id`+`log_message_id` (mod-log jump link), `reversed_at` (undo marker, unused until PR3). **No message content, no OCR text, no image bytes, no jump URL string.**

The privacy policy already anticipated this exact record — `messages_p_3`: *"A short record that an action occurred (without the message content) may also appear in the dashboard."* So this implements a pre-disclosed carve-out rather than breaking the zero-retention posture.

## Write path

`Bot::ActivityLog.post` already returns the posted discordrb `Message` (its last expression) — `VerdictExecutor` now captures it and persists a record via `Ops::Moderation::Verdicts::Create`, with `punish` returning the applied punishment. No `ActivityLog` code change (only a spec locking that return contract).

## GDPR (load-bearing — first personal-data moderation store)

- **Guild purge:** `has_many :verdict_records, dependent: :delete_all` on `ServerConfiguration` — the cascade *is* the purge (mirrors `phash_confirmations`).
- **Per-user erasure:** `Ops::Users::Destroy` deletes `VerdictRecord.for_user(discord_id)` — account deletion wipes the user's records across guilds.
- **Retention:** `Ops::Moderation::Verdicts::Prune` deletes records >30 days old, scheduled daily (offset from the phash prune).
- **Policy:** `updated` date bumped; new `data_moderation` (what's stored) + `retention_verdicts` (lifespan) entries; `deletion_account` now names moderation records. *(Policy copy remains subject to your legal review, per the standing note.)*

## Convention review

7 findings — accepted 6: DB check constraints on `action`/`punishment` (house convention, every prior enum column has them), the four policy-completeness items above, and a spec asserting no persist on `:allow`. **Rejected 1:** an exact-30-day-boundary prune test — `...30.days.ago` is recomputed at prune time, so a record created at the boundary is already past it microseconds later and would be pruned; asserting "kept" is racy. The 29d/31d margin tests bound it correctly and the microsecond edge is immaterial for a daily approximate prune.

## Notes

- Fixed a real bug found by gates: the `"none"` enum value collides with ActiveRecord's `.none` → `prefix: true` on the punishment enum (stored values unchanged).
- Made the migration reversible (`reversible` around the `mvr_` id-default `execute`) so it round-trips — the older phash migration has the same latent irreversibility but I left it untouched.
- Two gate false-positives fixed at config level (not code): `log_channel_id`/`log_message_id` added to the active_record_doctor unindexed-FK ignore list (Discord snowflakes, not FKs, never queried), and `i18n-tasks normalize`.

Gates green: rspec 1807, standardrb, active_record_doctor, undercover, i18n missing + normalized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)