### PR TITLE
Stop shrkbot double-posting its own kick/ban/timeout to the mod log

### DIFF
--- a/app/plugins/moderation/events/member_action_log.rb
+++ b/app/plugins/moderation/events/member_action_log.rb
@@ -23,6 +23,10 @@ module Moderation
 
     private
 
+    def performed_by_shrkbot?(moderator)
+      moderator&.id == event.bot.profile.id
+    end
+
     def loggable?
       raise AbstractMethodError, "#{self.class} must implement #loggable?"
     end

--- a/app/plugins/moderation/events/member_ban_log.rb
+++ b/app/plugins/moderation/events/member_ban_log.rb
@@ -8,17 +8,22 @@ module Moderation
     private
 
     def loggable?
-      true
+      !performed_by_shrkbot?(attribution&.moderator)
     end
 
     def entry
-      attribution = MemberLog::AuditLogLookup.attribution(event.server, action: :member_ban_add, target_id: event.user.id)
       MemberLog::ActivityEntry.build(
         event_key: :member_banned,
         target: event.user,
         moderator: attribution&.moderator,
         reason: attribution&.reason
       )
+    end
+
+    def attribution
+      return @attribution if defined?(@attribution)
+
+      @attribution = MemberLog::AuditLogLookup.attribution(event.server, action: :member_ban_add, target_id: event.user.id)
     end
   end
 end

--- a/app/plugins/moderation/events/member_kick_log.rb
+++ b/app/plugins/moderation/events/member_kick_log.rb
@@ -8,7 +8,7 @@ module Moderation
     private
 
     def loggable?
-      attribution.present?
+      attribution.present? && !performed_by_shrkbot?(attribution.moderator)
     end
 
     def entry

--- a/app/plugins/moderation/events/member_timeout_log.rb
+++ b/app/plugins/moderation/events/member_timeout_log.rb
@@ -8,7 +8,7 @@ module Moderation
     private
 
     def loggable?
-      member&.communication_disabled? && attribution.present? && first_sighting?
+      member&.communication_disabled? && attribution.present? && !performed_by_shrkbot?(attribution.moderator) && first_sighting?
     end
 
     def entry

--- a/app/plugins/moderation/events/spam_guard.rb
+++ b/app/plugins/moderation/events/spam_guard.rb
@@ -115,6 +115,10 @@ module Moderation
       )
       quoted = quoted_content
       body += "\n#{quoted}" if quoted
+      body += "\n" + PunishmentNote.line(
+        settings.punishment,
+        timeout_until: settings.punishment_timeout? ? Time.current + settings.timeout_seconds : nil
+      )
 
       Bot::ActivityLog.post(
         config,

--- a/app/plugins/moderation/image_scanning/verdict_executor.rb
+++ b/app/plugins/moderation/image_scanning/verdict_executor.rb
@@ -5,6 +5,8 @@ require "uri"
 module Moderation
   module ImageScanning
     class VerdictExecutor
+      Punishment = Data.define(:action, :timeout_until)
+
       def self.call(verdict:, context:, phash:, hash_state:, image_bytes: nil)
         new(verdict:, context:, phash:, hash_state:, image_bytes:).call
       end
@@ -20,7 +22,7 @@ module Moderation
       def call
         case verdict.action
         when :flag_for_review
-          flag(removed: false, punishment: "none")
+          flag(removed: false, punishment: no_punishment)
         when :remove
           delete_message if context.settings.action_delete?
           flag(removed: true, punishment: punish)
@@ -41,16 +43,24 @@ module Moderation
         settings = context.settings
         escalate = hash_state == :own_confirmed && settings.confirmed_punishment != "none"
         punishment = escalate ? settings.confirmed_punishment : settings.punishment
-        return "none" if punishment == "none"
+        return no_punishment if punishment == "none"
 
+        timeout_seconds = escalate ? settings.confirmed_timeout_seconds : settings.timeout_seconds
         Punisher.call(
           member: context.member,
           server: context.server,
           punishment:,
-          timeout_seconds: escalate ? settings.confirmed_timeout_seconds : settings.timeout_seconds,
+          timeout_seconds:,
           reason: I18n.t("moderation.image_scanning.punishment.reason")
         )
-        punishment
+        Punishment.new(
+          action: punishment,
+          timeout_until: (punishment == "timeout") ? Time.current + timeout_seconds : nil
+        )
+      end
+
+      def no_punishment
+        Punishment.new(action: "none", timeout_until: nil)
       end
 
       def flag(removed:, punishment:)
@@ -70,10 +80,10 @@ module Moderation
             author: "<@#{context.member.id}>",
             channel: "<##{context.channel_id}>",
             jump_url:
-          ) + "\n" + risk_line(state) + "\n" + reason_lines,
+          ) + "\n" + risk_line(state) + "\n" + reason_lines + "\n" + PunishmentNote.line(punishment.action, timeout_until: punishment.timeout_until),
           meta: I18n.t("moderation.image_scanning.flag.meta.#{state}"),
           image:,
