### PR TITLE
Add owner-curated global scam image blocklist

### DIFF
--- a/.active_record_doctor.rb
+++ b/.active_record_doctor.rb
@@ -34,7 +34,9 @@ ActiveRecordDoctor.configure do
       "server_channels.parent_id",
       "server_roles.discord_id",
       "channel_overwrites.target_id",
-      "moderation_settings.staff_role_id"
+      "moderation_settings.staff_role_id",
+      "moderation_verdicts.log_channel_id",
+      "moderation_verdicts.log_message_id"
     ]
 
   # These are NOT NULL with a DB default, so they're never nil — presence is wrong
@@ -46,6 +48,7 @@ ActiveRecordDoctor.configure do
       "Moderation::SpamProtection::Settings.match_symbol_only_messages",
       "Reminders::Reminder.deliver_via_dm",
       "ServerConfiguration.force_dm_reminders",
-      "ServerRole.managed"
+      "ServerRole.managed",
+      "Moderation::Phash.global_scam"
     ]
 end

--- a/app/operations/moderation/phashes/prune.rb
+++ b/app/operations/moderation/phashes/prune.rb
@@ -5,10 +5,10 @@ module Ops
     module Phashes
       class Prune < ApplicationOperation
         def call
-          old = ::Moderation::Phash.where(last_seen_at: ...30.days.ago)
+          old = ::Moderation::Phash.where(last_seen_at: ...30.days.ago).where(global_scam: false)
           ::Moderation::PhashConfirmation.where(phash_id: old.select(:id)).delete_all
           old.delete_all
-          ::Moderation::Phash.where.missing(:phash_confirmations).delete_all
+          ::Moderation::Phash.where.missing(:phash_confirmations).where(global_scam: false).delete_all
           ok
         end
       end

--- a/app/operations/moderation/phashes/set_global_scam.rb
+++ b/app/operations/moderation/phashes/set_global_scam.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Ops
+  module Moderation
+    module Phashes
+      class SetGlobalScam < ApplicationOperation
+        receives :phash_hex, :global
+
+        def call
+          phash = ::Moderation::Phash.find_or_create_by!(phash: phash_hex) { |record| record.last_seen_at = Time.current }
+          phash.update!(global_scam: global)
+          ::Moderation::ImageScanning::PhashIndex.invalidate
+          ok(phash)
+        end
+      end
+    end
+  end
+end

--- a/app/plugins/moderation/commands/report_scam.rb
+++ b/app/plugins/moderation/commands/report_scam.rb
@@ -12,7 +12,7 @@ module Moderation
 
     def execute
       message = event.target
-      attachments = image_attachments(message)
+      attachments = ImageScanning::ImageAttachments.call(message)
       return event.respond(content: I18n.t("moderation.image_scanning.report.none"), ephemeral: true) if attachments.empty?
 
       event.defer(ephemeral: true)
@@ -25,12 +25,6 @@ module Moderation
 
     def config
       @config ||= ServerConfiguration.find_by(discord_id: event.server.id)
-    end
-
-    def image_attachments(message)
-      return [] unless message
-
-      message.attachments.select { |attachment| ImageScanning::CONTENT_TYPES.include?(attachment.content_type) }
     end
 
     def confirm_all(attachments, config)

