### PR TITLE
Re-verify server management against live Discord

### DIFF
--- a/app/controllers/concerns/discord_reauth.rb
+++ b/app/controllers/concerns/discord_reauth.rb
@@ -16,7 +16,11 @@ module DiscordReauth
     end
 
     session[:reauth_attempted] = true
-    session[:return_to] = request.get? ? request.fullpath : servers_path
+    session[:return_to] = replayable_request? ? request.fullpath : servers_path
     render Views::Reauth.new
+  end
+
+  def replayable_request?
+    request.get? || request.head?
   end
 end

--- a/app/controllers/concerns/discord_reauth.rb
+++ b/app/controllers/concerns/discord_reauth.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module DiscordReauth
+  extend ActiveSupport::Concern
+
+  included do
+    rescue_from Bot::Discord::UserGuilds::Unauthorized, with: :reauthenticate
+  end
+
+  private
+
+  def reauthenticate
+    if session[:reauth_attempted]
+      reset_session
+      return redirect_to(root_path, alert: t("sessions.reauth_failed"))
+    end
+
+    session[:reauth_attempted] = true
+    session[:return_to] = request.get? ? request.fullpath : servers_path
+    render Views::Reauth.new
+  end
+end

--- a/app/controllers/concerns/requires_manageable_server.rb
+++ b/app/controllers/concerns/requires_manageable_server.rb
@@ -4,6 +4,7 @@ module RequiresManageableServer
   extend ActiveSupport::Concern
 
   include SetsManageableServers
+  include DiscordReauth
 
   included do
     before_action :require_manageable_server
@@ -14,9 +15,24 @@ module RequiresManageableServer
 
   def require_manageable_server
     @server_configuration = ServerConfiguration.find_by(discord_id: params[:server_id])
-    return if @server_configuration && manageable_server?(params[:server_id])
+    return if @server_configuration && manageable_now?(params[:server_id])
 
     redirect_to servers_path, alert: t("servers.not_found")
+  end
+
+  def manageable_now?(discord_id)
+    live_manageable_ids.include?(discord_id.to_i)
+  end
+
+  def live_manageable_ids
+    ids = ManageableServers.for(session[:discord_token]).map(&:id)
+    remember_manageable_servers(ServerConfiguration.configured_ids_among(ids))
+    session.delete(:reauth_attempted)
+    ids
+  rescue Bot::Discord::UserGuilds::Unauthorized
+    raise
+  rescue Bot::Discord::UserGuilds::Error
+    manageable_server_ids
   end
 
   def server_switcher
@@ -24,9 +40,5 @@ module RequiresManageableServer
       discord_id: params[:server_id].to_i,
       manageable_ids: manageable_server_ids
     )
-  end
-
-  def manageable_server?(discord_id)
-    manageable_server_ids.include?(discord_id.to_i)
   end
 end

--- a/app/controllers/concerns/requires_manageable_server.rb
+++ b/app/controllers/concerns/requires_manageable_server.rb
@@ -25,7 +25,7 @@ module RequiresManageableServer
   end
 
   def live_manageable_ids
-    ids = ManageableServers.for(session[:discord_token]).map(&:id)
+    ids = ManageableServers.cached_for(session[:discord_token]).map(&:id)
     remember_manageable_servers(ServerConfiguration.configured_ids_among(ids))
     session.delete(:reauth_attempted)
     ids

--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -6,7 +6,8 @@ class ServersController < ApplicationController
   before_action :load_dashboard, only: :show
 
   rescue_from Bot::Discord::UserGuilds::Error, with: :render_error
-  rescue_from Bot::Discord::UserGuilds::Unauthorized, with: :reauthenticate
+
+  include DiscordReauth
 
   def index
     manageable = ManageableServers.for(session[:discord_token])
@@ -49,13 +50,6 @@ class ServersController < ApplicationController
     @server_configuration = result.server_configuration
     @configured_servers = result.configured_servers
     @plugin_counts = result.plugin_counts
-  end
-
-  def reauthenticate
-    return render_error if session[:reauth_attempted]
-
-    session[:reauth_attempted] = true
-    render Views::Reauth.new
   end
 
   def render_error