-          components: message_components(punishment),
+          components: message_components(punishment.action),
           allowed_mentions: {parse: [], roles: StaffPing.allowed_roles(staff_role_id, ping:)}
         )
       end

--- a/app/plugins/moderation/punishment_note.rb
+++ b/app/plugins/moderation/punishment_note.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Moderation
+  module PunishmentNote
+    module_function
+
+    def line(punishment, timeout_until: nil)
+      case punishment
+      when "timeout"
+        I18n.t("moderation.punishment_note.timeout", until: "<t:#{timeout_until.to_i}:f>")
+      when "kick"
+        I18n.t("moderation.punishment_note.kick")
+      when "ban"
+        I18n.t("moderation.punishment_note.ban")
+      else
+        I18n.t("moderation.punishment_note.none")
+      end
+    end
+  end
+end

--- a/config/locales/moderation.en.yml
+++ b/config/locales/moderation.en.yml
@@ -70,6 +70,11 @@ en:
         not_in_server: That member isn't in the server, so there was nothing to clear.
         reversed_ban: Unbanned %{user}.
         reversed_timeout: Timeout cleared for %{user}.
+    punishment_note:
+      ban: User was banned.
+      kick: User was kicked.
+      none: No further action was taken.
+      timeout: User was timed out until %{until}.
     spam_protection:
       notification:
         body: "%{author} posted the same message in %{count} channels within %{window}

--- a/spec/plugins/moderation/events/member_ban_log_spec.rb
+++ b/spec/plugins/moderation/events/member_ban_log_spec.rb
@@ -8,13 +8,17 @@ RSpec.describe Moderation::MemberBanLog do
   let(:guild_id) { 111 }
   let(:user_id) { 222 }
 
+  let(:bot_user_id) { 999 }
+  let(:moderator_id) { 555 }
+
   let(:user) { double("user", id: user_id) }
   let(:server) { double("server", id: guild_id) }
-  let(:bot) { double("bot") }
+  let(:bot) { double("bot", profile: double("profile", id: bot_user_id)) }
   let(:event) { double("event", server:, user:, bot:) }
 
   let(:server_configuration) { double("server_configuration") }
-  let(:attribution) { double("attribution", moderator: double("mod"), reason: "spamming") }
+  let(:moderator) { double("mod", id: moderator_id) }
+  let(:attribution) { double("attribution", moderator:, reason: "spamming") }
   let(:built_entry) { {title: "Member banned", body: "body", meta: "meta"} }
 
   before do
@@ -56,6 +60,15 @@ RSpec.describe Moderation::MemberBanLog do
         bot:,
         **built_entry
       )
+    end
+  end
+
+  context "when shrkbot performed the ban" do
+    let(:moderator_id) { bot_user_id }
+
+    it "does not post" do
+      handle
+      expect(Bot::ActivityLog).not_to have_received(:post)
     end
   end
 

--- a/spec/plugins/moderation/events/member_kick_log_spec.rb
+++ b/spec/plugins/moderation/events/member_kick_log_spec.rb
@@ -8,13 +8,17 @@ RSpec.describe Moderation::MemberKickLog do
   let(:guild_id) { 111 }
   let(:user_id) { 222 }
 
+  let(:bot_user_id) { 999 }
+  let(:moderator_id) { 555 }
+
   let(:user) { double("user", id: user_id) }
   let(:server) { double("server", id: guild_id) }
-  let(:bot) { double("bot") }
+  let(:bot) { double("bot", profile: double("profile", id: bot_user_id)) }
   let(:event) { double("event", server:, user:, bot:) }
 
   let(:server_configuration) { double("server_configuration") }
-  let(:attribution) { double("attribution", moderator: double("mod"), reason: "rule break") }
+  let(:moderator) { double("mod", id: moderator_id) }
+  let(:attribution) { double("attribution", moderator:, reason: "rule break") }
   let(:built_entry) { {title: "Member kicked", body: "body", meta: "meta"} }
 
   before do
