### PR TITLE
Add an Undo punishment button to removal mod-logs

### DIFF
--- a/app/plugins/moderation/events/undo_punishment.rb
+++ b/app/plugins/moderation/events/undo_punishment.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Moderation
+  class UndoPunishment < Bot::BaseEvent
+    include Interaction::ComponentActions
+
+    on :button, custom_id: /\Amod:undo_punishment:/
+
+    def handle
+      return reject unless authorized?
+
+      args = Interaction::CustomId.undo_punishment_args(event.custom_id)
+      result = Unpunisher.call(server: event.server, user_id: args[:user_id], punishment: args[:punishment])
+      apologize(args[:user_id]) if result == :reversed
+
+      event.respond(content: feedback(result, args), ephemeral: true)
+    end
+
+    private
+
+    def apologize(user_id)
+      event.bot.user(user_id)&.pm(
+        I18n.t("moderation.image_scanning.undo_punishment.apology", server: event.server.name)
+      )
+    rescue => e
+      Rails.logger.warn("[Moderation::UndoPunishment] apology DM failed: #{e.class}: #{e.message}")
+    end
+
+    def feedback(result, args)
+      case result
+      when :reversed
+        I18n.t("moderation.image_scanning.undo_punishment.reversed_#{args[:punishment]}", user: "<@#{args[:user_id]}>")
+      when :not_in_server
+        I18n.t("moderation.image_scanning.undo_punishment.not_in_server")
+      else
+        I18n.t("moderation.image_scanning.undo_punishment.failed")
+      end
+    end
+  end
+end

--- a/app/plugins/moderation/events/undo_punishment.rb
+++ b/app/plugins/moderation/events/undo_punishment.rb
@@ -9,11 +9,12 @@ module Moderation
     def handle
       return reject unless authorized?
 
+      event.defer(ephemeral: true)
       args = Interaction::CustomId.undo_punishment_args(event.custom_id)
       result = Unpunisher.call(server: event.server, user_id: args[:user_id], punishment: args[:punishment])
       apologize(args[:user_id]) if result == :reversed
 
-      event.respond(content: feedback(result, args), ephemeral: true)
+      event.edit_response(content: feedback(result, args))
     end
 
     private

--- a/app/plugins/moderation/image_scanning/verdict_executor.rb
+++ b/app/plugins/moderation/image_scanning/verdict_executor.rb
@@ -20,11 +20,10 @@ module Moderation
       def call
         case verdict.action
         when :flag_for_review
-          flag(removed: false)
+          flag(removed: false, punishment: "none")
         when :remove
           delete_message if context.settings.action_delete?
-          punish
-          flag(removed: true)
+          flag(removed: true, punishment: punish)
         end
       end
 
@@ -42,7 +41,7 @@ module Moderation
         settings = context.settings
         escalate = hash_state == :own_confirmed && settings.confirmed_punishment != "none"
         punishment = escalate ? settings.confirmed_punishment : settings.punishment
-        return if punishment == "none"
+        return "none" if punishment == "none"
 
         Punisher.call(
           member: context.member,
@@ -51,9 +50,10 @@ module Moderation
           timeout_seconds: escalate ? settings.confirmed_timeout_seconds : settings.timeout_seconds,
           reason: I18n.t("moderation.image_scanning.punishment.reason")
         )
+        punishment
       end
 
-      def flag(removed:)
+      def flag(removed:, punishment:)
         config = context.settings.server_configuration
         settings = config.moderation_settings
         staff_role_id = settings.staff_role_id
@@ -70,15 +70,15 @@ module Moderation
             author: "<@#{context.member.id}>",
             channel: "<##{context.channel_id}>",
             jump_url:
-          ) + "\n" + risk_line(state) + "\n" + reason_lines,
+          ) + "\n" + risk_line(state) + "\n" + reason_lines + kick_note(punishment),
           meta: I18n.t("moderation.image_scanning.flag.meta.#{state}"),
           image:,
