### PR TITLE
Cap attachment downloads with a byte budget

### DIFF
--- a/app/plugins/moderation/attachment_download.rb
+++ b/app/plugins/moderation/attachment_download.rb
@@ -7,9 +7,11 @@ module Moderation
   module AttachmentDownload
     Error = Class.new(StandardError)
 
+    MAX_BYTES = 10 * 1024 * 1024
+
     module_function
 
-    def call(url)
+    def call(url, max_bytes: MAX_BYTES)
       uri = URI(url)
       Net::HTTP.start(
         uri.host,
@@ -18,15 +20,27 @@ module Moderation
         open_timeout: 5,
         read_timeout: 30
       ) do |http|
-        response = http.get(uri)
-        unless response.code.to_i.between?(200, 299)
-          raise Error, "download failed: #{response.code}"
-        end
+        http.request_get(uri) do |response|
+          unless response.code.to_i.between?(200, 299)
+            raise Error, "download failed: #{response.code}"
+          end
+          raise Error, "attachment too large" if (response.content_length || 0) > max_bytes
 
-        response.body
+          read_capped(response, max_bytes)
+        end
       end
     rescue Net::OpenTimeout, Net::ReadTimeout, SocketError => e
       raise Error, e.message
     end
+
+    def read_capped(response, max_bytes)
+      body = +""
+      response.read_body do |chunk|
+        body << chunk
+        raise Error, "attachment too large" if body.bytesize > max_bytes
+      end
+      body
+    end
+    private_class_method :read_capped
   end
 end

--- a/app/plugins/moderation/events/spam_guard.rb
+++ b/app/plugins/moderation/events/spam_guard.rb
@@ -7,7 +7,6 @@ module Moderation
     on :message
 
     CONTENT_PREVIEW_LIMIT = 800
-    MAX_FINGERPRINT_BYTES = 10 * 1024 * 1024
     MAX_HASHED_ATTACHMENTS = 3
 
     def handle
@@ -54,7 +53,7 @@ module Moderation
     end
 
     def attachment_fingerprint(attachment)
-      return filename_fingerprint(attachment) if attachment.size > MAX_FINGERPRINT_BYTES
+      return filename_fingerprint(attachment) if attachment.size > AttachmentDownload::MAX_BYTES
 
       "a:#{Digest::SHA256.hexdigest(AttachmentDownload.call(attachment.url))}"
     rescue AttachmentDownload::Error

--- a/app/plugins/moderation/image_scanning/scannable_images.rb
+++ b/app/plugins/moderation/image_scanning/scannable_images.rb
@@ -4,7 +4,6 @@ module Moderation
   module ImageScanning
     class ScannableImages
       MAX = 4
-      MAX_BYTES = 10 * 1024 * 1024
 
       def self.all(message)
         return [] unless message
@@ -37,7 +36,7 @@ module Moderation
 
       def attachments
         message.attachments
-          .select { |a| CONTENT_TYPES.include?(a.content_type) && a.size <= MAX_BYTES }
+          .select { |a| CONTENT_TYPES.include?(a.content_type) && a.size <= AttachmentDownload::MAX_BYTES }
           .first(MAX)
           .map(&:url)
       end

--- a/spec/plugins/moderation/attachment_download_spec.rb
+++ b/spec/plugins/moderation/attachment_download_spec.rb
@@ -6,21 +6,24 @@ RSpec.describe Moderation::AttachmentDownload do
   subject(:download) { described_class.call("https://cdn/x.png") }
 
   let(:http) { double("http") }
-  let(:response) { double("response", code: "200", body: "bytes") }
+  let(:chunks) { ["by", "tes"] }
+  let(:content_length) { nil }
+  let(:response) { double("response", code: "200", content_length:) }
 
   before do
     allow(Net::HTTP).to receive(:start) { |*_args, &block| block.call(http) }
-    allow(http).to receive(:get).and_return(response)
+    allow(http).to receive(:request_get) { |_uri, &block| block.call(response) }
+    allow(response).to receive(:read_body) { |&block| chunks.each { |chunk| block.call(chunk) } }
   end
 
   context "when the download succeeds" do
-    it "returns the response body" do
+    it "returns the streamed body" do
       expect(download).to eq("bytes")
     end
   end
 
   context "when the download returns a non-success status" do
-    let(:response) { double("response", code: "404", body: "") }
+    let(:response) { double("response", code: "404", content_length: nil) }
 
     it "raises an AttachmentDownload::Error" do
       expect { download }.to raise_error(Moderation::AttachmentDownload::Error, /404/)
