### PR TITLE
Add a one-time cookie notice banner

### DIFF
--- a/app/components/cookie_notice.rb
+++ b/app/components/cookie_notice.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Components::CookieNotice < Components::Base
+  def view_template
+    div(
+      hidden: true,
+      data: {controller: "cookie-notice"},
+      role: "status",
+      class: "fixed inset-x-0 bottom-0 z-40 border-t border-border-default bg-surface-sunken px-4 py-3"
+    ) do
+      div(class: "mx-auto flex max-w-3xl flex-wrap items-center justify-center gap-x-4 gap-y-2") do
+        p(class: "text-sm leading-relaxed text-text-primary") { t(".message") }
+        render Components::Button.new(
+          label: t(".dismiss"),
+          variant: :secondary,
+          size: :sm,
+          data: {action: "cookie-notice#dismiss"}
+        )
+      end
+    end
+  end
+end

--- a/app/components/cookie_notice.rb
+++ b/app/components/cookie_notice.rb
@@ -14,7 +14,7 @@ class Components::CookieNotice < Components::Base
           label: t(".dismiss"),
           variant: :primary,
           size: :sm,
-          class: "flex-none self-end whitespace-nowrap sm:self-auto",
+          class: "flex-none self-center whitespace-nowrap sm:self-auto",
           data: {action: "cookie-notice#dismiss"}
         )
       end

--- a/app/components/cookie_notice.rb
+++ b/app/components/cookie_notice.rb
@@ -6,14 +6,15 @@ class Components::CookieNotice < Components::Base
       hidden: true,
       data: {controller: "cookie-notice"},
       role: "status",
-      class: "fixed bottom-6 left-1/2 z-40 w-[30rem] max-w-[calc(100vw-2.5rem)] -translate-x-1/2 rounded-xl"
+      class: "fixed bottom-6 left-1/2 z-40 w-[40rem] max-w-[calc(100vw-2.5rem)] -translate-x-1/2 rounded-xl"
     ) do
-      div(class: "flex items-center justify-between gap-6 rounded-xl border border-border-default bg-surface-card px-5 py-3 shadow-lg") do
+      div(class: "flex flex-col gap-3 rounded-xl border border-border-default bg-surface-card px-5 py-3 shadow-lg sm:flex-row sm:items-center sm:justify-between sm:gap-6") do
         p(class: "text-sm leading-relaxed text-text-secondary") { t(".message") }
         render Components::Button.new(
           label: t(".dismiss"),
           variant: :primary,
           size: :sm,
+          class: "flex-none self-end whitespace-nowrap sm:self-auto",
           data: {action: "cookie-notice#dismiss"}
         )
       end

--- a/app/components/cookie_notice.rb
+++ b/app/components/cookie_notice.rb
@@ -6,13 +6,13 @@ class Components::CookieNotice < Components::Base
       hidden: true,
       data: {controller: "cookie-notice"},
       role: "status",
-      class: "fixed inset-x-0 bottom-0 z-40 border-t border-border-default bg-surface-sunken px-4 py-3"
+      class: "fixed bottom-6 left-1/2 z-40 w-[30rem] max-w-[calc(100vw-2.5rem)] -translate-x-1/2 rounded-xl"
     ) do
-      div(class: "mx-auto flex max-w-3xl flex-wrap items-center justify-center gap-x-4 gap-y-2") do
-        p(class: "text-sm leading-relaxed text-text-primary") { t(".message") }
+      div(class: "flex items-center justify-between gap-6 rounded-xl border border-border-default bg-surface-card px-5 py-3 shadow-lg") do
+        p(class: "text-sm leading-relaxed text-text-secondary") { t(".message") }
         render Components::Button.new(
           label: t(".dismiss"),
-          variant: :secondary,
+          variant: :primary,
           size: :sm,
           data: {action: "cookie-notice#dismiss"}
         )