--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -10,7 +10,7 @@ class ServersController < ApplicationController
   include DiscordReauth
 
   def index
-    manageable = ManageableServers.for(session[:discord_token])
+    manageable = ManageableServers.cached_for(session[:discord_token])
     session.delete(:reauth_attempted)
     configured = ServerConfiguration.configured_ids_among(manageable.map(&:id))
     remember_manageable_servers(configured)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,9 +6,11 @@ class SessionsController < ApplicationController
   def create
     auth = request.env["omniauth.auth"]
     user = User.from_omniauth(auth)
+    destination = session.delete(:return_to) || servers_path
     session[:user_id] = user.id
     session[:discord_token] = auth.credentials.token
-    redirect_to servers_path, notice: t("sessions.signed_in", name: user.display_name)
+    session.delete(:reauth_attempted)
+    redirect_to destination, notice: t("sessions.signed_in", name: user.display_name)
   end
 
   def destroy

--- a/app/presenters/manageable_servers.rb
+++ b/app/presenters/manageable_servers.rb
@@ -1,9 +1,23 @@
 # frozen_string_literal: true
 
+require "digest"
+
 class ManageableServers
+  CACHE_TTL = 30.seconds
+
   def self.for(discord_token)
     Bot::Discord::UserGuilds.call(discord_token)
       .select(&:manageable?)
       .sort_by { |server| -server.member_count.to_i }
+  end
+
+  def self.cached_for(discord_token)
+    Rails.cache.fetch(cache_key(discord_token), expires_in: CACHE_TTL) do
+      self.for(discord_token)
+    end
+  end
+
+  def self.cache_key(discord_token)
+    "manageable_guilds:#{Digest::SHA256.hexdigest(discord_token.to_s)}"
   end
 end

--- a/app/presenters/server_dashboard.rb
+++ b/app/presenters/server_dashboard.rb
@@ -24,7 +24,7 @@ class ServerDashboard
   private
 
   def live
-    manageable = ManageableServers.for(@discord_token)
+    manageable = ManageableServers.cached_for(@discord_token)
     server = manageable.find { |candidate| candidate.id == @target_id }
     config = ServerConfiguration.find_by(discord_id: @target_id) if server
     return unless server && config

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -384,6 +384,7 @@ en:
       saved: Welcomes settings saved.
   sessions:
     failed: Sign-in failed or was canceled.
+    reauth_failed: We couldn't refresh your Discord sign-in. Please sign in again.
     signed_in: Signed in as %{name}.
     signed_out: Signed out.
   views:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -85,24 +85,28 @@ and the web app, so a given mutation is written once and called from both.
 - **Server-scoped authorization** lives in two concerns, not in individual
   controllers. We don't persist which servers a user manages (it's a Discord fact,
   fetched per the metadata-sync design, not a DB relationship), so authorization is
