### PR TITLE
Reset the session on sign-in

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,9 +7,9 @@ class SessionsController < ApplicationController
     auth = request.env["omniauth.auth"]
     user = User.from_omniauth(auth)
     destination = session.delete(:return_to) || servers_path
+    reset_session
     session[:user_id] = user.id
     session[:discord_token] = auth.credentials.token
-    session.delete(:reauth_attempted)
     redirect_to destination, notice: t("sessions.signed_in", name: user.display_name)
   end
 

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -13,6 +13,16 @@ RSpec.describe "Authentication", type: :request do
       expect(session[:user_id]).to eq(User.find_by(discord_id: 12345).id)
       expect(callback).to redirect_to(servers_path)
     end
+
+    it "resets the session on sign-in so a pre-auth session can't be fixed" do
+      get servers_path
+      before_id = session.id&.public_id
+
+      callback
+
+      expect(before_id).to be_present
+      expect(session.id&.public_id).not_to eq(before_id)
+    end
   end
 
   describe "signing out" do


### PR DESCRIPTION
## What
Hardening (from the audit). Sign-in wrote `user_id`/`discord_token` into the **existing** session without rotating it, so pre-authentication session state carried into the authenticated session (session-fixation shape).

With `cookie_store` this isn't practically exploitable (the whole session lives in the signed/encrypted cookie — an attacker can't pre-set it), but rotating on a privilege change is best practice and cheap. `reset_session` on sign-in, matching what sign-out and account deletion already do.

## Scope note
The audit's companion finding — `redirect_back` allowing a cross-host Referer in `plugins_controller` — turned out to be a **non-issue on Rails 8.1**: `config.load_defaults 8.1` enables `raise_on_open_redirects`, which makes `redirect_back`'s `allow_other_host` default to `false` (verified in `actionpack` `redirecting.rb#_allow_other_host`). No change needed there, so this PR is just the session reset.

## Tests
Spec asserts the session id rotates on sign-in (a pre-auth session established via a signed-out request no longer matches after the callback). Full suite green (1891), standardrb / undercover clean.

## Heads-up (merge order)
This edits `SessionsController#create`, which PR #176 (live-server-authz) also edits (it reads `session[:return_to]` before redirecting). Whichever merges second will conflict — the combined `create` should read `destination = session.delete(:return_to) || servers_path` **before** `reset_session`, then set `user_id`/`discord_token`, then redirect to `destination`.