### PR TITLE
Link the public header logo to home

### DIFF
--- a/app/components/public_shell.rb
+++ b/app/components/public_shell.rb
@@ -20,9 +20,11 @@ class Components::PublicShell < Components::Base
 
   def header_bar
     header(class: "app-bar z-30 flex h-16 items-center gap-3 px-6") do
-      image_tag("shrkbot-mascot.png", alt: "shrkbot", class: "size-9 rounded-control")
-      span(class: "font-display text-lg font-bold tracking-tight") do
-        render Components::Wordmark.new
+      a(href: @user ? servers_path : root_path, class: "flex items-center gap-2") do
+        image_tag("shrkbot-mascot.png", alt: "shrkbot", class: "size-9 rounded-control")
+        span(class: "font-display text-lg font-bold tracking-tight") do
+          render Components::Wordmark.new
+        end
       end
       render Components::VersionBadge.new
       div(class: "flex-1")

--- a/spec/components/public_shell_spec.rb
+++ b/spec/components/public_shell_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::PublicShell do
+  include_context "component view context"
+
+  subject(:html) { described_class.new(user:).render_in(view_context) { "" } }
+
+  context "when logged out" do
+    let(:user) { nil }
+
+    it "links the logo to the landing page" do
+      expect(html).to include('<a href="/" class="flex items-center gap-2">')
+    end
+  end
+
+  context "when logged in" do
+    let(:user) { create(:user) }
+
+    it "links the logo to the servers dashboard" do
+      expect(html).to include('<a href="/servers" class="flex items-center gap-2">')
+    end
+  end
+end


### PR DESCRIPTION
## Problem
User report: logged out, going from the landing page to the TOS (or privacy) page leaves you stuck — the logo doesn't take you home. Same in the logged-in state.

Cause: the mascot + wordmark in `PublicShell` were bare markup, never wrapped in a link. `PublicShell` backs the landing page **and** the legal pages (TOS, privacy, imprint), so on any of those the logo did nothing.

## Fix
Wrap mascot + wordmark in an anchor, mirroring `AppShell#wordmark`:
- `/servers` when logged in
- `/` when logged out

`AppShell` (logged-in dashboard/config pages) already linked correctly — untouched.

## Tests
New `public_shell_spec.rb` asserts the logo anchor href in both auth states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)