@@ -50,6 +54,15 @@ RSpec.describe Moderation::MemberKickLog do
 
   context "when attribution is nil" do
     before { allow(Moderation::MemberLog::AuditLogLookup).to receive(:attribution).and_return(nil) }
+
+    it "does not post" do
+      handle
+      expect(Bot::ActivityLog).not_to have_received(:post)
+    end
+  end
+
+  context "when shrkbot performed the kick" do
+    let(:moderator_id) { bot_user_id }
 
     it "does not post" do
       handle

--- a/spec/plugins/moderation/events/member_timeout_log_spec.rb
+++ b/spec/plugins/moderation/events/member_timeout_log_spec.rb
@@ -18,12 +18,15 @@ RSpec.describe Moderation::MemberTimeoutLog do
     )
   end
   let(:server) { double("server", id: guild_id) }
-  let(:bot) { double("bot") }
+  let(:bot_user_id) { 999 }
+  let(:moderator_id) { 555 }
+  let(:bot) { double("bot", profile: double("profile", id: bot_user_id)) }
   let(:event) { double("event", server:, user:, bot:) }
 
   let(:ledger) { double("ledger", first_sighting?: true) }
   let(:server_configuration) { double("server_configuration") }
-  let(:attribution) { double("attribution", moderator: double("mod"), reason: "misbehaving") }
+  let(:moderator) { double("mod", id: moderator_id) }
+  let(:attribution) { double("attribution", moderator:, reason: "misbehaving") }
   let(:built_entry) { {title: "Member timed out", body: "body", meta: "meta"} }
 
   before do
@@ -92,6 +95,20 @@ RSpec.describe Moderation::MemberTimeoutLog do
         bot:,
         **built_entry
       )
+    end
+  end
+
+  context "when shrkbot performed the timeout" do
+    let(:moderator_id) { bot_user_id }
+
+    it "does not post" do
+      handle
+      expect(Bot::ActivityLog).not_to have_received(:post)
+    end
+
+    it "does not consume the ledger slot" do
+      handle
+      expect(ledger).not_to have_received(:first_sighting?)
     end
   end
 

--- a/spec/plugins/moderation/events/spam_guard_spec.rb
+++ b/spec/plugins/moderation/events/spam_guard_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe Moderation::SpamGuard do
       action_purge?: action == "purge",
       punishment:,
       punishment_none?: punishment == "none",
+      punishment_timeout?: punishment == "timeout",
       timeout_seconds: 300,
       match_symbol_only_messages:
     )
@@ -162,6 +163,38 @@ RSpec.describe Moderation::SpamGuard do
 
       expect(body).to include("within 60 seconds")
       expect(body).to include("> hello world foo bar")
+    end
+
+    it "notes that no member punishment was taken when punishment is 'none'" do
+      body = nil
+      allow(Bot::Discord::Components).to receive(:send_to) do |_channel, rendered, **|
+        body = rendered[:components].first[:components].first[:content]
+      end
+
+      simulate_message(channel_id: 1, message_id: 10)
+      simulate_message(channel_id: 2, message_id: 20)
+      simulate_message(channel_id: 3, message_id: 30)
+
+      expect(body).to include("No further action was taken.")
+    end
+
+    context "when the punishment is a timeout" do
+      let(:punishment) { "timeout" }
+
+      before { allow(Moderation::Punisher).to receive(:call) }
+
+      it "notes the timeout with an absolute Discord timestamp" do
+        body = nil
+        allow(Bot::Discord::Components).to receive(:send_to) do |_channel, rendered, **|
+          body = rendered[:components].first[:components].first[:content]
+        end
+
+        simulate_message(channel_id: 1, message_id: 10)
+        simulate_message(channel_id: 2, message_id: 20)
+        simulate_message(channel_id: 3, message_id: 30)
+
+        expect(body).to match(/User was timed out until <t:\d+:f>\./)
+      end
     end
 
     context "when a followup message lands inside the hot window" do
@@ -495,6 +528,20 @@ RSpec.describe Moderation::SpamGuard do
       simulate_message(channel_id: 1, message_id: 1)
       simulate_message(channel_id: 2, message_id: 2)
       simulate_message(channel_id: 3, message_id: 3)
+    end
+
+    it "notes the kick in the notification body" do
+      allow(Moderation::Punisher).to receive(:call)
+      body = nil
+      allow(Bot::Discord::Components).to receive(:send_to) do |_channel, rendered, **|
+        body = rendered[:components].first[:components].first[:content]
+      end
+
+      simulate_message(channel_id: 1, message_id: 1)
+      simulate_message(channel_id: 2, message_id: 2)
+      simulate_message(channel_id: 3, message_id: 3)
+
+      expect(body).to include("User was kicked.")
     end
   end
 end