-          components: message_components,
+          components: message_components(punishment),
           allowed_mentions: {parse: [], roles: StaffPing.allowed_roles(staff_role_id, ping:)}
         )
       end
 
-      def message_components
+      def message_components(punishment)
         components = []
         if (line = prior_verdict_text)
           components << Bot::Discord::Components.separator
@@ -88,9 +88,27 @@ module Moderation
           Interaction::VerdictButtons.build(
             server_configuration: context.settings.server_configuration,
             phash_hex: phash
-          )
+          ) + punishment_buttons(punishment)
         )
         components
+      end
+
+      def kick_note(punishment)
+        return "" unless punishment == "kick"
+
+        "\n" + I18n.t("moderation.image_scanning.flag.kick_note")
+      end
+
+      def punishment_buttons(punishment)
+        return [] unless %w[timeout ban].include?(punishment)
+
+        [
+          Bot::Discord::Components.button(
+            custom_id: Interaction::CustomId.undo_punishment(context.member.id, punishment),
+            label: I18n.t("moderation.image_scanning.undo_punishment.button"),
+            style: Bot::Discord::Components::BUTTON_SECONDARY
+          )
+        ]
       end
 
       def prior_verdict_text

--- a/app/plugins/moderation/image_scanning/verdict_executor.rb
+++ b/app/plugins/moderation/image_scanning/verdict_executor.rb
@@ -70,7 +70,7 @@ module Moderation
             author: "<@#{context.member.id}>",
             channel: "<##{context.channel_id}>",
             jump_url:
-          ) + "\n" + risk_line(state) + "\n" + reason_lines + kick_note(punishment),
+          ) + "\n" + risk_line(state) + "\n" + reason_lines,
           meta: I18n.t("moderation.image_scanning.flag.meta.#{state}"),
           image:,
           components: message_components(punishment),
@@ -80,9 +80,10 @@ module Moderation
 
       def message_components(punishment)
         components = []
-        if (line = prior_verdict_text)
+        notes = [prior_verdict_text, kick_note(punishment)].compact
+        if notes.any?
           components << Bot::Discord::Components.separator