-  cached in the signed session. `SetsManageableServers` (included by the picker and
-  dashboard) exposes `remember_manageable_servers`, called after proving
-  manageability via Discord. `RequiresManageableServer` (included by every
-  server-scoped controller) **applies `before_action :require_manageable_server`
-  on include** — so a controller can't forget to authorize — which checks the
-  cached set and sets `@server_configuration`. The check reads the session instead
-  of re-hitting Discord's rate-limited guild-list endpoint, and is not spoofable
-  (server-signed session).
-- **Re-authentication is localized to the guild-fetch seam.** The user's Discord
-  token is used in exactly one place — `Bot::Discord::UserGuilds.call`, from
-  `ServersController` (picker + dashboard) — so token-expiry handling (`rescue_from
-  Bot::Discord::UserGuilds::Unauthorized` → re-auth, `::Error` → error state) lives
-  there, not in `ApplicationController`. Everything else reads our own DB and
-  authorizes from the session cache, so an expired token elsewhere is harmless;
-  stale-cache cases redirect to the picker, which is where re-auth runs. **If a
-  second page ever fetches from Discord with the user token, revisit this**: extract
-  a shared `DiscordReauth` concern and add return-to-URL plumbing (so re-auth sends
-  the user back where they were) rather than always landing on the picker.
+  re-verified against live Discord on every server-scoped request.
+  `SetsManageableServers` (included by the picker, dashboard, and
+  `RequiresManageableServer`) exposes `remember_manageable_servers`/
+  `manageable_server_ids`, the session-cached fallback. `RequiresManageableServer`
+  (included by every server-scoped controller) **applies `before_action
+  :require_manageable_server` on include** — so a controller can't forget to
+  authorize — which calls `ManageableServers.for` fresh (`#live_manageable_ids`) and
+  sets `@server_configuration`. A demoted admin loses access on their very next
+  request rather than up to two weeks later. Discord being unreachable
+  (`UserGuilds::Error`) falls back to the session cache rather than locking admins
+  out during an outage; a bad/expired token (`UserGuilds::Unauthorized`) is not
+  caught here — it propagates to `DiscordReauth`.
+- **Re-authentication is centralized in the `DiscordReauth` concern**, included by
+  both `ServersController` and `RequiresManageableServer` (every server-scoped
+  controller), since the user's Discord token is now read on every server-scoped
+  request, not just the picker/dashboard. It `rescue_from`s
+  `Bot::Discord::UserGuilds::Unauthorized`, stashes the current path in
+  `session[:return_to]`, and renders `Views::Reauth`; a second consecutive failure
+  resets the session and bounces to the root page. `SessionsController#create`
+  redirects to `session[:return_to]` (falling back to the picker) and clears the
+  reauth flag, so re-auth returns the user to where they were instead of always
+  landing on the picker.
 - **Turbo Stream responses live in a view template**, not in controller helpers —
   the standard Rails `action.turbo_stream.erb` (e.g.
   `app/views/servers/plugins/update.turbo_stream.erb`). The controller sets its

--- a/spec/presenters/manageable_servers_spec.rb
+++ b/spec/presenters/manageable_servers_spec.rb
@@ -30,4 +30,40 @@ RSpec.describe ManageableServers do
       expect(guilds.map(&:id)).to eq([3, 1])
     end
   end
+
+  describe ".cached_for" do
+    include ActiveSupport::Testing::TimeHelpers
+
+    let(:guild) { Bot::Discord::Guild.new(id: 1, name: "Guild", owner: true, permissions: 0, icon: nil, member_count: 5) }
+    let(:memory) { ActiveSupport::Cache::MemoryStore.new }
+
+    before do
+      allow(Rails).to receive(:cache).and_return(memory)
+      allow(Bot::Discord::UserGuilds).to receive(:call).and_return([guild])
+    end
+
+    it "returns the manageable guilds" do
+      expect(described_class.cached_for("tok")).to eq([guild])
+    end
+
+    it "hits Discord only once for repeated calls within the TTL" do
+      3.times { described_class.cached_for("tok") }
+      expect(Bot::Discord::UserGuilds).to have_received(:call).once
+    end
+
+    it "refetches after the TTL expires" do
+      described_class.cached_for("tok")
+      travel(described_class::CACHE_TTL + 1.second) do
+        described_class.cached_for("tok")
+      end
+      expect(Bot::Discord::UserGuilds).to have_received(:call).twice
+    end
+
+    it "caches per token" do
+      described_class.cached_for("tok")
+      described_class.cached_for("other")
+      expect(Bot::Discord::UserGuilds).to have_received(:call).with("tok").once
+      expect(Bot::Discord::UserGuilds).to have_received(:call).with("other").once
+    end
+  end
 end

--- a/spec/presenters/server_dashboard_spec.rb
+++ b/spec/presenters/server_dashboard_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe ServerDashboard do
   let(:cached_ids) { [] }
 
   let(:target_guild) do
-    instance_double("Bot::Discord::Guild", id: target_id, manageable?: true, member_count: 100)
+    Bot::Discord::Guild.new(id: target_id, name: "Target", owner: true, permissions: 0, icon: nil, member_count: 100)
   end
   let(:other_guild) do
-    instance_double("Bot::Discord::Guild", id: other_id, manageable?: true, member_count: 50)
+    Bot::Discord::Guild.new(id: other_id, name: "Other", owner: true, permissions: 0, icon: nil, member_count: 50)
   end
 
   subject(:result) do
