### PR TITLE
Enable an enforcing Content Security Policy

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script>
+    <script nonce="<%= content_security_policy_nonce %>">
       (function () {
         var t = localStorage.getItem("shrk-theme");
         if (t !== "dark" && t !== "light") {

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,31 +1,17 @@
 # frozen_string_literal: true
 
-# Be sure to restart your server when you modify this file.
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src :self
+    policy.base_uri :self
+    policy.font_src :self, :data
+    policy.form_action :self
+    policy.img_src :self, :data, "https://cdn.discordapp.com", "https://media.discordapp.net"
+    policy.object_src :none
+    policy.script_src :self
+    policy.style_src :self, :unsafe_inline
+  end
 
-# Define an application-wide content security policy.
-# See the Securing Rails Applications Guide for more information:
-# https://guides.rubyonrails.org/security.html#content-security-policy-header
-
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src style-src)
-#
-#   # Automatically add `nonce` to `javascript_tag`, `javascript_include_tag`, and `stylesheet_link_tag`
-#   # if the corresponding directives are specified in `content_security_policy_nonce_directives`.
-#   # config.content_security_policy_nonce_auto = true
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+  config.content_security_policy_nonce_generator = ->(request) { SecureRandom.base64(16) }
+  config.content_security_policy_nonce_directives = %w[script-src]
+end

--- a/spec/requests/content_security_policy_spec.rb
+++ b/spec/requests/content_security_policy_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Content Security Policy", type: :request do
+  subject(:header) { response.headers["Content-Security-Policy"] }
+
+  before { get root_path }
+
+  it "enforces a script-src of self plus a per-request nonce" do
+    expect(header).to match(/script-src 'self' 'nonce-[^']+'/)
+  end
+
+  it "locks down the risky directives" do
+    expect(header).to include("default-src 'self'")
+    expect(header).to include("object-src 'none'")
+    expect(header).to include("base-uri 'self'")
+    expect(header).to include("form-action 'self'")
+  end
+
+  it "allows Discord's CDN for images and inline styles for dynamic colours" do
+    expect(header).to include("img-src 'self' data: https://cdn.discordapp.com https://media.discordapp.net")
+    expect(header).to include("style-src 'self' 'unsafe-inline'")
+  end
+
+  it "stamps the inline theme script and the importmap with the header's nonce" do
+    nonce = header[/script-src 'self' 'nonce-([^']+)'/, 1]
+
+    expect(response.body).to include(%(<script nonce="#{nonce}">))
+    expect(response.body).to match(/<script type="importmap"[^>]*nonce="#{Regexp.escape(nonce)}"/)
+  end
+end


### PR DESCRIPTION
## What
Security fix (from the audit). `config/initializers/content_security_policy.rb` was entirely commented out — no CSP header, no nonces, so any XSS had zero defense-in-depth behind it.

## Fix
Enable an **enforcing** policy:
- `script-src 'self'` + a **per-request nonce**. importmap-rails (2.2.3) auto-stamps its tags with the nonce, and the one inline `<script>` (the theme/FOUC guard in the layout) now carries `content_security_policy_nonce`.
- `object-src 'none'`, `base-uri 'self'`, `form-action 'self'`, `default-src 'self'`.
- `img-src` allows `cdn.discordapp.com` / `media.discordapp.net` (avatars, guild icons) + `data:`.
- `font-src 'self' data:` (fonts are self-hosted in `app/assets/fonts`).

## Why style-src keeps `unsafe-inline`
Role-colour swatches render inline `style="background:…"` with **arbitrary runtime colours** (`tom_select_controller.js`, `notification_bell`). Inline style *attributes* can't carry a nonce, and the colours aren't a fixed set, so a strict style-src would drop them. `script-src` — the directive that actually stops injected-script XSS — stays strict. Tightening style-src later would mean moving dynamic colours to CSS custom properties.

## Verification
Verified by static analysis (no browser in the sandbox): all importmap pins are vendored (no CDN), fonts are local, no external script/style hosts, no ActionCable/WebSocket usage. A request spec asserts the header directives and that both the theme script and the importmap script carry the header's nonce. Full suite green (1894), standardrb / undercover clean.

**Heads-up:** since I couldn't drive a real browser, please click through the dashboard once after merge (theme toggle, role menus / colour dots, image-scanning config) to confirm nothing trips the policy in practice.