### PR TITLE
Add optional join ping to welcomes

### DIFF
--- a/app/components/reminders/config_form.rb
+++ b/app/components/reminders/config_form.rb
@@ -15,17 +15,12 @@ class Components::Reminders::ConfigForm < Components::Base
   private
 
   def force_dm_card
-    render Components::Card.new(class: "flex items-center gap-4") do
-      div(class: "flex-1") do
-        p(class: "text-sm font-semibold") { t(".force_dm.label") }
-        p(class: "mt-0.5 text-sm text-text-secondary") { t(".force_dm.help") }
-      end
-      render Components::Toggle.new(
-        name: "reminders[force_dm_reminders]",
-        checked: @config.force_dm_reminders,
-        label: t(".force_dm.label")
-      )
-    end
+    render Components::ToggleCard.new(
+      name: "reminders[force_dm_reminders]",
+      checked: @config.force_dm_reminders,
+      label: t(".force_dm.label"),
+      help: t(".force_dm.help")
+    )
   end
 
   def command_callout

--- a/app/components/toggle_card.rb
+++ b/app/components/toggle_card.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class Components::ToggleCard < Components::Base
+  def initialize(name:, checked:, label:, help:)
+    @name = name
+    @checked = checked
+    @label = label
+    @help = help
+  end
+
+  def view_template
+    render Components::Card.new(class: "flex items-center gap-4") do
+      div(class: "flex-1") do
+        p(class: "text-sm font-semibold") { @label }
+        p(class: "mt-0.5 text-sm text-text-secondary") { @help }
+      end
+      render Components::Toggle.new(name: @name, checked: @checked, label: @label)
+    end
+  end
+end

--- a/app/components/welcomes/config_form.rb
+++ b/app/components/welcomes/config_form.rb
@@ -16,6 +16,7 @@ class Components::Welcomes::ConfigForm < Components::Base
       enable_error_callout
       channel_card
       message_cards
+      ping_toggle
       placeholder_help
       preview
     end
@@ -71,6 +72,15 @@ class Components::Welcomes::ConfigForm < Components::Base
         plain t(".#{name}.info")
       end
     end
+  end
+
+  def ping_toggle
+    render Components::ToggleCard.new(
+      name: "welcomes[ping_on_join]",
+      checked: @settings.ping_on_join,
+      label: t(".ping_on_join.label"),
+      help: t(".ping_on_join.help")
+    )
   end
 
   def placeholder_help

--- a/app/controllers/servers/welcomes_controller.rb
+++ b/app/controllers/servers/welcomes_controller.rb
@@ -18,6 +18,7 @@ class Servers::WelcomesController < ApplicationController
       channel_id: welcomes_params[:channel_id],
       join_message: welcomes_params[:join_message],
       leave_message: welcomes_params[:leave_message],
+      ping_on_join: welcomes_params.fetch(:ping_on_join, "1"),
       enabled: welcomes_params[:enabled]
     )
     respond_with_configuration(result)
@@ -26,6 +27,6 @@ class Servers::WelcomesController < ApplicationController
   private
 
   def welcomes_params
-    params.expect(welcomes: [:channel_id, :join_message, :leave_message, :enabled])
+    params.expect(welcomes: [:channel_id, :join_message, :leave_message, :ping_on_join, :enabled])
   end
 end

--- a/app/operations/welcomes/configure.rb
+++ b/app/operations/welcomes/configure.rb
@@ -5,11 +5,11 @@ module Ops
     class Configure < ApplicationOperation
       include Ops::PluginConfiguration
 
-      receives :server_configuration, :channel_id, :join_message, :leave_message, :enabled
+      receives :server_configuration, :channel_id, :join_message, :leave_message, :ping_on_join, :enabled
 
       def call
         settings = server_configuration.welcome_settings
-        settings.assign_attributes(channel_id:, join_message:, leave_message:)
+        settings.assign_attributes(channel_id:, join_message:, leave_message:, ping_on_join:)
         activation = staged_activation
 
         return failure(messages(settings, activation), value: activation) unless settings.valid? && activation.valid?

--- a/app/plugins/welcomes/events/member_join.rb
+++ b/app/plugins/welcomes/events/member_join.rb
@@ -10,7 +10,13 @@ module Welcomes
       return if setting.join_message.blank?
 
       content = Message.render(setting.join_message, user: event.user.mention, member_count: event.server.member_count)
-      event.bot.send_message(setting.channel_id, content)
+      event.bot.send_message(setting.channel_id, content, false, nil, nil, mention_suppression(setting))
+    end
+
+    private
+
+    def mention_suppression(setting)
+      {parse: []} unless setting.ping_on_join
     end
   end
 end

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -333,6 +333,10 @@ en:
           info: is a plain @username in leave messages.
           label: Leave message
           placeholder: "{user} has left the server."
+        ping_on_join:
+          help: Ping new members when the join message mentions them. Off shows the
+            mention without sending a notification.
+          label: Ping on join
         placeholders:
           intro: 'Placeholders:'
           membercount: Expands to the server's current member count.

--- a/db/migrate/20260713204954_add_ping_on_join_to_welcome_settings.rb
+++ b/db/migrate/20260713204954_add_ping_on_join_to_welcome_settings.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPingOnJoinToWelcomeSettings < ActiveRecord::Migration[8.1]
+  def change
+    add_column :welcome_settings, :ping_on_join, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_13_170330) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_13_204954) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -384,6 +384,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_13_170330) do
     t.datetime "created_at", null: false
     t.text "join_message"
     t.text "leave_message"
+    t.boolean "ping_on_join", default: true, null: false
     t.string "server_configuration_id", null: false
     t.datetime "updated_at", null: false
     t.index ["server_configuration_id"], name: "index_welcome_settings_on_server_configuration_id", unique: true

