### PR TITLE
Tune scam weights and retain phashes for 180 days

### DIFF
--- a/app/operations/moderation/phashes/prune.rb
+++ b/app/operations/moderation/phashes/prune.rb
@@ -5,7 +5,7 @@ module Ops
     module Phashes
       class Prune < ApplicationOperation
         def call
-          old = ::Moderation::Phash.where(last_seen_at: ...30.days.ago).where(global_scam: false)
+          old = ::Moderation::Phash.where(last_seen_at: ...180.days.ago).where(global_scam: false)
           ::Moderation::PhashConfirmation.where(phash_id: old.select(:id)).delete_all
           old.delete_all
           ::Moderation::Phash.where.missing(:phash_confirmations).where(global_scam: false).delete_all

--- a/app/plugins/moderation/image_scanning/scam_rules.rb
+++ b/app/plugins/moderation/image_scanning/scam_rules.rb
@@ -5,17 +5,20 @@ module Moderation
     module ScamRules
       RULES = [
         {pattern: "tuzawin", weight: 3, regex: false},
+        {pattern: "atomage.cc", weight: 3, regex: false},
         {pattern: "5[\\s,]?600", weight: 3, regex: true},
+        {pattern: "2[\\s,]?500 bonus", weight: 3, regex: true},
         {pattern: "cryptocurrency", weight: 3, regex: false},
+        {pattern: "crypto casino", weight: 3, regex: false},
         {pattern: "promo code", weight: 3, regex: false},
-        {pattern: "withdraw", weight: 3, regex: false},
         {pattern: "usdt", weight: 3, regex: false},
         {pattern: "withdrawal success", weight: 3, regex: false},
         {pattern: "tether", weight: 3, regex: false},
         {pattern: "vyro", weight: 2, regex: false},
         {pattern: "casino", weight: 2, regex: false},
         {pattern: "wallet address", weight: 2, regex: false},
-        {pattern: "receive usdt", weight: 2, regex: false}
+        {pattern: "receive usdt", weight: 2, regex: false},
+        {pattern: "withdraw", weight: 2, regex: false}
       ].freeze
     end
   end

--- a/config/locales/legal.en.yml
+++ b/config/locales/legal.en.yml
@@ -105,12 +105,12 @@ en:
         images a server's moderators explicitly confirm as scams, together with which
         servers confirmed them. These fingerprints are never linked to the user who
         posted the image, are deleted when every confirming server has removed the
-        bot, and are pruned automatically after 30 days without a match. The bot owner
-        may also mark images as global scams; their perceptual hashes are stored indefinitely
-        as a cross-server blocklist and are treated the same as scams a server's own
-        moderators confirmed, so a match can trigger that server's configured action
-        (flagging, removal, and any punishment). These hashes are not linked to any
-        user or server.
+        bot, and are pruned automatically after 180 days without a match. The bot
+        owner may also mark images as global scams; their perceptual hashes are stored
+        indefinitely as a cross-server blocklist and are treated the same as scams
+        a server's own moderators confirmed, so a match can trigger that server's
+        configured action (flagging, removal, and any punishment). These hashes are
+        not linked to any user or server.
       not_h: What we don't do
       not_p: We don't sell data, we don't advertise, we don't profile you, we don't
         run analytics, and we don't store your servers' member lists or conversations.
@@ -122,7 +122,7 @@ en:
       retention_infra: Caches, background-job records and logs are cleared automatically
         (at most 60 days, 30 days and briefly, respectively). Deleted data also drops
         out of database backups as they rotate.
-      retention_phash: 'Confirmed scam-image fingerprints: pruned 30 days after they
+      retention_phash: 'Confirmed scam-image fingerprints: pruned 180 days after they
         were last matched, and removed once every server that confirmed them has removed
         the bot. Global scam fingerprints set by the bot owner are retained indefinitely.'
       retention_reminders: 'Reminders: deleted once delivered, or earlier if you delete

--- a/spec/operations/moderation/phashes/prune_spec.rb
+++ b/spec/operations/moderation/phashes/prune_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe Ops::Moderation::Phashes::Prune do
   subject(:result) { described_class.call }
 
-  let!(:stale_phash) { create(:phash, last_seen_at: 31.days.ago) }
-  let!(:stale_confirmed_phash) { create(:phash, last_seen_at: 40.days.ago) }
+  let!(:stale_phash) { create(:phash, last_seen_at: 181.days.ago) }
+  let!(:stale_confirmed_phash) { create(:phash, last_seen_at: 200.days.ago) }
   let!(:fresh_orphan) { create(:phash, last_seen_at: 1.day.ago) }
   let!(:fresh_confirmed_phash) { create(:phash, last_seen_at: 1.day.ago) }
 
@@ -15,7 +15,7 @@ RSpec.describe Ops::Moderation::Phashes::Prune do
     create(:phash_confirmation, phash: fresh_confirmed_phash)
   end
 
-  it "deletes phashes not matched in 30 days and their confirmations" do
+  it "deletes phashes not matched in 180 days and their confirmations" do
     result
     expect(Moderation::Phash.exists?(stale_phash.id)).to be(false)
     expect(Moderation::Phash.exists?(stale_confirmed_phash.id)).to be(false)

--- a/spec/plugins/moderation/image_scanning/classifier_spec.rb
+++ b/spec/plugins/moderation/image_scanning/classifier_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Moderation::ImageScanning::Classifier do
       end
 
       context "score 5" do
-        let(:ocr_text) { "casino withdraw" }
+        let(:ocr_text) { "casino tuzawin" }
 
         it "flags at threshold" do
           expect(verdict.action).to eq(:flag_for_review)
@@ -71,7 +71,7 @@ RSpec.describe Moderation::ImageScanning::Classifier do
       end
 
       context "score 8" do
-        let(:ocr_text) { "casino withdraw tuzawin" }
+        let(:ocr_text) { "casino tuzawin promo code" }
 
         it "removes at threshold" do
           expect(verdict.action).to eq(:remove)
@@ -99,7 +99,7 @@ RSpec.describe Moderation::ImageScanning::Classifier do
       end
 
       context "score 6" do
-        let(:ocr_text) { "withdraw tuzawin" }
+        let(:ocr_text) { "tuzawin promo code" }
 
         it "removes at threshold" do
           expect(verdict.action).to eq(:remove)
@@ -127,7 +127,7 @@ RSpec.describe Moderation::ImageScanning::Classifier do
       end
 
       context "score 5" do
-        let(:ocr_text) { "casino withdraw" }
+        let(:ocr_text) { "casino tuzawin" }
 
         it "removes above threshold" do
           expect(verdict.action).to eq(:remove)


### PR DESCRIPTION
Two small moderation tweaks.

## Scam keyword weights
Adjusting to a new scam wave:
- Add `atomage.cc`, `crypto casino` (weight 3), `2,500 bonus` regex (weight 3).
- Drop `withdraw` from 3 to 2 — it fires too readily on its own in legitimate messages; still contributes, just needs corroboration.
- Classifier threshold specs rebuilt so each `score N` context still sums to N under the new weights (they use real keywords as score building-blocks).

## phash retention: 30 → 180 days
Scams can go quiet for a month or more. A 30-day prune window threw away confirmed fingerprints before the scam came back, losing all the moderator confirmation work. Bumped to 180 days.

- `Ops::Moderation::Phashes::Prune` window 30 → 180 days.
- Privacy policy (`legal.en.yml`) updated to state 180 days in both places; "Last updated" already today.
- Global-scam fingerprints unchanged (still indefinite).

Gates green locally: rspec (1890), standardrb, active_record_doctor, i18n-tasks missing/check-normalized, undercover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)