-          components << Bot::Discord::Components.text(line)
+          notes.each { |note| components << Bot::Discord::Components.text(note) }
         end
         components << Bot::Discord::Components.action_row(
           Interaction::VerdictButtons.build(
@@ -94,9 +95,9 @@ module Moderation
       end
 
       def kick_note(punishment)
-        return "" unless punishment == "kick"
+        return unless punishment == "kick"
 
-        "\n" + I18n.t("moderation.image_scanning.flag.kick_note")
+        I18n.t("moderation.image_scanning.flag.kick_note")
       end
 
       def punishment_buttons(punishment)

--- a/app/plugins/moderation/interaction/custom_id.rb
+++ b/app/plugins/moderation/interaction/custom_id.rb
@@ -19,6 +19,15 @@ module Moderation
         "#{PREFIX}:undo_verdict:#{phash_hex}"
       end
 
+      def undo_punishment(user_id, punishment)
+        "#{PREFIX}:undo_punishment:#{user_id}:#{punishment}"
+      end
+
+      def undo_punishment_args(custom_id)
+        _prefix, _action, user_id, punishment = custom_id.split(":")
+        {user_id: user_id.to_i, punishment:}
+      end
+
       def parse(custom_id)
         _prefix, action, phash_hex = custom_id.split(":")
         {action: action&.to_sym, phash_hex:}

--- a/app/plugins/moderation/unpunisher.rb
+++ b/app/plugins/moderation/unpunisher.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Moderation
+  module Unpunisher
+    module_function
+
+    def call(server:, user_id:, punishment:)
+      case punishment
+      when "timeout"
+        member = server.member(user_id)
+        return :not_in_server unless member
+
+        member.communication_disabled_until = nil
+        :reversed
+      when "ban"
+        server.unban(user_id)
+        :reversed
+      else
+        :noop
+      end
+    rescue => e
+      Rails.logger.warn("[Moderation::Unpunisher] #{punishment} reversal failed: #{e.class}: #{e.message}")
+      :failed
+    end
+  end
+end

--- a/config/locales/moderation.en.yml
+++ b/config/locales/moderation.en.yml
@@ -13,6 +13,7 @@ en:
         verdict_undone: Verdict undone by %{actor}.
       flag:
         body: "%{author} posted an image in %{channel}. [Jump to message](%{jump_url})."
+        kick_note: The member was kicked; a kick can't be undone.
         meta:
           flagged: Flagged for review - no automatic action taken.
           removed: The message was deleted automatically.
@@ -49,6 +50,14 @@ en:
             removed: The message was deleted.
           title: Image reported as a scam
         none: That message has no images to report.
+      undo_punishment:
+        apology: Sorry - you were automatically moderated in %{server} by mistake,
+          and a staff member has reversed it.
+        button: Undo punishment
+        failed: I couldn't reverse that - I may be missing permissions.
+        not_in_server: That member isn't in the server, so there was nothing to clear.
+        reversed_ban: Unbanned %{user}.
+        reversed_timeout: Timeout cleared for %{user}.
     spam_protection:
       notification:
         body: "%{author} posted the same message in %{count} channels within %{window}

--- a/spec/plugins/moderation/events/undo_punishment_spec.rb
+++ b/spec/plugins/moderation/events/undo_punishment_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe Moderation::UndoPunishment do
       server:,
       user:,
       respond: nil,
+      defer: nil,
+      edit_response: nil,
       bot:
     )
   end
@@ -45,7 +47,9 @@ RSpec.describe Moderation::UndoPunishment do
       expect(event).to have_received(:respond).with(hash_including(ephemeral: true))
     end
 
-    it "does not call update_message" do
+    it "does not defer, edit, or update the message" do
+      expect(event).not_to receive(:defer)
+      expect(event).not_to receive(:edit_response)
       expect(event).not_to receive(:update_message)
       handle
     end
@@ -59,6 +63,11 @@ RSpec.describe Moderation::UndoPunishment do
         allow(Moderation::Unpunisher).to receive(:call).and_return(:reversed)
         allow(bot).to receive(:user).with(target_id).and_return(target_user)
         allow(target_user).to receive(:pm)
+      end
+
+      it "defers the interaction before the slow reversal work" do
+        handle
+        expect(event).to have_received(:defer).with(ephemeral: true)
       end
 
       it "unpunishes the target from the custom_id, not the acting moderator" do
@@ -80,16 +89,15 @@ RSpec.describe Moderation::UndoPunishment do
         )
       end
 
-      it "responds ephemerally with the reversed_timeout message naming the target" do
+      it "edits the deferred response with the reversed_timeout message naming the target" do
         handle
 