--- a/app/plugins/moderation/commands/toggle_global_scam.rb
+++ b/app/plugins/moderation/commands/toggle_global_scam.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Moderation
+  class ToggleGlobalScam < Bot::BaseCommand
+    command_name "Toggle global scam block"
+    command_type :message
+    register_in :guild
+    plugin :image_scanning
+    owner_only true
+
+    def execute
+      attachments = ImageScanning::ImageAttachments.call(event.target)
+      return event.respond(content: I18n.t("moderation.image_scanning.global_scam.none"), ephemeral: true) if attachments.empty?
+
+      event.defer(ephemeral: true)
+      marked, unmarked = toggle_all(attachments)
+      event.edit_response(content: response_text(marked, unmarked))
+    end
+
+    private
+
+    def response_text(marked, unmarked)
+      return I18n.t("moderation.image_scanning.global_scam.failed") if marked.zero? && unmarked.zero?
+
+      parts = []
+      parts << I18n.t("moderation.image_scanning.global_scam.added", count: marked) if marked > 0
+      parts << I18n.t("moderation.image_scanning.global_scam.removed", count: unmarked) if unmarked > 0
+      parts.join(" ")
+    end
+
+    def toggle_all(attachments)
+      marked = 0
+      unmarked = 0
+      attachments.each do |attachment|
+        bytes = ImageScanning::ImageDownload.call(attachment.url)
+        hex = ImageScanning::Ocr::Client.new.phash(bytes)
+        now_global(hex) ? marked += 1 : unmarked += 1
+      rescue ImageScanning::Ocr::Error => e
+        Rails.logger.warn("[Moderation::ToggleGlobalScam] phash failed: #{e.class}: #{e.message}")
+      end
+      [marked, unmarked]
+    end
+
+    def now_global(hex)
+      target = !::Moderation::Phash.find_by(phash: hex)&.global_scam
+      Ops::Moderation::Phashes::SetGlobalScam.call(phash_hex: hex, global: target)
+      target
+    end
+  end
+end

--- a/app/plugins/moderation/image_scanning.rb
+++ b/app/plugins/moderation/image_scanning.rb
@@ -5,5 +5,6 @@ module Moderation
     CONTENT_TYPES = %w[image/png image/jpeg image/webp image/gif].freeze
     IMAGE_EXTENSIONS = %w[.png .jpg .jpeg .webp .gif].freeze
     DISCORD_CDN_HOSTS = %w[cdn.discordapp.com media.discordapp.net].freeze
+    CONFIRMED_HASH_STATES = %i[own_confirmed global_confirmed].freeze
   end
 end

--- a/app/plugins/moderation/image_scanning/classifier.rb
+++ b/app/plugins/moderation/image_scanning/classifier.rb
@@ -9,7 +9,8 @@ module Moderation
         "strict" => {flag: 2, remove: 4.5}
       }.freeze
       KEYWORD_WEIGHT = 2
-      OWN_CONFIRMED_RISK = 6
+      OWN_CONFIRMED_RISK = 8
+      GLOBAL_CONFIRMED_RISK = 6
       FUZZY_RATIO = 0.2
 
       module_function
@@ -38,7 +39,7 @@ module Moderation
         return :allow unless content_signal
 
         action =
-          if risk >= thresholds[:remove] && (ocr_score > 0 || hash_state == :own_confirmed)
+          if risk >= thresholds[:remove] && (ocr_score > 0 || CONFIRMED_HASH_STATES.include?(hash_state))
             (hash_state == :foreign_confirmed) ? :flag_for_review : :remove
           elsif risk >= thresholds[:flag]
             :flag_for_review
@@ -81,11 +82,18 @@ module Moderation
       def hash_reason(hash_state)
         return nil if hash_state == :none
 
-        weight = (hash_state == :own_confirmed) ? OWN_CONFIRMED_RISK : 0
-        Reason.new(key: hash_state, weight:)
+        Reason.new(key: hash_state, weight: hash_weight(hash_state))
       end
 
-      private_class_method :decide, :scam_rule_reasons, :matchable, :keyword_reasons, :amplifier_reasons, :hash_reason
+      def hash_weight(hash_state)
+        case hash_state
+        when :own_confirmed then OWN_CONFIRMED_RISK
+        when :global_confirmed then GLOBAL_CONFIRMED_RISK
+        else 0
+        end
+      end
+
+      private_class_method :decide, :scam_rule_reasons, :matchable, :keyword_reasons, :amplifier_reasons, :hash_reason, :hash_weight
     end
   end
 end

--- a/app/plugins/moderation/image_scanning/image_attachments.rb
+++ b/app/plugins/moderation/image_scanning/image_attachments.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Moderation
+  module ImageScanning
+    module ImageAttachments
+      module_function
+
+      def call(message)
+        return [] unless message
+
+        message.attachments.select { |attachment| CONTENT_TYPES.include?(attachment.content_type) }
+      end
+    end
+  end
+end

