### PR TITLE
Restrict reminder mentions to the recipient; bound duration

### DIFF
--- a/app/jobs/reminders/deliver_job.rb
+++ b/app/jobs/reminders/deliver_job.rb
@@ -27,7 +27,7 @@ module Reminders
         nil,
         nil,
         nil,
-        nil,
+        {parse: [], users: [reminder.user_id]},
         nil,
         rendered[:components],
         rendered[:flags]

--- a/app/operations/reminders/create.rb
+++ b/app/operations/reminders/create.rb
@@ -3,6 +3,8 @@
 module Ops
   module Reminders
     class Create < ApplicationOperation
+      MAX_DURATION = 100.years
+
       receives :user_id, :channel_id, :message, :duration
       receives :server_id, optional: true
       receives :deliver_via_dm, default: false
@@ -10,6 +12,7 @@ module Ops
       def call
         span = ::Reminders::Duration.parse(duration)
         return failure(I18n.t("operations.reminders.invalid_duration")) unless span
+        return failure(I18n.t("operations.reminders.duration_too_long")) if span > MAX_DURATION
         return failure(I18n.t("operations.reminders.message_required")) if message.blank?
 
         remind_at = Time.current + span

--- a/config/locales/operations.en.yml
+++ b/config/locales/operations.en.yml
@@ -14,6 +14,7 @@ en:
     plugin_activation:
       requires_settings: requires the plugin's settings to be configured first
     reminders:
+      duration_too_long: That's too far in the future for a reminder.
       invalid_duration: I couldn't understand that duration. Try something like `1d2h30m`.
       message_required: A reminder needs a message.
     roles:

--- a/spec/jobs/reminders/deliver_job_spec.rb
+++ b/spec/jobs/reminders/deliver_job_spec.rb
@@ -17,10 +17,11 @@ RSpec.describe Reminders::DeliverJob do
 
   context "in a channel" do
     it "posts the reminder as a branded container and then deletes it" do
-      expect(Discordrb::API::Channel).to receive(:create_message) do |token, channel_id, content, _tts, _embeds, _nonce, _attachments, _allowed_mentions, _message_reference, components, flags|
+      expect(Discordrb::API::Channel).to receive(:create_message) do |token, channel_id, content, _tts, _embeds, _nonce, _attachments, allowed_mentions, _message_reference, components, flags|
         expect(token).to eq("Bot tok")
         expect(channel_id).to eq(20)
         expect(content).to be_nil
+        expect(allowed_mentions).to eq({parse: [], users: [10]})
         expect(flags).to eq(Bot::Discord::Components::COMPONENTS_V2)
         body = components.first[:components].first[:content]
         expect(body).to include("<@10>")

--- a/spec/operations/reminders/create_spec.rb
+++ b/spec/operations/reminders/create_spec.rb
@@ -49,4 +49,16 @@ RSpec.describe Ops::Reminders::Create do
       expect(result.failure?).to be(true)
     end
   end
+
+  context "with a duration beyond the maximum" do
+    let(:duration) { "6000w" }
+
+    it "fails without creating or scheduling" do
+      expect {
+        expect { result }.not_to change(Reminders::Reminder, :count)
+      }.not_to have_enqueued_job(Reminders::DeliverJob)
+
+      expect(result.failure?).to be(true)
+    end
+  end
 end


### PR DESCRIPTION
## What
Security fix (from the audit). `Reminders::DeliverJob` called `create_message` with `allowed_mentions = nil`, so Discord parsed **every** mention in the user-supplied reminder body. `Reminders::Sanitizer` only zero-width-splits `@everyone`/`@here` — it does **not** neutralise `<@userid>` or `<@&roleid>`.

Any non-privileged user could set a channel-delivered reminder whose text contains `<@victim>` (always pings) or `<@&role>` (pings if the bot can mention roles), producing bot-attributed ping spam. Every other send path in the app already suppresses mentions (`ActivityLog` `SUPPRESS_MENTIONS`, staff pings' `{parse: [], roles: […]}`) — reminders was the lone exception.

## Fix
- Pass `allowed_mentions: {parse: [], users: [reminder.user_id]}` (8th positional arg of `create_message`) so only the person being reminded is pinged — the leading `<@user>` stays intentional, the body cannot ping anyone else.
- Cap the parsed duration (`MAX_DURATION = 100.years`) in `Ops::Reminders::Create` so a reminder can't be scheduled far enough out to overflow the timestamp. This is a sanity/overflow bound, not a taste cap — 100 years is well beyond any real use.

## Tests
Job spec now asserts the restricted `allowed_mentions`; op spec rejects an over-long duration without creating/scheduling. Full suite green, standardrb / i18n-tasks / undercover clean.