-        expect(event).to have_received(:respond).with(
-          content: I18n.t("moderation.image_scanning.undo_punishment.reversed_timeout", user: "<@#{target_id}>"),
-          ephemeral: true
+        expect(event).to have_received(:edit_response).with(
+          content: I18n.t("moderation.image_scanning.undo_punishment.reversed_timeout", user: "<@#{target_id}>")
         )
       end
 
-      it "does not call update_message" do
+      it "does not update the shared message" do
         expect(event).not_to receive(:update_message)
         handle
       end
@@ -99,7 +107,7 @@ RSpec.describe Moderation::UndoPunishment do
 
         it "swallows the failure and still confirms to the moderator" do
           expect { handle }.not_to raise_error
-          expect(event).to have_received(:respond).with(hash_including(ephemeral: true))
+          expect(event).to have_received(:edit_response)
         end
       end
 
@@ -108,7 +116,7 @@ RSpec.describe Moderation::UndoPunishment do
 
         it "skips the DM without raising and still confirms" do
           expect { handle }.not_to raise_error
-          expect(event).to have_received(:respond).with(hash_including(ephemeral: true))
+          expect(event).to have_received(:edit_response)
         end
       end
     end
@@ -116,13 +124,12 @@ RSpec.describe Moderation::UndoPunishment do
     context "when Unpunisher returns :not_in_server" do
       before { allow(Moderation::Unpunisher).to receive(:call).and_return(:not_in_server) }
 
-      it "responds ephemerally with not_in_server message and does not DM" do
+      it "edits the response with not_in_server message and does not DM" do
         expect(bot).not_to receive(:user)
         handle
 
-        expect(event).to have_received(:respond).with(
-          content: I18n.t("moderation.image_scanning.undo_punishment.not_in_server"),
-          ephemeral: true
+        expect(event).to have_received(:edit_response).with(
+          content: I18n.t("moderation.image_scanning.undo_punishment.not_in_server")
         )
       end
     end
@@ -130,13 +137,12 @@ RSpec.describe Moderation::UndoPunishment do
     context "when Unpunisher returns :failed" do
       before { allow(Moderation::Unpunisher).to receive(:call).and_return(:failed) }
 
-      it "responds ephemerally with the error message and does not DM" do
+      it "edits the response with the error message and does not DM" do
         expect(bot).not_to receive(:user)
         handle
 
-        expect(event).to have_received(:respond).with(
-          content: I18n.t("moderation.image_scanning.undo_punishment.failed"),
-          ephemeral: true
+        expect(event).to have_received(:edit_response).with(
+          content: I18n.t("moderation.image_scanning.undo_punishment.failed")
         )
       end
     end
@@ -144,13 +150,12 @@ RSpec.describe Moderation::UndoPunishment do
     context "when Unpunisher returns :noop" do
       before { allow(Moderation::Unpunisher).to receive(:call).and_return(:noop) }
 
-      it "responds ephemerally with the generic error message and does not DM" do
+      it "edits the response with the generic error message and does not DM" do
         expect(bot).not_to receive(:user)
         handle
 
-        expect(event).to have_received(:respond).with(
-          content: I18n.t("moderation.image_scanning.undo_punishment.failed"),
-          ephemeral: true
+        expect(event).to have_received(:edit_response).with(
+          content: I18n.t("moderation.image_scanning.undo_punishment.failed")
         )
       end
     end

--- a/spec/plugins/moderation/events/undo_punishment_spec.rb
+++ b/spec/plugins/moderation/events/undo_punishment_spec.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Moderation::UndoPunishment do
+  subject(:handle) { described_class.new(event).handle }
+
+  let(:guild_id) { 111 }
+  let(:staff_role_id) { 333 }
+  let(:actor_id) { 222 }
+  let(:target_id) { 999 }
+
+  let!(:config) { create(:server_configuration, discord_id: guild_id) }
+  let!(:settings) { create(:moderation_settings, server_configuration: config, staff_role_id:) }
+
+  let(:staff_role) { double("role", id: staff_role_id) }
+  let(:member) { double("member", mention: "<@#{actor_id}>", roles: [staff_role], permission?: false) }
+  let(:server) { double("server", id: guild_id, name: "Test Server") }
+  let(:user) { double("user", id: actor_id) }
+  let(:bot) { double("bot") }
+
+  let(:event) do
+    double(
+      "event",
+      custom_id: "mod:undo_punishment:#{target_id}:timeout",
+      server:,
+      user:,
+      respond: nil,
+      bot:
+    )
+  end
+
+  before do
+    allow(server).to receive(:member).with(actor_id).and_return(member)
+    allow(Moderation::Unpunisher).to receive(:call)
+  end
+
+  context "when the member lacks the staff role and Manage Messages" do
+    let(:member) { double("member", mention: "<@#{actor_id}>", roles: [], permission?: false) }
+
+    it "rejects without calling Unpunisher" do
+      handle
+
+      expect(Moderation::Unpunisher).not_to have_received(:call)
+      expect(event).to have_received(:respond).with(hash_including(ephemeral: true))
+    end
+
+    it "does not call update_message" do
+      expect(event).not_to receive(:update_message)
+      handle
+    end
+  end
+
+  context "when the member holds the staff role" do
+    context "when Unpunisher returns :reversed" do
+      let(:target_user) { double("target_user") }
+
+      before do
+        allow(Moderation::Unpunisher).to receive(:call).and_return(:reversed)
+        allow(bot).to receive(:user).with(target_id).and_return(target_user)
+        allow(target_user).to receive(:pm)
+      end
+
+      it "unpunishes the target from the custom_id, not the acting moderator" do
+        handle
+
+        expect(Moderation::Unpunisher).to have_received(:call).with(
+          server:,
+          user_id: target_id,
+          punishment: "timeout"
+        )
+      end
+
+      it "sends an apology DM to the target user" do
+        handle
+
+        expect(bot).to have_received(:user).with(target_id)
+        expect(target_user).to have_received(:pm).with(
+          I18n.t("moderation.image_scanning.undo_punishment.apology", server: "Test Server")
+        )
+      end
+
+      it "responds ephemerally with the reversed_timeout message naming the target" do
+        handle
+
+        expect(event).to have_received(:respond).with(
+          content: I18n.t("moderation.image_scanning.undo_punishment.reversed_timeout", user: "<@#{target_id}>"),
+          ephemeral: true
+        )
+      end
+
+      it "does not call update_message" do
+        expect(event).not_to receive(:update_message)
+        handle
+      end
+
+      context "when the user is unreachable and the DM raises" do
+        before { allow(target_user).to receive(:pm).and_raise(RuntimeError, "cannot send messages to this user") }
+
+        it "swallows the failure and still confirms to the moderator" do
+          expect { handle }.not_to raise_error
+          expect(event).to have_received(:respond).with(hash_including(ephemeral: true))
+        end
+      end
+
+      context "when the bot cannot resolve the user" do
+        before { allow(bot).to receive(:user).with(target_id).and_return(nil) }
+
+        it "skips the DM without raising and still confirms" do
+          expect { handle }.not_to raise_error
+          expect(event).to have_received(:respond).with(hash_including(ephemeral: true))
+        end
+      end
+    end
+
+    context "when Unpunisher returns :not_in_server" do
+      before { allow(Moderation::Unpunisher).to receive(:call).and_return(:not_in_server) }
+
+      it "responds ephemerally with not_in_server message and does not DM" do
+        expect(bot).not_to receive(:user)
+        handle
+
+        expect(event).to have_received(:respond).with(
+          content: I18n.t("moderation.image_scanning.undo_punishment.not_in_server"),
+          ephemeral: true
+        )
+      end
+    end
+
+    context "when Unpunisher returns :failed" do
+      before { allow(Moderation::Unpunisher).to receive(:call).and_return(:failed) }
+
+      it "responds ephemerally with the error message and does not DM" do
+        expect(bot).not_to receive(:user)
+        handle
+
+        expect(event).to have_received(:respond).with(
+          content: I18n.t("moderation.image_scanning.undo_punishment.failed"),
+          ephemeral: true
+        )
+      end
+    end
+
+    context "when Unpunisher returns :noop" do
+      before { allow(Moderation::Unpunisher).to receive(:call).and_return(:noop) }
+
+      it "responds ephemerally with the generic error message and does not DM" do
+        expect(bot).not_to receive(:user)
+        handle
+
+        expect(event).to have_received(:respond).with(
+          content: I18n.t("moderation.image_scanning.undo_punishment.failed"),
+          ephemeral: true
+        )
+      end
+    end
+  end
+
+  context "when the member lacks the staff role but has Manage Messages" do
+    let(:member) { double("member", mention: "<@#{actor_id}>", roles: [], permission?: true) }
+
+    before { allow(Moderation::Unpunisher).to receive(:call).and_return(:noop) }
+
+    it "is authorized and calls Unpunisher" do
+      handle
+      expect(Moderation::Unpunisher).to have_received(:call)
+    end
+  end
+end

--- a/spec/plugins/moderation/image_scanning/verdict_executor_spec.rb
+++ b/spec/plugins/moderation/image_scanning/verdict_executor_spec.rb
@@ -332,6 +332,16 @@ RSpec.describe Moderation::ImageScanning::VerdictExecutor do
           reason: I18n.t("moderation.image_scanning.punishment.reason")
         )
       end
+
+      it "carries the escalated punishment in the undo_punishment button" do
+        execute
+
+        expect(Bot::ActivityLog).to have_received(:post) do |_config, kwargs|
+          row = kwargs[:components].find { |c| c[:type] == Bot::Discord::Components::ACTION_ROW }
+          custom_ids = row[:components].map { |button| button[:custom_id] }
+          expect(custom_ids).to include("mod:undo_punishment:#{member_id}:ban")
+        end
+      end
     end
 
     context "when hash_state is :own_confirmed and confirmed_punishment is 'none'" do
@@ -374,6 +384,97 @@ RSpec.describe Moderation::ImageScanning::VerdictExecutor do
           timeout_seconds: 300,
           reason: I18n.t("moderation.image_scanning.punishment.reason")
         )
+      end
+    end
+  end
+
+  context "when the action is :remove with punishment 'timeout'" do
+    let(:punishment) { "timeout" }
+    let(:settings_action) { "none" }
+
+    it "includes an undo_punishment button for timeout in the action row" do
+      execute
+
+      expect(Bot::ActivityLog).to have_received(:post) do |_config, kwargs|
+        row = kwargs[:components].first
+        custom_ids = row[:components].map { |b| b[:custom_id] }
+        expect(custom_ids).to include("mod:undo_punishment:#{member_id}:timeout")
+      end
+    end
+
+    it "does not include a kick note in the body" do
+      execute
+
+      expect(Bot::ActivityLog).to have_received(:post) do |_config, kwargs|
+        expect(kwargs[:body]).not_to include(I18n.t("moderation.image_scanning.flag.kick_note"))
+      end
+    end
+  end
+
+  context "when the action is :remove with punishment 'ban'" do
+    let(:punishment) { "ban" }
+    let(:settings_action) { "none" }
+
+    it "includes an undo_punishment button for ban in the action row" do
+      execute
+
+      expect(Bot::ActivityLog).to have_received(:post) do |_config, kwargs|
+        row = kwargs[:components].first
+        custom_ids = row[:components].map { |b| b[:custom_id] }
+        expect(custom_ids).to include("mod:undo_punishment:#{member_id}:ban")
+      end
+    end
+  end
+
+  context "when the action is :remove with punishment 'kick'" do
+    let(:punishment) { "kick" }
+    let(:settings_action) { "none" }
+
+    it "does not include an undo_punishment button" do
+      execute
+
+      expect(Bot::ActivityLog).to have_received(:post) do |_config, kwargs|
+        row = kwargs[:components].first
+        custom_ids = row[:components].map { |b| b[:custom_id] }
+        expect(custom_ids).not_to include(a_string_starting_with("mod:undo_punishment:"))
+      end
+    end
+
+    it "includes the kick note in the body" do
+      execute
+
+      expect(Bot::ActivityLog).to have_received(:post) do |_config, kwargs|
+        expect(kwargs[:body]).to include(I18n.t("moderation.image_scanning.flag.kick_note"))
+      end
+    end
+  end
+
+  context "when the action is :flag_for_review with any punishment setting" do
+    let(:action) { :flag_for_review }
+    let(:punishment) { "timeout" }
+
+    it "does not include an undo_punishment button" do
+      execute
+
+      expect(Bot::ActivityLog).to have_received(:post) do |_config, kwargs|
+        row = kwargs[:components].first
+        custom_ids = row[:components].map { |b| b[:custom_id] }
+        expect(custom_ids).not_to include(a_string_starting_with("mod:undo_punishment:"))
+      end
+    end
+  end
+
+  context "when the action is :remove with punishment 'none'" do
+    let(:punishment) { "none" }
+    let(:settings_action) { "none" }
+
+    it "does not include an undo_punishment button" do
+      execute
+
+      expect(Bot::ActivityLog).to have_received(:post) do |_config, kwargs|
+        row = kwargs[:components].first
+        custom_ids = row[:components].map { |b| b[:custom_id] }
+        expect(custom_ids).not_to include(a_string_starting_with("mod:undo_punishment:"))
       end
     end
   end

--- a/spec/plugins/moderation/image_scanning/verdict_executor_spec.rb
+++ b/spec/plugins/moderation/image_scanning/verdict_executor_spec.rb
@@ -434,17 +434,20 @@ RSpec.describe Moderation::ImageScanning::VerdictExecutor do
       execute
 
       expect(Bot::ActivityLog).to have_received(:post) do |_config, kwargs|
-        row = kwargs[:components].first
+        row = kwargs[:components].find { |c| c[:type] == Bot::Discord::Components::ACTION_ROW }
         custom_ids = row[:components].map { |b| b[:custom_id] }
         expect(custom_ids).not_to include(a_string_starting_with("mod:undo_punishment:"))
       end
     end
 
-    it "includes the kick note in the body" do
+    it "shows the kick note as a component right above the buttons, not in the body" do
       execute
 
       expect(Bot::ActivityLog).to have_received(:post) do |_config, kwargs|
-        expect(kwargs[:body]).to include(I18n.t("moderation.image_scanning.flag.kick_note"))
+        expect(kwargs[:body]).not_to include(I18n.t("moderation.image_scanning.flag.kick_note"))
+        action_row_index = kwargs[:components].index { |c| c[:type] == Bot::Discord::Components::ACTION_ROW }
+        note = kwargs[:components][action_row_index - 1]
+        expect(note[:content]).to include(I18n.t("moderation.image_scanning.flag.kick_note"))
       end
     end
   end

--- a/spec/plugins/moderation/interaction/custom_id_spec.rb
+++ b/spec/plugins/moderation/interaction/custom_id_spec.rb
@@ -17,6 +17,15 @@ RSpec.describe Moderation::Interaction::CustomId do
     expect(described_class.undo_verdict(phash_hex)).to eq("mod:undo_verdict:0123456789abcdef")
   end
 
+  it "builds an undo_punishment id" do
+    expect(described_class.undo_punishment(222, "timeout")).to eq("mod:undo_punishment:222:timeout")
+  end
+
+  it "parses undo_punishment args into user_id integer and punishment string" do
+    expect(described_class.undo_punishment_args("mod:undo_punishment:222:timeout"))
+      .to eq(user_id: 222, punishment: "timeout")
+  end
+
   it "round-trips a confirm id" do
     expect(described_class.parse(described_class.confirm(phash_hex)))
       .to eq(action: :confirm, phash_hex:)

--- a/spec/plugins/moderation/unpunisher_spec.rb
+++ b/spec/plugins/moderation/unpunisher_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Moderation::Unpunisher do
+  let(:user_id) { 222 }
+  let(:member) { double("member") }
+  let(:server) { double("server") }
+
+  subject(:result) { described_class.call(server:, user_id:, punishment:) }
+
+  context "when punishment is 'timeout' and the member is in the server" do
+    let(:punishment) { "timeout" }
+
+    before do
+      allow(server).to receive(:member).with(user_id).and_return(member)
+      allow(member).to receive(:communication_disabled_until=)
+    end
+
+    it "clears the timeout" do
+      result
+      expect(member).to have_received(:communication_disabled_until=).with(nil)
+    end
+
+    it "returns :reversed" do
+      expect(result).to eq(:reversed)
+    end
+  end
+
+  context "when punishment is 'timeout' and the member is not in the server" do
+    let(:punishment) { "timeout" }
+
+    before { allow(server).to receive(:member).with(user_id).and_return(nil) }
+
+    it "returns :not_in_server" do
+      expect(result).to eq(:not_in_server)
+    end
+  end
+
+  context "when punishment is 'ban'" do
+    let(:punishment) { "ban" }
+
+    before { allow(server).to receive(:unban) }
+
+    it "unbans the user" do
+      result
+      expect(server).to have_received(:unban).with(user_id)
+    end
+
+    it "returns :reversed" do
+      expect(result).to eq(:reversed)
+    end
+  end
+
+  context "when punishment is 'kick'" do
+    let(:punishment) { "kick" }
+
+    it "returns :noop" do
+      expect(result).to eq(:noop)
+    end
+  end
+
+  context "when punishment is 'none'" do
+    let(:punishment) { "none" }
+
+    it "returns :noop" do
+      expect(result).to eq(:noop)
+    end
+  end
+
+  context "when the discordrb call raises" do
+    let(:punishment) { "ban" }
+
+    before do
+      allow(server).to receive(:unban).and_raise(RuntimeError, "forbidden")
+      allow(Rails.logger).to receive(:warn)
+    end
+
+    it "returns :failed" do
+      expect(result).to eq(:failed)
+    end
+
+    it "logs the failure" do
+      result
+      expect(Rails.logger).to have_received(:warn).with(
+        "[Moderation::Unpunisher] ban reversal failed: RuntimeError: forbidden"
+      )
+    end
+  end
+end


### PR DESCRIPTION
## What

Server Shield V2 #4 — **final piece** (PR-B of 2, after #157). Completes the mod-log undo model: alongside the verdict buttons, a removal that applied a **reversible punishment** (timeout/ban) now carries an **Undo punishment** button.

Clicking it (staff-gated):
- reverses the enforcement via a new `Moderation::Unpunisher` — clears the timeout (`communication_disabled_until = nil`) or lifts the ban (`server.unban`);
- sends the affected member a short **best-effort apology DM** — realistically lands for timeouts (still in the server); banned/kicked members are unreachable, so it fails silently (rescued);
- replies **ephemerally** to the moderator (Timeout cleared / Unbanned / couldn't-reach / error).

## Design

- **Stateless.** The button's `custom_id` carries `{user_id, punishment}` — no per-user record. (Consistent with the whole reframe: shrkbot stays zero-retention.)
- **Kick + deleted message aren't reversible** → a body note ("a kick can't be undone"), no button.
- **Ephemeral + idempotent.** The handler never edits the shared message, so re-clicks are harmless and the button persists. PR-A's verdict-rebuild preservation keeps it alive across Confirm/Dismiss/Undo-verdict clicks (proven there).
- `punish` now returns the punishment it applied, so the button reflects the **escalated** tier when a confirmed-scam hit escalates (e.g. `ban`, not the base `timeout`).

## Convention review

4 findings — accepted 3 (split conflated actor/target ids in the handler spec; add coverage that the escalated `ban` reaches the button custom_id; reword a `:noop` test description), rejected 1: the reviewer flagged that `:noop` and `:failed` share the "may be missing permissions" copy — but `:noop` is unreachable in production (the button only exists for timeout/ban and custom_ids aren't user-forgeable), so the mis-attribution never surfaces, while the permissions hint genuinely helps the real `:failed` case. Kept.

Reviewer also affirmed the `Unpunisher` (returns a status symbol) vs `Punisher` (void) asymmetry is justified — the interactive caller needs to branch on the outcome.

## Testing

`Unpunisher` (timeout clear / not-in-server / unban / noop / raise→failed), `UndoPunishment` handler (auth gate; distinct actor vs target ids; apology only on `:reversed`; **DM-raises and bot-can't-resolve-user both swallowed** — the expected path for bans/kicks; never edits the message), `VerdictExecutor` (button only for timeout/ban, escalated value, kick→note-no-button, none/flag→no button), custom_id round-trip.

**Not exercisable in the sandbox** (no Discord): the actual unban/timeout-clear/DM calls — needs your live pass. Gates green: rspec 1836, standardrb, active_record_doctor, undercover, i18n missing + normalized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)