--- a/app/plugins/moderation/image_scanning/phash_index.rb
+++ b/app/plugins/moderation/image_scanning/phash_index.rb
@@ -33,14 +33,17 @@ module Moderation
         @mutex.synchronize do
           refresh_locked
           target = phash_hex.to_i(16)
-          match = @by_int.find { |int, _verdicts| SimHash.hamming_distance(int, target) <= HAMMING_THRESHOLD }
+          match = @by_int.find { |int, _entry| SimHash.hamming_distance(int, target) <= HAMMING_THRESHOLD }
           return :none unless match
 
-          verdicts = match.last
-          own = verdicts[guild_id]
-          return (own == "confirmed") ? :own_confirmed : :own_dismissed if own
+          entry = match.last
+          own = entry[:verdicts][guild_id]
+          if own
+            return (own == "confirmed") ? :own_confirmed : :own_dismissed
+          end
+          return :global_confirmed if entry[:global]
 
-          verdicts.value?("confirmed") ? :foreign_confirmed : :none
+          entry[:verdicts].value?("confirmed") ? :foreign_confirmed : :none
         end
       end
 
@@ -55,11 +58,13 @@ module Moderation
       end
 
       def build
-        result = Hash.new { |h, k| h[k] = {} }
+        result = Hash.new { |hash, key| hash[key] = {verdicts: {}, global: false} }
         PhashConfirmation
           .joins(:phash, :server_configuration)
           .pluck("phashes.phash", "server_configurations.discord_id", "phash_confirmations.verdict")
-          .each { |hex, discord_id, verdict| result[hex.to_i(16)][discord_id] = verdict }
+          .each { |hex, discord_id, verdict| result[hex.to_i(16)][:verdicts][discord_id] = verdict }
+        ::Moderation::Phash.where(global_scam: true).pluck(:phash)
+          .each { |hex| result[hex.to_i(16)][:global] = true }
         result
       end
     end

--- a/app/plugins/moderation/image_scanning/scan_processor.rb
+++ b/app/plugins/moderation/image_scanning/scan_processor.rb
@@ -14,7 +14,7 @@ module Moderation
         Ops::Moderation::Phashes::MarkSeen.call(phash_hex: hex) unless state == :none
         return if state == :own_dismissed
 
