### PR TITLE
Add Open Graph / Twitter card meta tags

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,26 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  def social_meta_tags
+    title = content_for(:title).presence || t("meta.default_title")
+    description = content_for(:page_description).presence || t("meta.default_description")
+    image = image_url("shrkbot-mascot.png")
+
+    safe_join(
+      [
+        tag.meta(name: "description", content: description),
+        tag.meta(property: "og:site_name", content: "shrkbot"),
+        tag.meta(property: "og:type", content: "website"),
+        tag.meta(property: "og:title", content: title),
+        tag.meta(property: "og:description", content: description),
+        tag.meta(property: "og:url", content: request.original_url),
+        tag.meta(property: "og:image", content: image),
+        tag.meta(name: "twitter:card", content: "summary_large_image"),
+        tag.meta(name: "twitter:title", content: title),
+        tag.meta(name: "twitter:description", content: description),
+        tag.meta(name: "twitter:image", content: image)
+      ],
+      "\n"
+    )
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,7 @@
       })();
     </script>
     <title><%= content_for(:title) || "shrkbot" %></title>
+    <%= social_meta_tags %>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="application-name" content="shrkbot">

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -342,8 +342,8 @@ en:
           label: Live preview
           timestamp: Today
   meta:
-    default_description: A mechanical assistant for your Discord server - self-assignable
-      roles, reminders, welcomes, and moderation with teeth when needed.
+    default_description: A mechanical assistant for your Discord server. With teeth
+      when needed.
     default_title: shrkbot
   notifications:
     kinds:

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -341,6 +341,10 @@ en:
           empty: This message is off.
           label: Live preview
           timestamp: Today
+  meta:
+    default_description: A mechanical assistant for your Discord server - self-assignable
+      roles, reminders, welcomes, and moderation with teeth when needed.
+    default_title: shrkbot
   notifications:
     kinds:
       channel_deleted:

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApplicationHelper, type: :helper do
+  describe "#social_meta_tags" do
+    subject(:tags) { helper.social_meta_tags }
+
+    it "emits Open Graph and Twitter card tags" do
+      expect(tags).to include('property="og:type" content="website"')
+      expect(tags).to include('property="og:site_name" content="shrkbot"')
+      expect(tags).to include('name="twitter:card" content="summary_large_image"')
+    end
+
+    it "includes the request URL as og:url" do
+      expect(tags).to include(%(property="og:url" content="#{helper.request.original_url}"))
+    end
+
+    context "without a page title or description" do
+      it "falls back to the localized defaults" do
+        expect(tags).to include(%(property="og:title" content="#{I18n.t("meta.default_title")}"))
+        expect(tags).to include(%(property="og:description" content="#{I18n.t("meta.default_description")}"))
+      end
+    end
+
+    context "with a page title and description set" do
+      before do
+        helper.content_for(:title, "Roles")
+        helper.content_for(:page_description, "Manage self-assignable roles.")
+      end
+
+      it "uses them over the defaults" do
+        expect(tags).to include('property="og:title" content="Roles"')
+        expect(tags).to include('property="og:description" content="Manage self-assignable roles."')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why

Posting a shrkbot site link on Discord (or anywhere) produced **no embed at all**. Cause: the app layout emitted zero Open Graph tags, so Discord's unfurler — and every other one — had nothing to render. Not a Discord-side setting; the fix is on the website.

## What

- `ApplicationHelper#social_meta_tags` — emits `og:*` + `twitter:*` (`summary_large_image`) tags plus a plain `<meta name="description">`.
  - Title from `content_for(:title)`, description from `content_for(:page_description)`, both falling back to localized `meta.default_*`.
  - `og:image` / `twitter:image` use the existing `shrkbot-mascot.png` asset (`image_url`, absolute).
  - `og:url` from `request.original_url`.
- Called from `layouts/application.html.erb`.
- New `meta` locale scope (default title + description).
- Helper spec covers defaults, `content_for` overrides, and `og:url`.

## Notes / follow-ups

- Per-page pages can now set `content_for(:page_description)` to override the default — none do yet; defaults cover them.
- `og:image` is the mascot for now. A purpose-built 1200×630 social banner would look better in the large-card layout — deferred, not in scope.
- Two non-code gates for a live embed once merged: the page must return 200 to `Discordbot/2.0` and not sit behind auth. Server-side fetch, so CSP is irrelevant.

Gates: rspec, standardrb, i18n-tasks missing/check-normalized, undercover — all green locally.