### PR TITLE
Re-check declared command permissions at runtime

### DIFF
--- a/app/bot/base_command.rb
+++ b/app/bot/base_command.rb
@@ -127,7 +127,8 @@ module Bot
     def permitted?
       CommandPermissions.permitted?(
         event:,
-        owner_only: self.class.owner_only?
+        owner_only: self.class.owner_only?,
+        required_permissions: self.class.requires_permissions
       )
     end
 

--- a/app/bot/registration/command_permissions.rb
+++ b/app/bot/registration/command_permissions.rb
@@ -4,10 +4,11 @@ module Bot
   module CommandPermissions
     module_function
 
-    def permitted?(event:, owner_only:)
+    def permitted?(event:, owner_only:, required_permissions: [])
       return true if owner?(event)
+      return false if owner_only
 
-      !owner_only
+      required_permissions.all? { |permission| event.user.permission?(permission) }
     end
 
     def owner?(event)

--- a/spec/bot/base_command_spec.rb
+++ b/spec/bot/base_command_spec.rb
@@ -151,6 +151,29 @@ RSpec.describe Bot::BaseCommand do
       end
     end
 
+    context "when the invoker lacks a declared permission" do
+      subject(:dispatch) { klass.dispatch(denied_event) }
+
+      let(:klass) do
+        Class.new(described_class) do
+          command_name :probe
+          requires_permissions :manage_messages
+
+          def execute
+            raise "should not run"
+          end
+        end
+      end
+
+      let(:user) { double("user", id: 1, permission?: false) }
+      let(:denied_event) { double("event", user:, respond: nil) }
+
+      it "replies with a denial and skips #execute" do
+        expect(denied_event).to receive(:respond).with(hash_including(content: a_string_including("permission"), ephemeral: true))
+        dispatch
+      end
+    end
+
     context "when #execute raises" do
       subject(:dispatch) { klass.dispatch(event) }
 

--- a/spec/bot/registration/command_permissions_spec.rb
+++ b/spec/bot/registration/command_permissions_spec.rb
@@ -60,5 +60,33 @@ RSpec.describe Bot::CommandPermissions do
         is_expected.to be(true)
       end
     end
+
+    context "when the command declares required permissions" do
+      subject(:permitted) do
+        described_class.permitted?(event:, owner_only: false, required_permissions: [:manage_messages])
+      end
+
+      let(:user) { double("user", id: 7) }
+      let(:event) { double("event", user:) }
+
+      before do
+        allow(Bot::Config).to receive(:owner_id).and_return("42")
+      end
+
+      it "grants access when the user holds every required permission" do
+        allow(user).to receive(:permission?).with(:manage_messages).and_return(true)
+        is_expected.to be(true)
+      end
+
+      it "denies access when the user lacks a required permission" do
+        allow(user).to receive(:permission?).with(:manage_messages).and_return(false)
+        is_expected.to be(false)
+      end
+
+      it "grants the owner access regardless of missing permissions" do
+        allow(Bot::Config).to receive(:owner_id).and_return("7")
+        is_expected.to be(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
## What
Defense-in-depth (from the audit). A command's `requires_permissions` only became Discord's `default_member_permissions` on the registered command — the bot itself enforced nothing beyond `owner_only` at dispatch (`CommandPermissions.permitted?` ignored the declared perms). If registration drifts, or a guild admin re-opens a restricted command via Server Settings → Integrations, the handler runs for anyone. For `Report as scam` (`requires_permissions :manage_messages`) that means any member could confirm phashes and delete messages.

## Fix
`CommandPermissions.permitted?` now also verifies the invoker holds **every** declared permission (`event.user.permission?`, the same check `/info` already uses), in addition to Discord's gating. The owner still bypasses. Commands with no declared perms are unaffected (`[].all?` is true).

## Tests
`CommandPermissions` specs cover: has-all → allowed, missing-one → denied, owner → always allowed. `BaseCommand` dispatch spec covers an invoker lacking a declared permission being denied with the handler skipped. Full suite green (1894), standardrb / undercover clean.