-        ocr_text = (state == :own_confirmed) ? "" : client.scan(bytes)["text"]
+        ocr_text = CONFIRMED_HASH_STATES.include?(state) ? "" : client.scan(bytes)["text"]
         verdict = Classifier.call(
           ocr_text:,
           hash_state: state,

--- a/config/locales/legal.en.yml
+++ b/config/locales/legal.en.yml
@@ -105,7 +105,12 @@ en:
         images a server's moderators explicitly confirm as scams, together with which
         servers confirmed them. These fingerprints are never linked to the user who
         posted the image, are deleted when every confirming server has removed the
-        bot, and are pruned automatically after 30 days without a match.
+        bot, and are pruned automatically after 30 days without a match. The bot owner
+        may also mark images as global scams; their perceptual hashes are stored indefinitely
+        as a cross-server blocklist and are treated the same as scams a server's own
+        moderators confirmed, so a match can trigger that server's configured action
+        (flagging, removal, and any punishment). These hashes are not linked to any
+        user or server.
       not_h: What we don't do
       not_p: We don't sell data, we don't advertise, we don't profile you, we don't
         run analytics, and we don't store your servers' member lists or conversations.
@@ -119,7 +124,7 @@ en:
         out of database backups as they rotate.
       retention_phash: 'Confirmed scam-image fingerprints: pruned 30 days after they
         were last matched, and removed once every server that confirmed them has removed
-        the bot.'
+        the bot. Global scam fingerprints set by the bot owner are retained indefinitely.'
       retention_reminders: 'Reminders: deleted once delivered, or earlier if you delete
         them.'
       rights_h: Your rights
@@ -139,7 +144,7 @@ en:
         and our hosting provider Hetzner (Helsinki, Finland, within the EEA), where
         the Service and its database run. We may disclose data where required by law.'
       title: Privacy policy
-      updated: 'Last updated: July 5th, 2026'
+      updated: 'Last updated: July 13th, 2026'
     terms_of_service:
       admin_h: Your responsibilities as a server admin
       admin_p: If you add shrkbot to a server or configure it, you're responsible

--- a/config/locales/moderation.en.yml
+++ b/config/locales/moderation.en.yml
@@ -25,6 +25,7 @@ en:
             one: matched %{count} custom keyword
             other: matched %{count} custom keywords
           foreign_confirmed: matches an image confirmed as a scam on another server
+          global_confirmed: matches an image on shrkbot's global known-scam blocklist
           has_link: the message contains a link
           new_account: the account is only %{days} days old
           no_role: the author has no role on this server
@@ -36,6 +37,17 @@ en:
         title:
           flagged: Possible scam image flagged for review
           removed: Scam image removed
+      global_scam:
+        added:
+          one: Added 1 image to the global scam blocklist. It will be treated as a
+            known scam on every server.
+          other: Added %{count} images to the global scam blocklist. They will be
+            treated as known scams on every server.
+        failed: None of the images could be processed; nothing changed.
+        none: No scannable images found in that message.
+        removed:
+          one: Removed 1 image from the global scam blocklist.
+          other: Removed %{count} images from the global scam blocklist.
       punishment:
         reason: Scam image detected
       report:

--- a/db/migrate/20260713170330_add_global_scam_to_phashes.rb
+++ b/db/migrate/20260713170330_add_global_scam_to_phashes.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddGlobalScamToPhashes < ActiveRecord::Migration[8.1]
+  def change
+    add_column :phashes, :global_scam, :boolean, default: false, null: false
+    add_index :phashes, :global_scam, where: "global_scam", name: "index_phashes_on_global_scam"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_12_115205) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_13_170330) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -88,6 +88,23 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_12_115205) do
     t.check_constraint "new_account_age_days >= 1 AND new_account_age_days <= 365", name: "moderation_settings_new_account_age_days_check"
   end
 
+  create_table "moderation_verdicts", id: :string, default: -> { "('mvr_'::text || gen_random_uuid())" }, force: :cascade do |t|
+    t.string "action", null: false
+    t.datetime "created_at", null: false
+    t.bigint "discord_user_id", null: false
+    t.bigint "log_channel_id"
+    t.bigint "log_message_id"
+    t.string "phash"
+    t.string "punishment", default: "none", null: false
+    t.datetime "reversed_at"
+    t.string "server_configuration_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["discord_user_id"], name: "index_moderation_verdicts_on_discord_user_id"
+    t.index ["server_configuration_id", "created_at"], name: "idx_on_server_configuration_id_created_at_47198f0f26"
+    t.check_constraint "action::text = ANY (ARRAY['flag_for_review'::character varying, 'remove'::character varying]::text[])", name: "moderation_verdicts_action_check"
+    t.check_constraint "punishment::text = ANY (ARRAY['none'::character varying, 'timeout'::character varying, 'kick'::character varying, 'ban'::character varying]::text[])", name: "moderation_verdicts_punishment_check"
+  end
+
   create_table "notifications", id: :string, default: -> { "('ntf_'::text || gen_random_uuid())" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.jsonb "data", default: {}, null: false
@@ -112,9 +129,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_12_115205) do
 
   create_table "phashes", id: :string, default: -> { "('phs_'::text || gen_random_uuid())" }, force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.boolean "global_scam", default: false, null: false
     t.datetime "last_seen_at", null: false
     t.string "phash", limit: 16, null: false
     t.datetime "updated_at", null: false
+    t.index ["global_scam"], name: "index_phashes_on_global_scam", where: "global_scam"
     t.index ["phash"], name: "index_phashes_on_phash", unique: true
   end
 
@@ -375,6 +394,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_12_115205) do
   add_foreign_key "image_scanning_settings", "server_configurations"
   add_foreign_key "logging_settings", "server_configurations"
   add_foreign_key "moderation_settings", "server_configurations"