@@ -50,7 +50,7 @@ RSpec.describe ServerDashboard do
   context "when target guild is not among manageable guilds" do
     let!(:config) { create(:server_configuration, discord_id: target_id) }
     let(:other_guild_only) do
-      instance_double("Bot::Discord::Guild", id: other_id, manageable?: true, member_count: 50)
+      Bot::Discord::Guild.new(id: other_id, name: "Other", owner: true, permissions: 0, icon: nil, member_count: 50)
     end
 
     before do

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -27,6 +27,41 @@ RSpec.describe "Authentication", type: :request do
     end
   end
 
+  describe "token expiry on a server-scoped page" do
+    let(:guild) { Bot::Discord::Guild.new(id: 900_000_005, name: "Token Test", owner: true, permissions: 0, icon: nil, member_count: 3) }
+
+    before do
+      post "/auth/discord/callback"
+      create(:server_configuration, discord_id: guild.id)
+      allow(Bot::Discord::UserGuilds).to receive(:call).and_raise(Bot::Discord::UserGuilds::Unauthorized)
+    end
+
+    it "renders the reauth page and stores the current path" do
+      get server_logging_path(guild.id)
+      expect(response.body).to include("Signing you back in")
+      expect(session[:return_to]).to eq(server_logging_path(guild.id))
+    end
+
+    it "stores the picker as the return path for a non-GET request" do
+      patch server_logging_path(guild.id), params: {logging: {channel_id: "", enabled: "0", actions: {}}}
+      expect(session[:return_to]).to eq(servers_path)
+    end
+
+    it "returns the user to the stored path once the callback succeeds" do
+      get server_logging_path(guild.id)
+      post "/auth/discord/callback"
+      expect(response).to redirect_to(server_logging_path(guild.id))
+    end
+
+    it "resets the session and redirects home on a second consecutive failure" do
+      get server_logging_path(guild.id)
+      get server_logging_path(guild.id)
+      expect(response).to redirect_to(root_path)
+      expect(flash[:alert]).to be_present
+      expect(session[:reauth_attempted]).to be_nil
+    end
+  end
+
   describe "a failed sign-in" do
     it "redirects home with an alert" do
       get "/auth/failure"

--- a/spec/requests/image_scanning_config_spec.rb
+++ b/spec/requests/image_scanning_config_spec.rb
@@ -29,7 +29,11 @@ RSpec.describe "Image scanning config", type: :request do
       allow(Bot::Discord::UserGuilds).to receive(:call).and_return([guild])
     end
 
-    context "without proving the server is manageable this session" do
+    context "when the user no longer manages the server" do
+      before do
+        allow(Bot::Discord::UserGuilds).to receive(:call).and_return([])
+      end
+
       it "redirects to the picker" do
         get server_image_scanning_path(guild.id)
         expect(response).to redirect_to(servers_path)

--- a/spec/requests/logging_config_spec.rb
+++ b/spec/requests/logging_config_spec.rb
@@ -26,7 +26,11 @@ RSpec.describe "Logging config", type: :request do
       allow(Bot::Discord::UserGuilds).to receive(:call).and_return([guild])
     end
 
-    context "without proving the server is manageable this session" do
+    context "when the user no longer manages the server" do
+      before do
+        allow(Bot::Discord::UserGuilds).to receive(:call).and_return([])
+      end
+
       it "redirects to the picker" do
         get server_logging_path(guild.id)
         expect(response).to redirect_to(servers_path)
@@ -36,6 +40,33 @@ RSpec.describe "Logging config", type: :request do
     context "after loading the dashboard authorizes the server" do
       before do
         get server_path(guild.id)
