### PR TITLE
Scope global-scam toggle to owner guild

### DIFF
--- a/app/plugins/moderation/commands/toggle_global_scam.rb
+++ b/app/plugins/moderation/commands/toggle_global_scam.rb
@@ -4,7 +4,7 @@ module Moderation
   class ToggleGlobalScam < Bot::BaseCommand
     command_name "Toggle global scam block"
     command_type :message
-    register_in :guild
+    register_in :owner_guild
     plugin :image_scanning
     owner_only true
 


### PR DESCRIPTION
## What
The "Toggle global scam block" message context-menu command was registered in every guild (`register_in :guild`), so every member saw it. `owner_only` only gates *execution*, so non-owners saw the entry and got an "you don't have permission" rejection — a poor experience.

Discord has no per-user command visibility (only guild-scope or `default_member_permissions`, which is role/permission-based). So the command is now registered in the owner guild only (`register_in :owner_guild`), matching `Bot::Commands::Announce`.

## Tradeoff
The command now only appears in the owner guild — global-scam phashes can only be toggled on images present there. Acceptable for an owner-only tool; a future owner-only website upload page could lift this.

## Testing
- `rspec spec/plugins/moderation/commands/toggle_global_scam_spec.rb` — 8 examples, 0 failures
- standardrb, active_record_doctor, undercover — clean