+  add_foreign_key "moderation_verdicts", "server_configurations"
   add_foreign_key "notifications", "server_configurations"
   add_foreign_key "phash_confirmations", "phashes"
   add_foreign_key "phash_confirmations", "server_configurations"

--- a/spec/operations/moderation/phashes/set_global_scam_spec.rb
+++ b/spec/operations/moderation/phashes/set_global_scam_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Ops::Moderation::Phashes::SetGlobalScam do
+  subject(:result) do
+    described_class.call(
+      phash_hex:,
+      global:
+    )
+  end
+
+  let(:phash_hex) { "00000000000000ab" }
+  let(:global) { true }
+
+  it "invalidates the phash index" do
+    expect(Moderation::ImageScanning::PhashIndex).to receive(:invalidate)
+    result
+  end
+
+  context "when marking as global scam" do
+    it "creates the phash when absent and sets global_scam true" do
+      expect { result }.to change(Moderation::Phash, :count).by(1)
+      expect(result).to be_success
+      expect(result.value.global_scam).to be(true)
+    end
+  end
+
+  context "when unmarking a global scam" do
+    let(:global) { false }
+
+    before do
+      create(:phash, phash: phash_hex, global_scam: true)
+    end
+
+    it "sets global_scam false without adding a row" do
+      expect { result }.not_to change(Moderation::Phash, :count)
+      expect(result.value.global_scam).to be(false)
+    end
+  end
+end

--- a/spec/plugins/moderation/commands/toggle_global_scam_spec.rb
+++ b/spec/plugins/moderation/commands/toggle_global_scam_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Moderation::ToggleGlobalScam do
+  subject(:execute) { described_class.new(event).execute }
+
+  let(:guild_id) { 111 }
+  let!(:config) { create(:server_configuration, discord_id: guild_id) }
+
+  let(:image_attachment) { double("att", content_type: "image/png", url: "https://cdn/x.png") }
+  let(:attachments) { [image_attachment] }
+  let(:target) { double("message", attachments:) }
+  let(:server) { double("server", id: guild_id) }
+  let(:event) do
+    double(
+      "event",
+      target:,
+      server:,
+      defer: nil,
+      edit_response: nil,
+      respond: nil
+    )
+  end
+
+  let(:client) { double("client") }
+
+  before do
+    allow(Moderation::ImageScanning::Ocr::Client).to receive(:new).and_return(client)
+    allow(client).to receive(:phash).and_return("deadbeefdeadbeef")
+    allow(Moderation::ImageScanning::ImageDownload).to receive(:call).and_return("bytes")
+    allow(Ops::Moderation::Phashes::SetGlobalScam).to receive(:call)
+  end
+
+  context "when there is no target message" do
+    let(:target) { nil }
+
+    it "responds with the none message and never defers" do
+      execute
+
+      expect(event).to have_received(:respond).with(hash_including(ephemeral: true))
+      expect(event).not_to have_received(:defer)
+      expect(Ops::Moderation::Phashes::SetGlobalScam).not_to have_received(:call)
+    end
+  end
+
+  context "when the message has no image attachments" do
+    let(:attachments) { [] }
+
+    it "responds with the none message and never defers" do
+      execute
+
+      expect(event).to have_received(:respond).with(hash_including(ephemeral: true))
+      expect(event).not_to have_received(:defer)
+      expect(Ops::Moderation::Phashes::SetGlobalScam).not_to have_received(:call)
+    end
+  end
+
+  context "when the image has no phash record yet" do
+    it "treats it as new and marks it global" do
+      execute
+
+      expect(Ops::Moderation::Phashes::SetGlobalScam).to have_received(:call).with(
+        phash_hex: "deadbeefdeadbeef",
+        global: true
+      )
+      expect(event).to have_received(:edit_response).with(
+        content: I18n.t("moderation.image_scanning.global_scam.added", count: 1)
+      )
+    end
+  end
+
+  context "when the image is not yet marked global" do
+    before do
+      create(:phash, phash: "deadbeefdeadbeef", global_scam: false)
+    end
+
+    it "defers, marks as global, and reports the added copy" do
+      execute
+
+      expect(event).to have_received(:defer).with(ephemeral: true)
+      expect(Ops::Moderation::Phashes::SetGlobalScam).to have_received(:call).with(
+        phash_hex: "deadbeefdeadbeef",
+        global: true
+      )
+      expect(event).to have_received(:edit_response).with(
+        content: I18n.t("moderation.image_scanning.global_scam.added", count: 1)
+      )
+    end
+  end
+
+  context "when the image is already marked global" do
+    before do
+      create(:phash, phash: "deadbeefdeadbeef", global_scam: true)
+    end
+
+    it "defers, unmarks global, and reports the removed copy" do
+      execute
+
+      expect(event).to have_received(:defer).with(ephemeral: true)
+      expect(Ops::Moderation::Phashes::SetGlobalScam).to have_received(:call).with(
+        phash_hex: "deadbeefdeadbeef",
+        global: false
+      )
+      expect(event).to have_received(:edit_response).with(
+        content: I18n.t("moderation.image_scanning.global_scam.removed", count: 1)
+      )
+    end
+  end
+
+  context "when an attachment fails to phash" do
+    before do
+      allow(Moderation::ImageScanning::ImageDownload).to receive(:call).and_raise(Moderation::ImageScanning::Ocr::Error, "boom")
+    end
+
+    it "does not raise and skips the failed attachment" do
+      expect { execute }.not_to raise_error
+
+      expect(Ops::Moderation::Phashes::SetGlobalScam).not_to have_received(:call)
+    end
+
+    it "reports that nothing could be processed" do
+      execute
+
+      expect(event).to have_received(:edit_response).with(
+        content: I18n.t("moderation.image_scanning.global_scam.failed")
+      )
+    end
+  end
+end