+      end
+
+      context "when the user is demoted afterward" do
+        before do
+          allow(Bot::Discord::UserGuilds).to receive(:call).and_return([])
+        end
+
+        it "redirects a page load to the picker" do
+          get server_logging_path(guild.id)
+          expect(response).to redirect_to(servers_path)
+        end
+
+        it "redirects a save attempt to the picker" do
+          patch server_logging_path(guild.id), params: {logging: {channel_id: 200, enabled: "1", actions: {}}}
+          expect(response).to redirect_to(servers_path)
+        end
+      end
+
+      context "when Discord is unreachable after the dashboard cached authorization" do
+        before do
+          allow(Bot::Discord::UserGuilds).to receive(:call).and_raise(Bot::Discord::UserGuilds::Error)
+        end
+
+        it "still serves the config page from the cached authorization" do
+          get server_logging_path(guild.id)
+          expect(response).to have_http_status(:ok)
+        end
       end
 
       describe "GET /servers/:server_id/logging" do

--- a/spec/requests/moderation_config_spec.rb
+++ b/spec/requests/moderation_config_spec.rb
@@ -31,7 +31,11 @@ RSpec.describe "Moderation config", type: :request do
       allow(Bot::Discord::UserGuilds).to receive(:call).and_return([guild])
     end
 
-    context "without proving the server is manageable this session" do
+    context "when the user no longer manages the server" do
+      before do
+        allow(Bot::Discord::UserGuilds).to receive(:call).and_return([])
+      end
+
       it "redirects to the picker" do
         get server_moderation_path(guild.id)
         expect(response).to redirect_to(servers_path)

--- a/spec/requests/reminders_config_spec.rb
+++ b/spec/requests/reminders_config_spec.rb
@@ -23,7 +23,11 @@ RSpec.describe "Reminders config", type: :request do
       allow(Bot::Discord::UserGuilds).to receive(:call).and_return([guild])
     end
 
-    context "without proving the server is manageable this session" do
+    context "when the user no longer manages the server" do
+      before do
+        allow(Bot::Discord::UserGuilds).to receive(:call).and_return([])
+      end
+
       it "redirects to the picker" do
         get server_reminders_path(guild.id)
         expect(response).to redirect_to(servers_path)

--- a/spec/requests/roles_config_spec.rb
+++ b/spec/requests/roles_config_spec.rb
@@ -28,7 +28,11 @@ RSpec.describe "Roles config", type: :request do
       allow(Bot::Discord::UserGuilds).to receive(:call).and_return([guild])
     end
 
-    context "without proving the server is manageable this session" do
+    context "when the user no longer manages the server" do
+      before do
+        allow(Bot::Discord::UserGuilds).to receive(:call).and_return([])
+      end
+
       it "redirects to the picker" do
         get server_roles_path(guild.id)
         expect(response).to redirect_to(servers_path)

--- a/spec/requests/server_dashboard_spec.rb
+++ b/spec/requests/server_dashboard_spec.rb
@@ -180,20 +180,18 @@ RSpec.describe "Server dashboard", type: :request do
     describe "PATCH /servers/:server_id/plugins/:id" do
       let(:turbo) { {headers: {"Accept" => "text/vnd.turbo-stream.html"}} }
 
-      # Loading the dashboard is what proves the user manages this server and
-      # caches that authorization for the toggle that follows.
       before do
         get server_path(guild.id)
       end
 
-      it "enables a plugin in place without re-contacting Discord" do
+      it "enables a plugin in place, re-verifying live authorization first" do
         config.create_role_setting!(channel_id: 7)
         roles
         patch server_plugin_path(guild.id, "roles"), params: {enabled: true}, **turbo
         expect(response).to have_http_status(:ok)
         expect(response.media_type).to eq("text/vnd.turbo-stream.html")
         expect(config.plugin_activations.find_by(plugin: roles).enabled).to be(true)
-        expect(Bot::Discord::UserGuilds).to have_received(:call).once
+        expect(Bot::Discord::UserGuilds).to have_received(:call).twice
       end
 
       it "refuses to enable a plugin missing its prerequisites" do
@@ -224,7 +222,11 @@ RSpec.describe "Server dashboard", type: :request do
       end
     end
 
-    describe "toggling a server not authorized this session" do
+    describe "toggling a server the user no longer manages" do
+      before do
+        allow(Bot::Discord::UserGuilds).to receive(:call).and_return([])
+      end
+
       it "redirects to the picker" do
         roles
         patch server_plugin_path(guild.id, "roles"), params: {enabled: true}