@@ -34,6 +37,25 @@ RSpec.describe Moderation::AttachmentDownload do
 
     it "raises an AttachmentDownload::Error" do
       expect { download }.to raise_error(Moderation::AttachmentDownload::Error, "no dns")
+    end
+  end
+
+  context "when the declared content length exceeds the cap" do
+    let(:content_length) { described_class::MAX_BYTES + 1 }
+
+    it "refuses without reading the body" do
+      expect(response).not_to receive(:read_body)
+      expect { download }.to raise_error(Moderation::AttachmentDownload::Error, /too large/)
+    end
+  end
+
+  context "when the streamed body exceeds the cap" do
+    subject(:download) { described_class.call("https://cdn/x.png", max_bytes: 3) }
+
+    let(:chunks) { ["ab", "cd"] }
+
+    it "raises once the byte budget is blown" do
+      expect { download }.to raise_error(Moderation::AttachmentDownload::Error, /too large/)
     end
   end
 end

--- a/spec/plugins/moderation/events/spam_guard_spec.rb
+++ b/spec/plugins/moderation/events/spam_guard_spec.rb
@@ -369,7 +369,7 @@ RSpec.describe Moderation::SpamGuard do
     end
   end
 
-  context "when the attachment exceeds MAX_FINGERPRINT_BYTES" do
+  context "when the attachment exceeds AttachmentDownload::MAX_BYTES" do
     let(:oversize) { 11 * 1024 * 1024 }
     let(:attachment) { double("attachment", filename: "big.png", size: oversize, url: "https://cdn/big.png") }
 

--- a/spec/plugins/moderation/image_scanning/image_download_spec.rb
+++ b/spec/plugins/moderation/image_scanning/image_download_spec.rb
@@ -6,11 +6,12 @@ RSpec.describe Moderation::ImageScanning::ImageDownload do
   subject(:download) { described_class.call("https://cdn/x.png") }
 
   let(:http) { double("http") }
-  let(:response) { double("response", code: "200", body: "bytes") }
+  let(:response) { double("response", code: "200", content_length: nil) }
 
   before do
     allow(Net::HTTP).to receive(:start) { |*_args, &block| block.call(http) }
-    allow(http).to receive(:get).and_return(response)
+    allow(http).to receive(:request_get) { |_uri, &block| block.call(response) }
+    allow(response).to receive(:read_body) { |&block| block.call("bytes") }
   end
 
   context "when the download succeeds" do
@@ -20,7 +21,7 @@ RSpec.describe Moderation::ImageScanning::ImageDownload do
   end
 
   context "when the download returns a non-success status" do
-    let(:response) { double("response", code: "404", body: "") }
+    let(:response) { double("response", code: "404", content_length: nil) }
 
     it "raises an Ocr::Error" do
       expect { download }.to raise_error(Moderation::ImageScanning::Ocr::Error, /404/)

--- a/spec/plugins/moderation/image_scanning/scannable_images_spec.rb
+++ b/spec/plugins/moderation/image_scanning/scannable_images_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Moderation::ImageScanning::ScannableImages do
       end
     end
 
-    context "when attachment exceeds MAX_BYTES" do
+    context "when attachment exceeds AttachmentDownload::MAX_BYTES" do
       let(:attachments) { [double("att", content_type: png_type, size: 11 * 1024 * 1024, url: "https://cdn/big.png")] }
 
       it "skips it" do
@@ -43,7 +43,7 @@ RSpec.describe Moderation::ImageScanning::ScannableImages do
       end
     end
 
-    context "when attachment is exactly at MAX_BYTES" do
+    context "when attachment is exactly at AttachmentDownload::MAX_BYTES" do
       let(:attachments) { [double("att", content_type: jpeg_type, size: 10 * 1024 * 1024, url: "https://cdn/ok.jpg")] }
 
       it "includes it" do


### PR DESCRIPTION
## What
Security fix (from the audit). `Moderation::AttachmentDownload` read the entire HTTP response body into memory with no size limit. The image-scan content-link path (`ScannableImages#content_links`) validates host/scheme/extension but **not** size, so a message linking several large Discord-CDN files could make the two scan workers each hold hundreds of MB — a memory-exhaustion vector.

## Fix
Stream the response and abort once a byte budget is exceeded (default `MAX_BYTES = 10 MB`, matching the existing attachment/image ceiling), rejecting early when `Content-Length` already exceeds it. Both callers already cap their inputs at 10 MB, so legitimate downloads are unaffected; oversize content-links now fail gracefully (caught as `Ocr::Error`).

## Tests
Spec covers: streamed success, non-2xx, connection failure, oversize `Content-Length` (rejected before reading), and oversize streamed body (budget blown mid-stream). Full suite green (1892), standardrb / undercover clean.