--- a/spec/plugins/moderation/image_scanning/classifier_spec.rb
+++ b/spec/plugins/moderation/image_scanning/classifier_spec.rb
@@ -278,8 +278,8 @@ RSpec.describe Moderation::ImageScanning::Classifier do
     context "own_confirmed" do
       let(:hash_state) { :own_confirmed }
 
-      it "adds 6 to risk" do
-        expect(verdict.risk).to eq(6)
+      it "adds 8 to risk" do
+        expect(verdict.risk).to eq(8)
       end
 
       context "standard sensitivity with empty ocr text" do
@@ -301,8 +301,40 @@ RSpec.describe Moderation::ImageScanning::Classifier do
       context "relaxed sensitivity alone" do
         let(:sensitivity) { "relaxed" }
 
-        it "flags below the remove threshold" do
+        it "removes at the remove threshold (risk 8 == remove 8)" do
+          expect(verdict.action).to eq(:remove)
+        end
+      end
+    end
+
+    context "global_confirmed" do
+      let(:hash_state) { :global_confirmed }
+
+      it "adds 6 to risk" do
+        expect(verdict.risk).to eq(6)
+      end
+
+      context "relaxed sensitivity alone" do
+        let(:sensitivity) { "relaxed" }
+
+        it "flags below the remove threshold (risk 6 < remove 8)" do
           expect(verdict.action).to eq(:flag_for_review)
+        end
+      end
+
+      context "standard sensitivity with empty ocr text" do
+        let(:sensitivity) { "standard" }
+
+        it "removes on the hash content signal" do
+          expect(verdict.action).to eq(:remove)
+        end
+      end
+
+      context "strict sensitivity with empty ocr text" do
+        let(:sensitivity) { "strict" }
+
+        it "removes on the hash content signal" do
+          expect(verdict.action).to eq(:remove)
         end
       end
     end

--- a/spec/plugins/moderation/image_scanning/phash_index_spec.rb
+++ b/spec/plugins/moderation/image_scanning/phash_index_spec.rb
@@ -108,6 +108,49 @@ RSpec.describe Moderation::ImageScanning::PhashIndex do
       end
     end
 