--- a/spec/requests/server_picker_spec.rb
+++ b/spec/requests/server_picker_spec.rb
@@ -132,10 +132,11 @@ RSpec.describe "Server picker", type: :request do
           expect(session[:reauth_attempted]).to be(true)
         end
 
-        it "falls back to the error state instead of looping if re-auth still fails" do
+        it "resets the session and redirects home instead of looping if re-auth still fails" do
           get servers_path
           get servers_path
-          expect(response.body).to include("reach Discord")
+          expect(response).to redirect_to(root_path)
+          expect(flash[:alert]).to be_present
           expect(session[:reauth_attempted]).to be_nil
         end
       end

--- a/spec/requests/spam_protection_config_spec.rb
+++ b/spec/requests/spam_protection_config_spec.rb
@@ -29,7 +29,11 @@ RSpec.describe "Spam protection config", type: :request do
       allow(Bot::Discord::UserGuilds).to receive(:call).and_return([guild])
     end
 
-    context "without proving the server is manageable this session" do
+    context "when the user no longer manages the server" do
+      before do
+        allow(Bot::Discord::UserGuilds).to receive(:call).and_return([])
+      end
+
       it "redirects to the picker" do
         get server_spam_protection_path(guild.id)
         expect(response).to redirect_to(servers_path)

--- a/spec/requests/welcomes_config_spec.rb
+++ b/spec/requests/welcomes_config_spec.rb
@@ -26,8 +26,9 @@ RSpec.describe "Welcomes config", type: :request do
       allow(Bot::Discord::UserGuilds).to receive(:call).and_return([guild])
     end
 
-    context "without proving the server is manageable this session" do
+    context "when the user no longer manages the server" do
       it "redirects to the picker" do
+        allow(Bot::Discord::UserGuilds).to receive(:call).and_return([])
         get server_welcomes_path(guild.id)
         expect(response).to redirect_to(servers_path)
       end


### PR DESCRIPTION
## What
Security fix (from the audit). Web authorization trusted a **session-cached** guild list, refreshed only on the picker and the server dashboard. An admin demoted or removed from a guild on Discord kept config-write access via direct URLs (e.g. `PATCH /servers/:id/moderation`) until the cache happened to refresh or the session expired — up to two weeks.

`docs/architecture.md` deliberately chose the session cache to avoid Discord's rate-limited guild-list endpoint, and explicitly anticipated this change ("If a second page ever fetches from Discord with the user token, revisit this: extract a shared `DiscordReauth` concern and add return-to-URL plumbing"). This PR does exactly that.

## Fix
- **Live re-verification** on every server-scoped request: `RequiresManageableServer#live_manageable_ids` fetches the user's manageable guilds from Discord and authorizes against them, refreshing the session cache as a by-product. On `UserGuilds::Error` (Discord unreachable / rate-limited) it **falls back to the cached ids** so an outage doesn't lock admins out.
- **Shared `DiscordReauth` concern**: centralizes token-expiry handling (`rescue_from UserGuilds::Unauthorized`). It records the current path in `session[:return_to]`, and `SessionsController#create` sends the user back there after re-auth instead of always the picker. A second consecutive failure resets the session and returns home (loop-break).
- Docs updated to describe the new live-verify + re-auth flow.

## Notes
- **`rescue_from` precedence is load-bearing** in `ServersController`: `Unauthorized < Error`, and Rails matches handlers in reverse registration order, so `include DiscordReauth` is placed **after** `rescue_from …Error` so the `Unauthorized` handler wins. Swapping them would silently route token-expiry to the generic error state — guarded by the picker/dashboard specs.
- **Deferred cleanup:** `live_manageable_ids` shares the "fetch live → re-raise Unauthorized → fall back to cache on Error" shape with `ServerDashboard#resolve`. A clean extraction means restructuring `ServerDashboard` (it returns a full Result, not ids), so I left it out of this security PR — worth a follow-up.

## Tests
New coverage: live demotion → redirect to picker; Discord outage → cache fallback (still authorized); token expiry → reauth page + `return_to` stored + return after callback (GET and non-GET); double-failure → session reset + home. Full suite green (1897), standardrb / active_record_doctor / undercover / i18n-tasks clean.