### PR TITLE
Escape option values in the Icon custom-glyph path

### DIFF
--- a/app/components/icon.rb
+++ b/app/components/icon.rb
@@ -28,7 +28,7 @@ class Components::Icon < Components::Base
   private
 
   def custom_glyph
-    attrs_str = @options.map { |k, v| "#{k.to_s.tr("_", "-")}=\"#{v}\"" }.join(" ")
+    attrs_str = @options.map { |k, v| "#{k.to_s.tr("_", "-")}=\"#{ERB::Util.html_escape(v)}\"" }.join(" ")
     CUSTOM_GLYPHS[@name] % {attrs: attrs_str}
   end
 end

--- a/spec/components/icon_spec.rb
+++ b/spec/components/icon_spec.rb
@@ -70,5 +70,14 @@ RSpec.describe Components::Icon do
       real_svg = described_class.new("sun").call
       expect(real_svg).to eq(PhosphorIcons::Icon.new("sun", style: :regular, class: "size-5").to_svg)
     end
+
+    context "with an injection attempt in an option value" do
+      let(:options) { {data_probe: %("><script>alert(1)</script>)} }
+
+      it "escapes the value so it can't break out of the attribute" do
+        expect(svg).not_to include("<script>")
+        expect(svg).to include("&quot;").and include("&lt;script&gt;")
+      end
+    end
   end
 end


### PR DESCRIPTION
## What
Hardening (from the audit). `Components::Icon#custom_glyph` interpolated caller-supplied option **values** straight into the SVG attribute string, then rendered the result `raw`. All current call sites pass literals, so it's not exploitable today — but any future caller feeding guild/user data into an icon option could break out of the attribute (`">…`) and inject markup (a latent XSS, unmitigated with CSP off).

## Fix
`ERB::Util.html_escape` the interpolated value.

## Tests
Added a case where an option value contains `"><script>…` and asserts the output is escaped (no literal `<script>`; `&quot;` / `&lt;script&gt;` present). Full suite green (1891), standardrb / undercover clean.