### PR TITLE
Surface report-as-scam as an info callout on the image scanning page

### DIFF
--- a/app/components/moderation/image_scanning_form.rb
+++ b/app/components/moderation/image_scanning_form.rb
@@ -10,11 +10,11 @@ class Components::Moderation::ImageScanningForm < Components::Base
     div(id: "image_scanning-config", class: "flex flex-col gap-5") do
       enable_error_callout
       consent_callout
+      report_scam_callout
       sensitivity_card
       custom_keywords_card
       response_card
       image_explainer
-      report_scam_hint
     end
   end
 
@@ -31,6 +31,15 @@ class Components::Moderation::ImageScanningForm < Components::Base
       div do
         p(class: "font-semibold") { t(".consent.title") }
         p(class: "mt-1") { t(".consent.body") }
+      end
+    end
+  end
+
+  def report_scam_callout
+    render Components::Callout.new(variant: :info) do
+      div do
+        p(class: "font-semibold") { t(".report_scam.title") }
+        p(class: "mt-1") { t(".report_scam.body") }
       end
     end
   end
@@ -184,13 +193,6 @@ class Components::Moderation::ImageScanningForm < Components::Base
     p(class: "flex items-start gap-2.5 text-sm text-text-secondary") do
       render Components::Icon.new(icon, class: "size-4 mt-0.5 text-text-muted flex-none")
       span { text }
-    end
-  end
-
-  def report_scam_hint
-    p(class: "mt-2 flex items-center gap-1.5 text-xs text-text-muted") do
-      render Components::Icon.new("terminal-window", class: "size-4")
-      span { t(".report_scam_hint") }
     end
   end
 

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -114,8 +114,11 @@ en:
           line_staff: Staff confirm or dismiss every flag with buttons in your log
             channel.
           title: How image scanning works
-        report_scam_hint: You can report any message with images as a scam by right-clicking
-          it → Apps → shrkbot → Report as scam.
+        report_scam:
+          body: Anyone with the staff role can right-click any message with images
+            -> Apps -> shrkbot -> Report as scam. Works whether or not automated scanning
+            catches it.
+          title: Report a scam yourself
         response:
           action:
             delete: Delete the image

--- a/spec/components/moderation/image_scanning_form_spec.rb
+++ b/spec/components/moderation/image_scanning_form_spec.rb
@@ -88,7 +88,8 @@ RSpec.describe Components::Moderation::ImageScanningForm do
     expect(html).to include('data-dropdown-target="menu"')
   end
 
-  it "renders the report-as-scam hint" do
+  it "renders the report-as-scam callout" do
+    expect(html).to include("Report a scam yourself")
     expect(html).to include("Report as scam")
   end
 


### PR DESCRIPTION
## What

The manual "Report as scam" action was only mentioned in a tiny footer at the bottom of the Image Scanning config page. This promotes it to an `:info` callout directly under the "Before you turn this on" consent warning, where users are already reading about how detection works.

## Changes

- `Components::Moderation::ImageScanningForm`: dropped the `report_scam_hint` footer paragraph, added a `report_scam_callout` (info variant, title + body) rendered right after the consent callout.
- `web.en.yml`: `report_scam_hint` string replaced with a `report_scam` `title`/`body` pair. Copy notes it's staff-gated and works regardless of automated scanning; ASCII arrows.
- Spec updated to assert the new callout title.

## Gates

rspec, standardrb, i18n-tasks (missing + normalized), undercover — all green.