--- a/spec/plugins/moderation/image_scanning/verdict_executor_spec.rb
+++ b/spec/plugins/moderation/image_scanning/verdict_executor_spec.rb
@@ -482,6 +482,56 @@ RSpec.describe Moderation::ImageScanning::VerdictExecutor do
     end
   end
 
+  describe "punishment note in the body" do
+    context "when flagged for review with no action" do
+      let(:action) { :flag_for_review }
+
+      it "states that no further action was taken" do
+        execute
+
+        expect(Bot::ActivityLog).to have_received(:post) do |_config, kwargs|
+          expect(kwargs[:body]).to include("No further action was taken.")
+        end
+      end
+    end
+
+    context "when the member was kicked" do
+      let(:punishment) { "kick" }
+
+      it "states that the user was kicked" do
+        execute
+
+        expect(Bot::ActivityLog).to have_received(:post) do |_config, kwargs|
+          expect(kwargs[:body]).to include("User was kicked.")
+        end
+      end
+    end
+
+    context "when the member was banned" do
+      let(:punishment) { "ban" }
+
+      it "states that the user was banned" do
+        execute
+
+        expect(Bot::ActivityLog).to have_received(:post) do |_config, kwargs|
+          expect(kwargs[:body]).to include("User was banned.")
+        end
+      end
+    end
+
+    context "when the member was timed out" do
+      let(:punishment) { "timeout" }
+
+      it "states the timeout with an absolute Discord timestamp" do
+        execute
+
+        expect(Bot::ActivityLog).to have_received(:post) do |_config, kwargs|
+          expect(kwargs[:body]).to match(/User was timed out until <t:\d+:f>\./)
+        end
+      end
+    end
+  end
+
   context "when no staff role is configured" do
     let(:staff_role_id) { nil }
 

--- a/spec/plugins/moderation/punishment_note_spec.rb
+++ b/spec/plugins/moderation/punishment_note_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Moderation::PunishmentNote do
+  subject(:line) { described_class.line(punishment, timeout_until:) }
+
+  let(:timeout_until) { nil }
+
+  context "when the punishment is a timeout" do
+    let(:punishment) { "timeout" }
+    let(:timeout_until) { Time.at(1_700_000_000) }
+
+    it "renders an absolute Discord timestamp" do
+      expect(line).to eq("User was timed out until <t:1700000000:f>.")
+    end
+  end
+
+  context "when the member was kicked" do
+    let(:punishment) { "kick" }
+
+    it "states the kick" do
+      expect(line).to eq("User was kicked.")
+    end
+  end
+
+  context "when the member was banned" do
+    let(:punishment) { "ban" }
+
+    it "states the ban" do
+      expect(line).to eq("User was banned.")
+    end
+  end
+
+  context "when there is no punishment" do
+    let(:punishment) { "none" }
+
+    it "states that no further action was taken" do
+      expect(line).to eq("No further action was taken.")
+    end
+  end
+end


### PR DESCRIPTION
## What

shrkbot's moderation activity log listens for Discord ban/kick/timeout events and posts an entry attributed to the audit-log executor. But shrkbot only ever performs those actions itself as part of **image scanning** and the **cross-channel spam guard** — and both modules already post their own log entry. Result: every automated punishment was logged **twice**.

This PR:
1. **Skips the mod-log entry when the audit-log executor is shrkbot** (`event.bot.profile.id`). Actions by human moderators (or other bots) still log as before.
2. **Makes the modules' own entries state the punishment taken**, since the mod-log entry was previously the only place the action was spelled out:
   - none → "No further action was taken."
   - kick / ban → "User was kicked/banned."
   - timeout → "User was timed out until \<absolute Discord timestamp\>."

   via a shared `Moderation::PunishmentNote` helper (image scanning + spam guard).

## Notes

- No new data stored → no privacy-policy / GDPR changes.
- Convention review run; findings adjudicated (one accepted, rest rejected with reasoning — e.g. a sub-second timestamp drift in the timeout note that is invisible at `<t:…:f>` minute resolution and would need a `Punisher` signature change to eliminate everywhere).

## Tests

`rspec` (1890 examples), `standardrb`, `active_record_doctor`, `i18n-tasks missing`/`check-normalized`, and `undercover` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)