### PR TITLE
Fix image-scanning overview toggle wiping confirmed-punishment settings

### DIFF
--- a/app/components/moderation/sub_plugin_row.rb
+++ b/app/components/moderation/sub_plugin_row.rb
@@ -140,6 +140,8 @@ class Components::Moderation::SubPluginRow < Components::Base
     input(type: "hidden", name: "image_scanning[action]", value: @settings.action, form: stub_form_id)
     input(type: "hidden", name: "image_scanning[punishment]", value: @settings.punishment, form: stub_form_id)
     input(type: "hidden", name: "image_scanning[timeout_seconds]", value: @settings.timeout_seconds, form: stub_form_id)
+    input(type: "hidden", name: "image_scanning[confirmed_punishment]", value: @settings.confirmed_punishment, form: stub_form_id)
+    input(type: "hidden", name: "image_scanning[confirmed_timeout_seconds]", value: @settings.confirmed_timeout_seconds, form: stub_form_id)
     input(type: "hidden", name: "image_scanning[custom_keyword_min_hits]", value: @settings.custom_keyword_min_hits, form: stub_form_id)
     @settings.custom_keywords.each do |keyword|
       input(type: "hidden", name: "image_scanning[custom_keywords][]", value: keyword, form: stub_form_id)

--- a/spec/components/moderation/sub_plugin_row_spec.rb
+++ b/spec/components/moderation/sub_plugin_row_spec.rb
@@ -98,6 +98,8 @@ RSpec.describe Components::Moderation::SubPluginRow do
       expect(html).to include('name="image_scanning[action]"')
       expect(html).to include('name="image_scanning[punishment]"')
       expect(html).to include('name="image_scanning[timeout_seconds]"')
+      expect(html).to include('name="image_scanning[confirmed_punishment]"')
+      expect(html).to include('name="image_scanning[confirmed_timeout_seconds]"')
       expect(html).to include('name="image_scanning[custom_keyword_min_hits]"')
     end
 


### PR DESCRIPTION
## Bug

Toggling image scanning from the Server Shield **overview** page on a config whose image-scanning settings were never edited raised:

> Confirmed punishment is not included in the list and Confirmed timeout seconds is not a number

## Cause

The overview toggle has no form of its own — it re-submits the current settings as hidden fields so a plain enable/disable round-trips every value through `Ops::Moderation::ImageScanning::Configure`. `confirmed_punishment` / `confirmed_timeout_seconds` were added to the model (migration `20260711125937`) after the toggle's hidden-field list was written and never added to it. So the toggle submitted both as `nil`, and the op assigned `nil` over the DB defaults, tripping the model's inclusion + numericality validations.

Only image scanning was affected; the spam-protection path already carries all its fields.

## Fix

Add the two missing hidden fields to `image_scanning_hidden_fields`, plus spec assertions guarding their presence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)