+    context "when the phash is marked global_scam with no confirmations" do
+      before do
+        create(:phash, phash: stored_hex, global_scam: true)
+      end
+
+      it "returns :global_confirmed" do
+        expect(index.lookup(stored_hex, own_guild.discord_id)).to eq(:global_confirmed)
+      end
+    end
+
+    context "when the phash is global_scam and the querying guild dismissed it" do
+      before do
+        phash = create(:phash, phash: stored_hex, global_scam: true)
+        create(:phash_confirmation, phash:, server_configuration: own_guild, verdict: "dismissed")
+      end
+
+      it "own dismissed takes precedence over global" do
+        expect(index.lookup(stored_hex, own_guild.discord_id)).to eq(:own_dismissed)
+      end
+    end
+
+    context "when the phash is global_scam and the querying guild confirmed it" do
+      before do
+        phash = create(:phash, phash: stored_hex, global_scam: true)
+        create(:phash_confirmation, phash:, server_configuration: own_guild, verdict: "confirmed")
+      end
+
+      it "own confirmed takes precedence over global" do
+        expect(index.lookup(stored_hex, own_guild.discord_id)).to eq(:own_confirmed)
+      end
+    end
+
+    context "when the phash is global_scam and only a foreign guild confirmed it" do
+      before do
+        phash = create(:phash, phash: stored_hex, global_scam: true)
+        create(:phash_confirmation, phash:, server_configuration: foreign_guild, verdict: "confirmed")
+      end
+
+      it "returns :global_confirmed (global beats foreign)" do
+        expect(index.lookup(stored_hex, own_guild.discord_id)).to eq(:global_confirmed)
+      end
+    end
+
     context "called repeatedly within the refresh interval" do
       before do
         create(:phash_confirmation, phash: create(:phash, phash: stored_hex), server_configuration: own_guild, verdict: "confirmed")


### PR DESCRIPTION
## What

An owner-only message command that marks an image's perceptual hash as a **global scam**, so recurring scam images can be blocked across every server without shipping a new build. Fills a gap the per-server confirm/dismiss flow can't: the same scam images circulate everywhere, and this lets the owner curate a known-bad list centrally.

Right-click a message → Apps → **"Toggle global scam block"** (owner only). Each attached image's hash is flipped in/out of the blocklist; the command is a toggle so the same action revokes.

## Detection behaviour

A `global_confirmed` hash match is treated **like a normally-detected scam**, not like a hash the server confirmed itself:

- risk weight 6 → **flags on relaxed, removes on standard/strict** (mirrors what an OCR-detected scam of that risk would do);
- uses the server's **normal** `punishment`, *not* the `confirmed_punishment` escalation — that escalation stays reserved for hashes a server explicitly confirmed, so the owner's list never applies a harsher action than the admin opted into for their own confirmations;
- a server that **locally dismisses** the image wins (`own_dismissed` > `own_confirmed` > `global_confirmed` > `foreign_confirmed`).

Running the command **never deletes the carrier message or punishes its author** — samples are forwarded by trusted people, so curation has no moderation side effects. It only toggles the flag.

Also raises `own_confirmed` risk 6 → 8 so a server's *own* confirmation now removes even on the relaxed preset (previously it only flagged there).

## Data / privacy

- `global_scam` boolean on `phashes`, exempt from **both** prune paths → non-expiring blocklist.
- Privacy policy updated: indefinitely-retained perceptual-hash blocklist, not linked to any user or server. Global hashes intentionally survive guild purge (they aren't guild-scoped); no per-user data added, so `Ops::Users::Destroy` is unaffected.

## Boyscout

- Extracted `ImageScanning::ImageAttachments` (was duplicated in `ReportScam`; now shared).
- Added the pre-existing `moderation_verdicts` Discord-snowflake FKs to the `active_record_doctor` ignore list, and `db/schema.rb` re-dumped to include the `moderation_verdicts` table (schema was stale on main).

## Tests

Classifier (per-sensitivity actions for both hash states), `PhashIndex` precedence, the `SetGlobalScam` op, and the command (mark / unmark / brand-new image / all-failed). Full suite green; undercover clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)