### PR TITLE
Rate-limit the live server listing per user

### DIFF
--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -3,6 +3,8 @@
 class ServersController < ApplicationController
   include SetsManageableServers
 
+  rate_limit to: 60, within: 1.minute, by: -> { session[:user_id] }, only: :index
+
   before_action :load_dashboard, only: :show
 
   rescue_from Bot::Discord::UserGuilds::Error, with: :render_error

--- a/spec/requests/server_listing_rate_limit_spec.rb
+++ b/spec/requests/server_listing_rate_limit_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Server listing rate limit", type: :request do
+  include_context "discord auth"
+
+  let(:guild) { Bot::Discord::Guild.new(id: 900_000_001, name: "Dev Refuge", owner: true, permissions: 0, icon: nil, member_count: 5) }
+
+  before do
+    post "/auth/discord/callback"
+    create(:server_configuration, discord_id: guild.id)
+    allow(Bot::Discord::UserGuilds).to receive(:call).and_return([guild])
+  end
+
+  it "serves the listing when under the limit" do
+    get servers_path
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "refuses further listings once the per-user limit is exceeded" do
+    allow(Rails.cache).to receive(:increment).and_return(9_999)
+
+    get servers_path
+
+    expect(response).to have_http_status(:too_many_requests)
+  end
+end


### PR DESCRIPTION
## What
Security/abuse fix (from the audit). There was no rate limiting anywhere. `ServersController#index` proxies a live Discord `/users/@me/guilds` call on every request — a signed-in user could hammer it and burn the bot's Discord API budget (and risk the bot getting throttled).

## Fix
Rails 8 native `rate_limit` on `index`, keyed per user (`session[:user_id]`), 60 requests / minute, backed by the durable cache store (`solid_cache_store` in production). Over the limit → `429 Too Many Requests`.

Login is intentionally **not** throttled: sign-in is OAuth-only, so there's no credential brute-force surface.

## Tests
Spec verifies a normal listing serves 200 and that exceeding the per-user limit returns 429 (stubbing the cache `increment` to exceed the threshold, since the test `null_store` doesn't count). Full suite green (1892), standardrb / undercover clean.