### PR TITLE
Toggle single-selection roles off

### DIFF
--- a/app/plugins/roles/assignment.rb
+++ b/app/plugins/roles/assignment.rb
@@ -4,7 +4,9 @@ module Roles
   module Assignment
     module_function
 
-    def single(set_role_ids, picked_id)
+    def single(set_role_ids, picked_id, held_ids)
+      return {add: [], remove: [picked_id]} if held_ids.include?(picked_id)
+
       {add: [picked_id], remove: set_role_ids - [picked_id]}
     end
 

--- a/app/plugins/roles/events/pick.rb
+++ b/app/plugins/roles/events/pick.rb
@@ -10,8 +10,8 @@ module Roles
       picked = CustomId.parse(event.custom_id)[:role_id]
       return unless set_role_ids.include?(picked)
 
-      diff = Assignment.single(set_role_ids, picked)
       had = member_set_role_ids
+      diff = Assignment.single(set_role_ids, picked, had)
       apply(diff)
       event.respond(content: Message.pick_confirmation(set, picked, had), ephemeral: true)
       log_assignment(had, diff)

--- a/app/plugins/roles/message.rb
+++ b/app/plugins/roles/message.rb
@@ -32,12 +32,11 @@ module Roles
     def pick_confirmation(set, picked_id, had_role_ids)
       names = role_names(set)
       picked = "**#{names[picked_id] || UNKNOWN_ROLE}**"
-      replaced = (had_role_ids - [picked_id]).map { |role_id| "**#{names[role_id] || UNKNOWN_ROLE}**" }
+      return "Removed #{picked}." if had_role_ids.include?(picked_id)
 
+      replaced = (had_role_ids - [picked_id]).map { |role_id| "**#{names[role_id] || UNKNOWN_ROLE}**" }
       if replaced.any?
         "You now have #{picked} - swapped out #{replaced.to_sentence}."
-      elsif had_role_ids.include?(picked_id)
-        "No change - you already have #{picked}."
       else
         "You now have #{picked}."
       end
@@ -56,7 +55,7 @@ module Roles
     end
 
     def single_content(set)
-      "### #{set.name}\nPick a role below - you can only have one, so choosing a role replaces your current one."
+      "### #{set.name}\nPick a role below - you can only have one, so choosing a role replaces your current one.\n-# Click the role you already have to remove it without replacement."
     end
 
     def multi_content(set)

--- a/spec/plugins/roles/assignment_spec.rb
+++ b/spec/plugins/roles/assignment_spec.rb
@@ -4,17 +4,29 @@ require "rails_helper"
 
 RSpec.describe Roles::Assignment do
   describe ".single" do
-    subject(:diff) { described_class.single(set_role_ids, picked) }
+    subject(:diff) { described_class.single(set_role_ids, picked, held_ids) }
 
     let(:set_role_ids) { [1, 2, 3] }
     let(:picked) { 2 }
+    let(:held_ids) { [] }
 
-    it "adds the picked role" do
-      expect(diff[:add]).to eq([2])
+    context "when the member does not hold the picked role" do
+      it "adds the picked role" do
+        expect(diff[:add]).to eq([2])
+      end
+
+      it "removes every other role in the set (exclusive selection)" do
+        expect(diff[:remove]).to contain_exactly(1, 3)
+      end
     end
 
-    it "removes every other role in the set (exclusive selection)" do
-      expect(diff[:remove]).to contain_exactly(1, 3)
+    context "when the member already holds the picked role" do
+      let(:held_ids) { [2] }
+
+      it "removes it and adds nothing (toggle off)" do
+        expect(diff[:add]).to be_empty
+        expect(diff[:remove]).to eq([2])
+      end
     end
   end
 

--- a/spec/plugins/roles/events/pick_spec.rb
+++ b/spec/plugins/roles/events/pick_spec.rb
@@ -59,6 +59,31 @@ RSpec.describe Roles::Pick do
     end
   end
 
+  context "when the member picks the role they already have" do
+    let(:member) { double("member", roles: [double("role", id: 200)], modify_roles: nil, mention: "<@42>") }
+
+    it "removes it without replacement (toggle off)" do
+      expect(member).to receive(:modify_roles).with([], [200])
+      handle
+    end
+
+    it "confirms the removal" do
+      expect(event).to receive(:respond).with(content: "Removed **Blue**.", ephemeral: true)
+      handle
+    end
+
+    it "logs the role the user lost" do
+      expect(Bot::ActivityLog).to receive(:post).with(
+        server_config,
+        bot:,
+        title: "Roles updated",
+        body: "<@42> lost **Blue**.",
+        meta: "Self-assigned via the \"#{set.name}\" role menu"
+      )
+      handle
+    end
+  end
+
   context "when the custom id references a role outside the set" do
     let(:event) do
       double("event", custom_id: "roles:pick:#{set.id}:999", server:, user:, respond: nil)

--- a/spec/plugins/roles/message_spec.rb
+++ b/spec/plugins/roles/message_spec.rb
@@ -92,6 +92,10 @@ RSpec.describe Roles::Message do
         expect(content).to include("replaces your current one")
       end
 
+      it "tells the member how to remove their role without replacement" do
+        expect(text_block(rendered)[:content]).to include("Click the role you already have to remove it")
+      end
+
       it "separates the text from the buttons" do
         expect(container_blocks(rendered).map { |block| block[:type] }).to include(Bot::Discord::Components::SEPARATOR)
       end
@@ -198,8 +202,8 @@ RSpec.describe Roles::Message do
     context "when the member picks the role they already have" do
       let(:had) { [200] }
 
-      it "says nothing changed" do
-        expect(confirmation).to eq("No change - you already have **Blue**.")
+      it "confirms the role was removed (toggle off)" do
+        expect(confirmation).to eq("Removed **Blue**.")
       end
     end
 


### PR DESCRIPTION
## Problem

Single-selection role menus were a dead end once you held a role. The buttons are radio-style — click a role you lack and it swaps in, replacing your current one. But clicking the role you *already* hold just returned "No change - you already have **Blue**." There was no way back to holding none of the set's roles (the classic radio-button-can't-deselect problem).

## Fix

Clicking the role you currently hold now **removes it without replacement** (toggle off). Everything else is unchanged: picking a different role still swaps.

- `Assignment.single` gains `held_ids`; returns remove-only when the picked role is already held.
- Confirmation flips from "No change - you already have **Blue**." to "Removed **Blue**."
- The shared menu gains a footer: *Click the role you already have to remove it without replacement.* The public message isn't per-user, so a highlighted "active" button isn't possible — the footer is the discoverability lever.

No new data, no schema change, no locale change (menu copy is inline).

## Tests

`Assignment.single` toggle-off case, the `Pick` handler (removes only, logs the loss, confirms), and the message footer + removal copy. All gates green locally (rspec, standardrb, undercover).