--- a/spec/components/toggle_card_spec.rb
+++ b/spec/components/toggle_card_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::ToggleCard do
+  subject(:html) do
+    described_class.new(
+      name: "welcomes[ping_on_join]",
+      checked: true,
+      label: "Ping on join",
+      help: "Ping new members."
+    ).call
+  end
+
+  it "renders the label and help text" do
+    expect(html).to include("Ping on join").and include("Ping new members.")
+  end
+
+  it "renders a checked toggle wired to the given field name" do
+    expect(html).to include('name="welcomes[ping_on_join]"')
+    expect(html).to include('type="checkbox"').and include("checked")
+  end
+end

--- a/spec/components/welcomes/config_form_spec.rb
+++ b/spec/components/welcomes/config_form_spec.rb
@@ -21,4 +21,8 @@ RSpec.describe Components::Welcomes::ConfigForm do
   it "shows the none-message when no channels have synced" do
     expect(html).to include("No channels have synced yet")
   end
+
+  it "renders the ping-on-join toggle" do
+    expect(html).to include('name="welcomes[ping_on_join]"')
+  end
 end

--- a/spec/operations/welcomes/configure_spec.rb
+++ b/spec/operations/welcomes/configure_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Ops::Welcomes::Configure do
       channel_id:,
       join_message: "hi {user}",
       leave_message: "bye",
+      ping_on_join: false,
       enabled:
     )
   end
@@ -25,6 +26,7 @@ RSpec.describe Ops::Welcomes::Configure do
       expect(config.welcome_settings.reload.channel_id).to eq(111)
       expect(config.welcome_settings.join_message).to eq("hi {user}")
       expect(config.plugin_activations.find_by(plugin:).enabled).to be(true)
+      expect(config.welcome_settings.ping_on_join).to be(false)
     end
   end
 

--- a/spec/plugins/welcomes/events/member_join_spec.rb
+++ b/spec/plugins/welcomes/events/member_join_spec.rb
@@ -15,10 +15,19 @@ RSpec.describe Welcomes::MemberJoin do
   end
 
   context "with an active setting and a join message" do
-    let(:setting) { double("settings", channel_id: 555, join_message: "Welcome {user}! Members: {membercount}") }
+    let(:setting) { double("settings", channel_id: 555, join_message: "Welcome {user}! Members: {membercount}", ping_on_join: true) }
 
     it "posts the rendered message to the configured channel" do
-      expect(bot).to receive(:send_message).with(555, "Welcome <@7>! Members: 10")
+      expect(bot).to receive(:send_message).with(555, "Welcome <@7>! Members: 10", false, nil, nil, nil)
+      handle
+    end
+  end
+
+  context "when pinging on join is disabled" do
+    let(:setting) { double("settings", channel_id: 555, join_message: "Welcome {user}!", ping_on_join: false) }
+
+    it "suppresses the mention so no ping fires" do
+      expect(bot).to receive(:send_message).with(555, "Welcome <@7>!", false, nil, nil, {parse: []})
       handle
     end
   end

--- a/spec/requests/welcomes_config_spec.rb
+++ b/spec/requests/welcomes_config_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe "Welcomes config", type: :request do
           expect(response.body).to include("Welcomes")
           expect(response.body).to include("Join message")
           expect(response.body).to include("Live preview")
+          expect(response.body).to include("Ping on join")
         end
 
         it "renders the save bar wired to the form" do
@@ -90,13 +91,14 @@ RSpec.describe "Welcomes config", type: :request do
 
         it "saves the settings and enables the plugin in one request" do
           patch server_welcomes_path(guild.id),
-            params: {welcomes: {channel_id: 111, join_message: "hi {user}", leave_message: "", enabled: "1"}},
+            params: {welcomes: {channel_id: 111, join_message: "hi {user}", leave_message: "", ping_on_join: "0", enabled: "1"}},
             **turbo
           expect(response.media_type).to eq("text/vnd.turbo-stream.html")
           expect(config.welcome_settings.reload.channel_id).to eq(111)
           expect(config.plugins.enabled.exists?(key: :welcomes)).to be(true)
           expect(response.body).to include("saved")
           expect(response.body).to include('target="plugin-sidebar"')
+          expect(config.welcome_settings.reload.ping_on_join).to be(false)
         end
 
         it "re-renders the form with an inline error when enabling without a channel" do


### PR DESCRIPTION
## What

Welcome **join** messages have always pinged the mentioned member. This adds a per-guild **Ping on join** toggle so admins can show the `{user}` mention *without* firing a notification.

Mechanism: when the toggle is off, the join message is sent with `allowed_mentions: {parse: []}` — the mention text still renders as a clickable pill, but no ping/notification is delivered. Leave messages are unaffected (they never pinged).

## Behaviour

- New `ping_on_join` boolean on `welcome_settings`, **default `true`** — existing servers keep pinging exactly as before.
- UI: a toggle card in the Welcomes config, between the message editors and the placeholder help, mirroring the Reminders "Force DM" toggle.

## Notes

- The whole slice mirrors the existing `reminders.force_dm_reminders` toggle (model column → op → controller → config-form toggle → locale → specs).
- Boyscout: extracted the shared *label + help + Toggle* card skeleton (Reminders + Welcomes) into `Components::ToggleCard` (rule of two).
- Privacy/GDPR: no change needed — `welcome_settings` already cascades on guild purge (`has_one … dependent: :delete`), and a boolean preference introduces no new data category (already disclosed as "welcome settings").

## Gates

`rspec` 1868/0 · `standardrb` · `active_record_doctor` · `undercover --compare origin/main` · `i18n-tasks missing` + `check-normalized` — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)