--- a/app/javascript/controllers/cookie_notice_controller.js
+++ b/app/javascript/controllers/cookie_notice_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    if (document.cookie.includes("shrk-cookie-notice=")) return
+
+    this.element.hidden = false
+  }
+
+  dismiss() {
+    document.cookie = "shrk-cookie-notice=seen; max-age=31536000; path=/; samesite=lax"
+    this.element.hidden = true
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,5 +37,6 @@
   <body class="min-h-screen bg-surface-page font-sans text-text-primary antialiased">
     <%= yield %>
     <%= render Components::Toasts.new(flash: flash) %>
+    <%= render Components::CookieNotice.new %>
   </body>
 </html>

--- a/config/locales/legal.en.yml
+++ b/config/locales/legal.en.yml
@@ -41,8 +41,11 @@ en:
         age requirement (at least 13, or older where your country requires) to use
         Discord and the Service.
       cookies_h: Cookies
-      cookies_p: 'We set exactly one cookie: the essential encrypted session cookie
-        described above. No tracking, no third-party cookies.'
+      cookies_p: 'We set two cookies: the essential encrypted session cookie described
+        above, and a small flag (valid one year) remembering that you dismissed our
+        cookie note. No tracking, no third-party cookies. Your browser also keeps
+        a few purely local preferences in localStorage — your theme choice and collapsed-panel
+        state. These never leave your device and we never read them server-side.'
       data_account: 'Dashboard account: when you sign in with Discord we store your
         Discord ID, username, display name and avatar reference. We request only the
         identify and guilds OAuth scopes - we never receive your email, password or
@@ -144,7 +147,7 @@ en:
         and our hosting provider Hetzner (Helsinki, Finland, within the EEA), where
         the Service and its database run. We may disclose data where required by law.'
       title: Privacy policy
-      updated: 'Last updated: July 13th, 2026'
+      updated: 'Last updated: July 17th, 2026'
     terms_of_service:
       admin_h: Your responsibilities as a server admin
       admin_p: If you add shrkbot to a server or configure it, you're responsible

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -43,7 +43,7 @@ en:
       dismiss: Oh, nice!
       message: We only set technical cookies to make the site work. No tracking, analytics,
         or anything else from a third party. We will remember that you've seen this,
-        though - with a cookie, of course.
+        though - with a cookie, of course. :)
     legal_links:
       imprint: Imprint
       privacy: Privacy policy

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -39,6 +39,11 @@ en:
       enable: Enable %{plugin}
       enabled: Enabled
       servers: Servers
+    cookie_notice:
+      dismiss: Oh, nice!
+      message: We only set technical cookies to make the site work. No tracking, analytics,
+        or anything else from a third party. We will remember that you've seen this,
+        though - with a cookie, of course.
     legal_links:
       imprint: Imprint
       privacy: Privacy policy

--- a/spec/components/cookie_notice_spec.rb
+++ b/spec/components/cookie_notice_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::CookieNotice do
+  include_context "component view context"
+
+  subject(:html) { described_class.new.render_in(view_context) }
+
+  it "renders hidden by default" do
+    expect(html).to include("hidden")
+  end
+
+  it "wires the Stimulus controller and dismiss action" do
+    expect(html).to include('data-controller="cookie-notice"').and include("cookie-notice#dismiss")
+  end
+
+  it "shows the no-tracking message and dismiss label" do
+    expect(html).to include("only set technical cookies").and include("Oh, nice!")
+  end
+end


### PR DESCRIPTION
## What

A dismissible one-time banner on every page: *"We only set technical cookies to make the site work. No tracking, analytics, or anything else from a third party. We will remember that you've seen this, though - with a cookie, of course."* with an **Oh, nice!** button.

This is flavor, not compliance — everything shrkbot stores client-side is exempt from consent under §25(2) TDDDG / ePrivacy Art. 5(3) (essential session cookie, user-requested UI preferences), so no consent flow is needed or implied. The banner just brags about it.

## How

- `Components::CookieNotice` (Phlex), mounted in the layout next to `Components::Toasts` — renders `hidden`, fixed to the bottom edge, `role="status"`.
- `cookie_notice_controller.js` (Stimulus) reveals it on connect unless the `shrk-cookie-notice` cookie is present; dismissing sets that cookie (one year, `SameSite=Lax`) and hides the banner. Cookie on purpose, not localStorage — so the copy stays literally true.
- No server-side storage at all; nothing reads the cookie server-side.
- Privacy policy updated in the same chunk: now discloses both cookies and the localStorage UI preferences (theme, collapsed panels), "Last updated" bumped to July 17th, 2026.
- No JS: banner simply never appears (it ships hidden). Acceptable for a flavor feature.

## Tests

Component spec covers default-hidden rendering, Stimulus wiring, and the copy. All gates green locally: rspec (1920/0), standardrb, active_record_doctor, undercover, i18n-tasks missing + check-normalized.