### PR TITLE
Suppress leave-message mentions; ack role interactions before REST

### DIFF
--- a/app/plugins/roles/events/component_handler.rb
+++ b/app/plugins/roles/events/component_handler.rb
@@ -24,10 +24,6 @@ module Roles
       member.modify_roles(diff[:add], diff[:remove])
     end
 
-    def update(picker)
-      event.update_message(components: picker[:components], has_components: true)
-    end
-
     def log_assignment(had, diff)
       names = role_names(diff[:add] + diff[:remove])
       gained = logged_roles(:role_gained, diff[:add] - had, names)

--- a/app/plugins/roles/events/pick.rb
+++ b/app/plugins/roles/events/pick.rb
@@ -12,8 +12,9 @@ module Roles
 
       had = member_set_role_ids
       diff = Assignment.single(set_role_ids, picked, had)
+      event.defer(ephemeral: true)
       apply(diff)
-      event.respond(content: Message.pick_confirmation(set, picked, had), ephemeral: true)
+      event.edit_response(content: Message.pick_confirmation(set, picked, had))
       log_assignment(had, diff)
     end
   end

--- a/app/plugins/roles/events/select.rb
+++ b/app/plugins/roles/events/select.rb
@@ -10,8 +10,10 @@ module Roles
       selected = event.values.map(&:to_i)
       diff = Assignment.multi(set_role_ids, selected)
       had = member_set_role_ids
+      event.defer_update
       apply(diff)
-      update(Message.multi_picker(set, selected & set_role_ids))
+      picker = Message.multi_picker(set, selected & set_role_ids)
+      event.edit_response(components: picker[:components], has_components: true)
       log_assignment(had, diff)
     end
   end

--- a/app/plugins/welcomes/events/member_leave.rb
+++ b/app/plugins/welcomes/events/member_leave.rb
@@ -10,7 +10,7 @@ module Welcomes
       return if setting.leave_message.blank?
 
       content = Message.render(setting.leave_message, user: "@#{event.user.username}", member_count: event.server.member_count)
-      event.bot.send_message(setting.channel_id, content)
+      event.bot.send_message(setting.channel_id, content, false, nil, nil, {parse: []})
     end
   end
 end

--- a/spec/plugins/roles/events/pick_spec.rb
+++ b/spec/plugins/roles/events/pick_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Roles::Pick do
   let(:server) { double("server", id: server_config.discord_id, member:) }
   let(:bot) { double("bot") }
   let(:event) do
-    double("event", custom_id: Roles::CustomId.pick(set, blue), server:, user:, respond: nil, bot:)
+    double("event", custom_id: Roles::CustomId.pick(set, blue), server:, user:, defer: nil, edit_response: nil, bot:)
   end
 
   before do
@@ -31,6 +31,12 @@ RSpec.describe Roles::Pick do
 
   it "adds the picked role and removes the other roles in the set" do
     expect(member).to receive(:modify_roles).with([200], [100])
+    handle
+  end
+
+  it "acknowledges the interaction before changing roles" do
+    expect(event).to receive(:defer).with(ephemeral: true).ordered
+    expect(member).to receive(:modify_roles).ordered
     handle
   end
 
@@ -59,8 +65,8 @@ RSpec.describe Roles::Pick do
     handle
   end
 
-  it "confirms what changed ephemerally" do
-    expect(event).to receive(:respond).with(content: "You now have **Blue**.", ephemeral: true)
+  it "confirms what changed in the deferred reply" do
+    expect(event).to receive(:edit_response).with(content: "You now have **Blue**.")
     handle
   end
 
@@ -68,7 +74,7 @@ RSpec.describe Roles::Pick do
     let(:member) { double("member", roles: [double("role", id: 100)], modify_roles: nil, mention: "<@42>") }
 
     it "names the swapped-out role in the confirmation" do
-      expect(event).to receive(:respond).with(content: "You now have **Blue** - swapped out **Red**.", ephemeral: true)
+      expect(event).to receive(:edit_response).with(content: "You now have **Blue** - swapped out **Red**.")
       handle
     end
   end
@@ -82,7 +88,7 @@ RSpec.describe Roles::Pick do
     end
 
     it "confirms the removal" do
-      expect(event).to receive(:respond).with(content: "Removed **Blue**.", ephemeral: true)
+      expect(event).to receive(:edit_response).with(content: "Removed **Blue**.")
       handle
     end
 
@@ -100,11 +106,12 @@ RSpec.describe Roles::Pick do
 
   context "when the custom id references a role outside the set" do
     let(:event) do
-      double("event", custom_id: "roles:pick:#{set.id}:999", server:, user:, respond: nil)
+      double("event", custom_id: "roles:pick:#{set.id}:999", server:, user:)
     end
 
