### PR TITLE
Verify submitted channel snowflakes belong to the guild

### DIFF
--- a/app/controllers/concerns/verifies_guild_channels.rb
+++ b/app/controllers/concerns/verifies_guild_channels.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module VerifiesGuildChannels
+  extend ActiveSupport::Concern
+
+  private
+
+  def guild_channels?(*channel_ids)
+    ids = channel_ids.flatten.compact_blank.map(&:to_s).uniq
+    ids.empty? || @server_configuration.server_channels.where(discord_id: ids).count == ids.size
+  end
+end

--- a/app/controllers/servers/logging_controller.rb
+++ b/app/controllers/servers/logging_controller.rb
@@ -3,6 +3,7 @@
 class Servers::LoggingController < ApplicationController
   include RequiresManageableServer
   include ConfiguresPlugin
+  include VerifiesGuildChannels
 
   def show
     render Views::Servers::Logging::Show.new(
@@ -13,6 +14,8 @@ class Servers::LoggingController < ApplicationController
   end
 
   def update
+    return head :not_found unless guild_channels?(logging_params[:channel_id])
+
     result = Ops::Logging::Configure.call(
       server_configuration: @server_configuration,
       channel_id: logging_params[:channel_id],

--- a/app/controllers/servers/roles_controller.rb
+++ b/app/controllers/servers/roles_controller.rb
@@ -3,6 +3,7 @@
 class Servers::RolesController < ApplicationController
   include RequiresManageableServer
   include ConfiguresPlugin
+  include VerifiesGuildChannels
 
   def show
     render Views::Servers::Roles::Show.new(
@@ -13,6 +14,8 @@ class Servers::RolesController < ApplicationController
   end
 
   def update
+    return head :not_found unless guild_channels?(roles_params[:channel_id], submitted_channel_overrides)
+
     result = Ops::Roles::Configure.call(
       server_configuration: @server_configuration,
       channel_id: roles_params[:channel_id],
@@ -39,6 +42,10 @@ class Servers::RolesController < ApplicationController
     raw = roles_params[:role_sets]
     list = raw.respond_to?(:values) ? raw.values : Array(raw)
     list.map { |set| set.to_h.symbolize_keys }
+  end
+
+  def submitted_channel_overrides
+    submitted_sets.filter_map { |set| set[:channel_override] }
   end
 
   def roles_params

--- a/app/controllers/servers/welcomes_controller.rb
+++ b/app/controllers/servers/welcomes_controller.rb
@@ -3,6 +3,7 @@
 class Servers::WelcomesController < ApplicationController
   include RequiresManageableServer
   include ConfiguresPlugin
+  include VerifiesGuildChannels
 
   def show
     render Views::Servers::Welcomes::Show.new(
@@ -13,6 +14,8 @@ class Servers::WelcomesController < ApplicationController
   end
 
   def update
+    return head :not_found unless guild_channels?(welcomes_params[:channel_id])
+
     result = Ops::Welcomes::Configure.call(
       server_configuration: @server_configuration,
       channel_id: welcomes_params[:channel_id],

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -93,6 +93,14 @@ and the web app, so a given mutation is written once and called from both.
   cached set and sets `@server_configuration`. The check reads the session instead
   of re-hitting Discord's rate-limited guild-list endpoint, and is not spoofable
   (server-signed session).
+- **Snowflakes submitted from the web are scoped to the guild in the controller.**
+  A channel/role id posted by a user is untrusted input: the controller verifies it
+  belongs to `@server_configuration` (e.g. `VerifiesGuildChannels#guild_channels?`
+  against `server_channels`) and returns 404 on a foreign reference, before handing
+  the value to the op. Ops trust the values they receive — scoping is the caller's
+  job (same anti-spoofing rule as loading records). Assignability *rules* beyond mere
+  ownership (managed/above-bot role filtering in `Roles::AssignableServerRoles`) stay
+  in the op as business logic.
 - **Re-authentication is localized to the guild-fetch seam.** The user's Discord
   token is used in exactly one place — `Bot::Discord::UserGuilds.call`, from
   `ServersController` (picker + dashboard) — so token-expiry handling (`rescue_from

--- a/spec/requests/logging_config_spec.rb
+++ b/spec/requests/logging_config_spec.rb
@@ -110,6 +110,13 @@ RSpec.describe "Logging config", type: :request do
           expect(response).to redirect_to(server_logging_path(guild.id))
           expect(flash[:alert]).to be_present
         end
+
+        it "rejects a channel from another server with 404" do
+          patch server_logging_path(guild.id),
+            params: {logging: {channel_id: 424242, enabled: "1", actions: {}}},
+            **turbo
+          expect(response).to have_http_status(:not_found)
+        end
       end
     end
   end

--- a/spec/requests/roles_config_spec.rb
+++ b/spec/requests/roles_config_spec.rb
@@ -120,6 +120,26 @@ RSpec.describe "Roles config", type: :request do
           expect(response).to redirect_to(server_roles_path(guild.id))
           expect(flash[:alert]).to be_present
         end
+
+        it "rejects a channel from another server with 404" do
+          patch server_roles_path(guild.id),
+            params: {roles: {channel_id: 424242, enabled: "1", role_sets: {}}},
+            **turbo
+          expect(response).to have_http_status(:not_found)
+        end
+
+        it "rejects a role set channel_override from another server with 404" do
+          patch server_roles_path(guild.id),
+            params: {
+              roles: {
+                channel_id: 111,
+                enabled: "1",
+                role_sets: {"0" => {name: "Pings", selection_mode: "multi", channel_override: 424242, role_ids: ["222"]}}
+              }
+            },
+            **turbo
+          expect(response).to have_http_status(:not_found)
+        end
       end
     end
   end

--- a/spec/requests/welcomes_config_spec.rb
+++ b/spec/requests/welcomes_config_spec.rb
@@ -131,6 +131,13 @@ RSpec.describe "Welcomes config", type: :request do
           expect(response).to redirect_to(server_welcomes_path(guild.id))
           expect(flash[:alert]).to be_present
         end
+
+        it "rejects a channel from another server with 404" do
+          patch server_welcomes_path(guild.id),
+            params: {welcomes: {channel_id: 424242, join_message: "hi", leave_message: "", enabled: "1"}},
+            **turbo
+          expect(response).to have_http_status(:not_found)
+        end
       end
     end
   end


### PR DESCRIPTION
## What
Security fix (found in a security audit). Web config forms for the **logging**, **welcomes**, and **roles** plugins submit a raw Discord channel snowflake. Nothing verified the channel belongs to the guild being configured. Because the bot resolves channel IDs **globally** across every guild it is in (`bot.channel(id)`), a guild admin could set their log/welcome/role-menu channel to a channel ID in *any other server sharing the bot* — a cross-tenant write (log entries with user mentions, welcome messages, and role menus posted into a server the attacker isn't even in), bounded only by the bot's send perms there.

The sibling `role_ids` input was already tenant-checked (`AssignableServerRoles`); channels were just missed.

## Fix
Scope submitted channel snowflakes to the guild **in the controller** — authorization/scoping is the caller's job; ops trust the values they receive (per `docs/architecture.md`). A shared `VerifiesGuildChannels` concern checks `channel_id` (and role-set `channel_override`s) against `@server_configuration.server_channels`, returning `404` on a foreign reference. Blank (channel-cleared) stays allowed.

## Notes
- The unused `Ops::*::Settings::Update` and `Ops::Roles::Sets::{Create,Update}` ops also take unvalidated channels but have **zero callers** (dead code, no attack surface) — flagged separately for deletion, not touched here.
- Documented the scoping convention in `docs/architecture.md`.

## Tests
Added foreign-channel → 404 request specs for all three controllers (incl. a foreign `channel_override` case for roles). Full suite green (1894 examples), standardrb / active_record_doctor / undercover clean.