### PR TITLE
Scope role lookups to the acting guild

### DIFF
--- a/app/controllers/servers/moderation_controller.rb
+++ b/app/controllers/servers/moderation_controller.rb
@@ -15,6 +15,8 @@ class Servers::ModerationController < ApplicationController
   end
 
   def update
+    return head :not_found unless guild_role?(moderation_params[:staff_role_id])
+
     result = Ops::Moderation::Configure.call(
       server_configuration: @server_configuration,
       staff_role_id: moderation_params[:staff_role_id],
@@ -29,6 +31,10 @@ class Servers::ModerationController < ApplicationController
 
   def moderation_params
     params.expect(moderation: [:staff_role_id, :enabled, :ping_staff, :new_account_age_days])
+  end
+
+  def guild_role?(role_id)
+    role_id.blank? || @server_configuration.server_roles.exists?(discord_id: role_id)
   end
 
   def build_context

--- a/app/plugins/roles/events/component_handler.rb
+++ b/app/plugins/roles/events/component_handler.rb
@@ -5,7 +5,7 @@ module Roles
     private
 
     def set
-      @set ||= Set.find_by(id: CustomId.parse(event.custom_id)[:set_id])
+      @set ||= server_configuration&.role_setting&.role_sets&.find_by(id: CustomId.parse(event.custom_id)[:set_id])
     end
 
     def member
@@ -61,7 +61,7 @@ module Roles
     end
 
     def server_configuration
-      set.role_setting.server_configuration
+      @server_configuration ||= ServerConfiguration.find_by(discord_id: event.server&.id)
     end
   end
 end

--- a/app/plugins/roles/events/component_handler.rb
+++ b/app/plugins/roles/events/component_handler.rb
@@ -5,13 +5,15 @@ module Roles
     private
 
     def set
-      @set ||= server_configuration&.role_setting&.role_sets&.find_by(id: CustomId.parse(event.custom_id)[:set_id])
+      return unless event.server
+
+      @set ||= server_configuration.role_setting.role_sets.find_by(id: CustomId.parse(event.custom_id)[:set_id])
     end
 
     def member
       return @member if defined?(@member)
 
-      @member = event.server&.member(event.user.id)
+      @member = event.server.member(event.user.id)
     end
 
     def set_role_ids
@@ -61,7 +63,7 @@ module Roles
     end
 
     def server_configuration
-      @server_configuration ||= ServerConfiguration.find_by(discord_id: event.server&.id)
+      @server_configuration ||= ServerConfiguration.find_by(discord_id: event.server.id)
     end
   end
 end

--- a/spec/plugins/roles/events/manage_spec.rb
+++ b/spec/plugins/roles/events/manage_spec.rb
@@ -38,6 +38,11 @@ RSpec.describe Roles::Manage do
     let(:event) { double("event", custom_id: "roles:manage:rst_gone", server:, user:) }
     let(:set) { nil }
     let(:server_id) { 900_001 }
+    let!(:server_config) do
+      create(:server_configuration, discord_id: server_id).tap do |config|
+        create(:role_setting, server_configuration: config)
+      end
+    end
 
     it "does nothing" do
       expect(event).not_to receive(:respond)

--- a/spec/plugins/roles/events/manage_spec.rb
+++ b/spec/plugins/roles/events/manage_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Roles::Manage do
 
   let(:user) { double("user", id: 42) }
   let(:member) { double("member", roles: [double("role", id: 200)]) }
-  let(:server) { double("server") }
+  let(:server) { double("server", id: server_id) }
   let(:event) { double("event", custom_id: Roles::CustomId.manage(set), server:, user:) }
 
   before do
@@ -16,6 +16,7 @@ RSpec.describe Roles::Manage do
 
   context "for a multi-selection set" do
     let(:set) { create(:role_set, selection_mode: "multi") }
+    let(:server_id) { set.role_setting.server_configuration.discord_id }
 
     before do
       create(:assignable_role, role_set: set, role_id: 200, position: 0)
@@ -36,6 +37,7 @@ RSpec.describe Roles::Manage do
   context "when the set no longer exists" do
     let(:event) { double("event", custom_id: "roles:manage:rst_gone", server:, user:) }
     let(:set) { nil }
+    let(:server_id) { 900_001 }
 
     it "does nothing" do
       expect(event).not_to receive(:respond)

--- a/spec/plugins/roles/events/pick_spec.rb
+++ b/spec/plugins/roles/events/pick_spec.rb
@@ -35,7 +35,12 @@ RSpec.describe Roles::Pick do
   end
 
   context "when the interaction comes from a different server than the set" do
-    let(:server) { double("server", id: server_config.discord_id + 1, member:) }
+    let(:server) { double("server", id: foreign_config.discord_id, member:) }
+    let!(:foreign_config) do
+      create(:server_configuration, discord_id: server_config.discord_id + 1).tap do |config|
+        create(:role_setting, server_configuration: config)
+      end
+    end
 
     it "ignores it and changes no roles" do
       expect(member).not_to receive(:modify_roles)

--- a/spec/plugins/roles/events/pick_spec.rb
+++ b/spec/plugins/roles/events/pick_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Roles::Pick do
 
   let(:user) { double("user", id: 42) }
   let(:member) { double("member", roles: [], modify_roles: nil, mention: "<@42>") }
-  let(:server) { double("server", member:) }
+  let(:server) { double("server", id: server_config.discord_id, member:) }
   let(:bot) { double("bot") }
   let(:event) do
     double("event", custom_id: Roles::CustomId.pick(set, blue), server:, user:, respond: nil, bot:)
@@ -32,6 +32,15 @@ RSpec.describe Roles::Pick do
   it "adds the picked role and removes the other roles in the set" do
     expect(member).to receive(:modify_roles).with([200], [100])
     handle
+  end
+
+  context "when the interaction comes from a different server than the set" do
+    let(:server) { double("server", id: server_config.discord_id + 1, member:) }
+
+    it "ignores it and changes no roles" do
+      expect(member).not_to receive(:modify_roles)
+      handle
+    end
   end
 
   it "logs the role the user gained" do

--- a/spec/plugins/roles/events/select_spec.rb
+++ b/spec/plugins/roles/events/select_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Roles::Select do
 
   let(:user) { double("user", id: 42) }
   let(:member) { double("member", roles: [], modify_roles: nil, mention: "<@42>") }
-  let(:server) { double("server", member:) }
+  let(:server) { double("server", id: server_config.discord_id, member:) }
   let(:bot) { double("bot") }
   let(:event) do
     double("event", custom_id: Roles::CustomId.select(set), server:, user:, values: ["100"], update_message: nil, bot:)
@@ -28,6 +28,15 @@ RSpec.describe Roles::Select do
   it "adds the selected set roles and removes the unselected ones" do
     expect(member).to receive(:modify_roles).with([100], [200])
     handle
+  end
+
+  context "when the interaction comes from a different server than the set" do
+    let(:server) { double("server", id: server_config.discord_id + 1, member:) }
+
+    it "ignores it and changes no roles" do
+      expect(member).not_to receive(:modify_roles)
+      handle
+    end
   end
 
   it "logs the gained role" do

--- a/spec/plugins/roles/events/select_spec.rb
+++ b/spec/plugins/roles/events/select_spec.rb
@@ -31,7 +31,12 @@ RSpec.describe Roles::Select do
   end
 
   context "when the interaction comes from a different server than the set" do
-    let(:server) { double("server", id: server_config.discord_id + 1, member:) }
+    let(:server) { double("server", id: foreign_config.discord_id, member:) }
+    let!(:foreign_config) do
+      create(:server_configuration, discord_id: server_config.discord_id + 1).tap do |config|
+        create(:role_setting, server_configuration: config)
+      end
+    end
 
     it "ignores it and changes no roles" do
       expect(member).not_to receive(:modify_roles)

--- a/spec/requests/moderation_config_spec.rb
+++ b/spec/requests/moderation_config_spec.rb
@@ -158,6 +158,13 @@ RSpec.describe "Moderation config", type: :request do
           expect(response).to redirect_to(server_moderation_path(guild.id))
         end
 
+        it "rejects a staff role from another server with 404" do
+          patch server_moderation_path(guild.id),
+            params: {moderation: {staff_role_id: 424_242, enabled: "1"}},
+            **turbo
+          expect(response).to have_http_status(:not_found)
+        end
+
         it "sets ping_staff to false when param is '0'" do
           patch server_moderation_path(guild.id),
             params: {moderation: {staff_role_id: 500, enabled: "1", ping_staff: "0"}},


### PR DESCRIPTION
## What
Two guild-scoping hardening items from the audit (both low / defense-in-depth):

1. **Moderation `staff_role_id`** — the config form accepted any role snowflake with no check it belonged to the guild. Not cross-tenant exploitable (a foreign role id just matches no member), but a consistency gap next to the channel scoping. The controller now verifies it against `@server_configuration.server_roles` and returns `404` on a foreign reference; the op keeps trusting its input (same pattern as the channel fix).
2. **`Roles::ComponentHandler#set`** — looked a role set up by id straight from the `custom_id` with no check it belonged to the interaction's guild. Discord already makes this hard to exploit (interactions are message-bound; cross-guild role IDs are rejected by the API), but the lookup now resolves through the acting guild's config, so a foreign set yields `nil` and the existing `return unless set` guards ignore the interaction.

## Tests
- Moderation request spec: foreign `staff_role_id` → 404.
- Pick/Select specs: an interaction whose `event.server` differs from the set's guild changes no roles. (Server doubles updated with `id`, since `server_configuration` now derives from the interaction's guild.)

Full suite green (1893), standardrb / undercover clean.