-    it "makes no change" do
+    it "makes no change and never acknowledges" do
       expect(member).not_to receive(:modify_roles)
+      expect(event).not_to receive(:defer)
       handle
     end
   end
@@ -113,7 +120,8 @@ RSpec.describe Roles::Pick do
     let(:server) { nil }
 
     it "does nothing" do
-      expect(event).not_to receive(:respond)
+      expect(event).not_to receive(:defer)
+      expect(event).not_to receive(:edit_response)
       handle
     end
   end

--- a/spec/plugins/roles/events/select_spec.rb
+++ b/spec/plugins/roles/events/select_spec.rb
@@ -22,11 +22,17 @@ RSpec.describe Roles::Select do
   let(:server) { double("server", id: server_config.discord_id, member:) }
   let(:bot) { double("bot") }
   let(:event) do
-    double("event", custom_id: Roles::CustomId.select(set), server:, user:, values: ["100"], update_message: nil, bot:)
+    double("event", custom_id: Roles::CustomId.select(set), server:, user:, values: ["100"], defer_update: nil, edit_response: nil, bot:)
   end
 
   it "adds the selected set roles and removes the unselected ones" do
     expect(member).to receive(:modify_roles).with([100], [200])
+    handle
+  end
+
+  it "acknowledges the interaction before changing roles" do
+    expect(event).to receive(:defer_update).ordered
+    expect(member).to receive(:modify_roles).ordered
     handle
   end
 
@@ -92,7 +98,7 @@ RSpec.describe Roles::Select do
       double("member", roles: [double("role", id: 100), double("role", id: 200)], modify_roles: nil, mention: "<@42>")
     end
     let(:event) do
-      double("event", custom_id: Roles::CustomId.select(set), server:, user:, values: [], update_message: nil, bot:)
+      double("event", custom_id: Roles::CustomId.select(set), server:, user:, values: [], defer_update: nil, edit_response: nil, bot:)
     end
 
     it "logs only the lost roles" do
@@ -133,13 +139,13 @@ RSpec.describe Roles::Select do
     let(:server) { nil }
 
     it "does nothing" do
-      expect(event).not_to receive(:update_message)
+      expect(event).not_to receive(:defer_update)
       handle
     end
   end
 
-  it "re-renders the picker via update_message" do
-    expect(event).to receive(:update_message)
+  it "re-renders the picker in the deferred update" do
+    expect(event).to receive(:edit_response)
     handle
   end
 

--- a/spec/plugins/welcomes/events/member_leave_spec.rb
+++ b/spec/plugins/welcomes/events/member_leave_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe Welcomes::MemberLeave do
   context "with an active setting and a leave message" do
     let(:setting) { double("settings", channel_id: 555, leave_message: "{user} left. {membercount} remain.") }
 
-    it "posts the rendered message with the @handle (no mention)" do
-      expect(bot).to receive(:send_message).with(555, "@ghost left. 9 remain.")
+    it "posts the rendered message with the @handle and suppresses all mentions" do
+      expect(bot).to receive(:send_message).with(555, "@ghost left. 9 remain.", false, nil, nil, {parse: []})
       handle
     end
   end


### PR DESCRIPTION
## What
Two bot-event hardening items from the audit (both low):

1. **Welcome leave message** sent with no `allowed_mentions`, while the join path already suppresses conditionally. A leave template interpolating `@username` can't form `@everyone`, but for consistency and defense-in-depth the leave send now passes `{parse: []}` so it can never ping.
2. **Role self-assign button/select** ran the role-change REST call (`member.modify_roles`) *before* acknowledging the interaction. Under Discord rate-limiting a slow modify can blow the 3-second ack window → "Unknown interaction" even though the roles changed. Now they acknowledge first, then edit the response:
   - `Pick` (ephemeral confirmation): `event.defer(ephemeral: true)` → `edit_response` (the same pattern `report_scam`/`undo_punishment` already use).
   - `Select` (re-renders the picker message): `event.defer_update` → `edit_response`.
   - The now-unused `update` helper is removed.

## Tests
Leave spec asserts the suppressed `allowed_mentions`. Pick/Select specs assert the interaction is acknowledged **before** `modify_roles` (ordered) and that the confirmation/re-render now go through `edit_response`. Full suite green (1892), standardrb / undercover clean.

## Heads-up (needs a live check)
There's no Discord network in my environment, so I couldn't exercise the real interaction flow. The `defer`/`defer_update` → `edit_response` sequence is the standard Discord pattern and discordrb supports it, and unit tests confirm the call order — but please click a role button and a role multi-select once after merge to confirm the picker still updates and the confirmation still shows.