### PR TITLE
Send proactive messages with a push-notification subject

### DIFF
--- a/app/bot/activity_log.rb
+++ b/app/bot/activity_log.rb
@@ -6,11 +6,11 @@ module Bot
 
     module_function
 
-    def post(server_configuration, bot:, title:, body:, meta:, image: nil, components: [], allowed_mentions: SUPPRESS_MENTIONS)
+    def post(server_configuration, bot:, title:, body:, meta:, image: nil, components: [], allowed_mentions: SUPPRESS_MENTIONS, subject: nil)
       channel_id = server_configuration.logging_setting.channel_id
       return unless channel_id
 
-      deliver(bot, channel_id, entry(title, body, meta, image:, components:), allowed_mentions:, attachments: image && [image])
+      deliver(bot, channel_id, entry(title, body, meta, image:, components:), allowed_mentions:, attachments: image && [image], subject:)
     end
 
     def enabled?(server_configuration, action)
@@ -26,11 +26,11 @@ module Bot
       Discord::Components.container(blocks)
     end
 
-    def deliver(bot, channel_id, entry, allowed_mentions: SUPPRESS_MENTIONS, attachments: nil)
+    def deliver(bot, channel_id, entry, allowed_mentions: SUPPRESS_MENTIONS, attachments: nil, subject: nil)
       channel = bot.channel(channel_id)
       return unless channel
 
-      Discord::Components.send_to(channel, entry, allowed_mentions:, attachments:)
+      Discord::Components.send_to(channel, entry, allowed_mentions:, attachments:, subject:)
     rescue => e
       Rails.logger.warn("[ActivityLog] could not write to ##{channel_id}: #{e.class}: #{e.message}")
     end

--- a/app/bot/discord/components.rb
+++ b/app/bot/discord/components.rb
@@ -50,8 +50,29 @@ module Bot
         {type: MEDIA_GALLERY, items: urls.map { |url| {media: {url:}} }}
       end
 
-      def send_to(channel, rendered, allowed_mentions: nil, attachments: nil)
-        channel.send_message(nil, false, nil, attachments, allowed_mentions, nil, rendered[:components], rendered[:flags])
+      def send_to(channel, rendered, allowed_mentions: nil, attachments: nil, subject: nil)
+        unless subject
+          return channel.send_message(nil, false, nil, attachments, allowed_mentions, nil, rendered[:components], rendered[:flags])
+        end
+
+        message = channel.send_message(subject, false, nil, attachments, allowed_mentions, nil, nil, 0)
+        convert_to_v2(channel.id, message.id, rendered)
+        message
+      end
+
+      def convert_to_v2(channel_id, message_id, rendered)
+        Discordrb::API::Channel.edit_message(
+          Bot::Config.rest_token,
+          channel_id,
+          message_id,
+          nil,
+          nil,
+          nil,
+          rendered[:components],
+          rendered[:flags]
+        )
+      rescue => e
+        Rails.logger.warn("[Components] message #{message_id} left as plain text: #{e.class}: #{e.message}")
       end
     end
   end

--- a/app/bot/discord/components.rb
+++ b/app/bot/discord/components.rb
@@ -66,7 +66,7 @@ module Bot
           channel_id,
           message_id,
           nil,
-          nil,
+          {parse: []},
           nil,
           rendered[:components],
           rendered[:flags]

--- a/app/bot/owner_broadcast.rb
+++ b/app/bot/owner_broadcast.rb
@@ -17,7 +17,7 @@ module Bot
     end
 
     def deliver(bot, owner_id, content)
-      Discord::Components.send_to(bot.pm_channel(owner_id), message(content))
+      Discord::Components.send_to(bot.pm_channel(owner_id), message(content), subject: content)
       true
     rescue => e
       Rails.logger.warn("[OwnerBroadcast] could not DM owner #{owner_id}: #{e.class}: #{e.message}")

--- a/app/bot/owner_broadcast.rb
+++ b/app/bot/owner_broadcast.rb
@@ -17,11 +17,15 @@ module Bot
     end
 
     def deliver(bot, owner_id, content)
-      Discord::Components.send_to(bot.pm_channel(owner_id), message(content), subject: content)
+      Discord::Components.send_to(bot.pm_channel(owner_id), message(content), subject: subject(content))
       true
     rescue => e
       Rails.logger.warn("[OwnerBroadcast] could not DM owner #{owner_id}: #{e.class}: #{e.message}")
       false
+    end
+
+    def subject(content)
+      "New shrkbot announcement: #{content}"
     end
 
     def message(content)

--- a/app/bot/server_onboarder.rb
+++ b/app/bot/server_onboarder.rb
@@ -7,7 +7,7 @@ module Bot
     def notify(bot, server, config)
       return if config.onboarded_at?
 
-      Discord::Components.send_to(bot.pm_channel(server.owner.id), message(server))
+      Discord::Components.send_to(bot.pm_channel(server.owner.id), message(server), subject: subject(server))
       config.update!(onboarded_at: Time.current)
     rescue => e
       Rails.logger.error("[ServerOnboarder] could not onboard server #{server.id}: #{e.class}: #{e.message}")
@@ -21,6 +21,10 @@ module Bot
           Discord::Components.text("-# Sign in with Discord to enable plugins and manage settings.")
         ]
       )
+    end
+
+    def subject(server)
+      "Thanks for adding shrkbot! Set up #{server.name} on the web dashboard."
     end
 
     def body(server)

--- a/app/bot/server_onboarder.rb
+++ b/app/bot/server_onboarder.rb
@@ -24,7 +24,7 @@ module Bot
     end
 
     def subject(server)
-      "Thanks for adding shrkbot! Set up #{server.name} on the web dashboard."
+      "Thanks for adding shrkbot! Set up #{server.name} here: #{dashboard_url(server)}"
     end
 
     def body(server)

--- a/app/jobs/reminders/deliver_job.rb
+++ b/app/jobs/reminders/deliver_job.rb
@@ -18,24 +18,25 @@ module Reminders
 
     def deliver(reminder)
       channel_id = deliver_via_dm?(reminder) ? dm_channel_id(reminder.user_id) : reminder.channel_id
-      rendered = message(reminder)
-      Discordrb::API::Channel.create_message(
+      text = content(reminder)
+      response = Discordrb::API::Channel.create_message(
         Bot::Config.rest_token,
         channel_id,
-        nil,
+        text,
         false,
         nil,
         nil,
         nil,
         {parse: [], users: [reminder.user_id]},
         nil,
-        rendered[:components],
-        rendered[:flags]
+        nil,
+        nil
       )
+      Bot::Discord::Components.convert_to_v2(channel_id, response_id(response), message(text))
     end
 
-    def message(reminder)
-      Bot::Discord::Components.container([Bot::Discord::Components.text(content(reminder))])
+    def message(text)
+      Bot::Discord::Components.container([Bot::Discord::Components.text(text)])
     end
 
     def deliver_via_dm?(reminder)
@@ -46,7 +47,11 @@ module Reminders
     end
 
     def dm_channel_id(user_id)
-      JSON.parse(Discordrb::API::User.create_pm(Bot::Config.rest_token, user_id))["id"]
+      response_id(Discordrb::API::User.create_pm(Bot::Config.rest_token, user_id))
+    end
+
+    def response_id(response)
+      JSON.parse(response)["id"]
     end
 
     def content(reminder)

--- a/app/jobs/reminders/deliver_job.rb
+++ b/app/jobs/reminders/deliver_job.rb
@@ -18,11 +18,10 @@ module Reminders
 
     def deliver(reminder)
       channel_id = deliver_via_dm?(reminder) ? dm_channel_id(reminder.user_id) : reminder.channel_id
-      text = content(reminder)
       response = Discordrb::API::Channel.create_message(
         Bot::Config.rest_token,
         channel_id,
-        text,
+        subject(reminder),
         false,
         nil,
         nil,
@@ -32,11 +31,15 @@ module Reminders
         nil,
         nil
       )
-      Bot::Discord::Components.convert_to_v2(channel_id, response_id(response), message(text))
+      Bot::Discord::Components.convert_to_v2(channel_id, response_id(response), message(reminder))
     end
 
-    def message(text)
-      Bot::Discord::Components.container([Bot::Discord::Components.text(text)])
+    def subject(reminder)
+      "Reminder: #{reminder.message} <@#{reminder.user_id}>"
+    end
+
+    def message(reminder)
+      Bot::Discord::Components.container([Bot::Discord::Components.text(content(reminder))])
     end
 
     def deliver_via_dm?(reminder)

--- a/app/plugins/moderation/events/spam_guard.rb
+++ b/app/plugins/moderation/events/spam_guard.rb
@@ -119,12 +119,14 @@ module Moderation
         timeout_until: settings.punishment_timeout? ? Time.current + settings.timeout_seconds : nil
       )
 
+      title = I18n.t("moderation.spam_protection.notification.title.#{settings.action}")
       Bot::ActivityLog.post(
         config,
         bot: event.bot,
-        title: I18n.t("moderation.spam_protection.notification.title.#{settings.action}"),
+        title:,
         body:,
         meta: I18n.t("moderation.spam_protection.notification.meta.#{settings.action}"),
+        subject: StaffPing.prefix(staff_role_id, ping:) + title,
         allowed_mentions: {parse: [], roles: StaffPing.allowed_roles(staff_role_id, ping:)}
       )
     end

--- a/app/plugins/moderation/image_scanning/verdict_executor.rb
+++ b/app/plugins/moderation/image_scanning/verdict_executor.rb
@@ -70,11 +70,12 @@ module Moderation
         ping = settings.ping_staff
         state = removed ? "removed" : "flagged"
         image = image_bytes && Bot::Discord::FileUpload.new(image_bytes, File.basename(URI(context.image_url).path))
+        title = I18n.t("moderation.image_scanning.flag.title.#{state}")
 
         Bot::ActivityLog.post(
           config,
           bot: context.bot,
-          title: I18n.t("moderation.image_scanning.flag.title.#{state}"),
+          title:,
           body: StaffPing.prefix(staff_role_id, ping:) + I18n.t(
             "moderation.image_scanning.flag.body",
             author: "<@#{context.member.id}>",
@@ -84,6 +85,7 @@ module Moderation
           meta: I18n.t("moderation.image_scanning.flag.meta.#{state}"),
           image:,
           components: message_components(punishment.action),
+          subject: StaffPing.prefix(staff_role_id, ping:) + title,
           allowed_mentions: {parse: [], roles: StaffPing.allowed_roles(staff_role_id, ping:)}
         )
       end

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -354,10 +354,17 @@ the `CONTAINER`/`TEXT_DISPLAY`/`SEPARATOR` type ids, the `COMPONENTS_V2` flag, a
 `container`/`text`/`separator` builders — so every sender (role messages, `/info`, the
 owner broadcast, the onboarding DM, activity-log entries) renders the same way and the
 brand colour lives in one place (`Bot::Config::ACCENT_COLOR`, the container default).
-`Components.send_to(channel, rendered, allowed_mentions:)` owns the positional
+`Components.send_to(channel, rendered, allowed_mentions:, subject:)` owns the positional
 `channel.send_message` shape (nil content + components + flags), so call sites never
 enumerate the discordrb signature; only `Reminders::DeliverJob` sends over raw REST
 (no gateway in the jobs process) and keeps its own `create_message` call.
+Components V2 messages carry no `content`, so their push notifications have an empty
+preview — proactive sends (reminders, the owner broadcast, the onboarding DM) therefore
+pass a `subject:`: the wrapper sends it as plain content (the notification fires on
+create with that preview), then `convert_to_v2` edits the message into the container
+(explicit null content + the `COMPONENTS_V2` flag — Discord only allows this conversion
+plain→V2, never back). A failed conversion is logged and leaves the readable plain
+message standing; `DeliverJob` shares `convert_to_v2` after its REST `create_message`.
 
 `Roles::Message` composes those builders into a **Components V2** payload, so
 `public_message`/`multi_picker` return `{components:, flags:}` with the `COMPONENTS_V2`

--- a/spec/bot/activity_log_spec.rb
+++ b/spec/bot/activity_log_spec.rb
@@ -48,6 +48,29 @@ RSpec.describe Bot::ActivityLog do
       post
     end
 
+    it "sends without a subject by default" do
+      expect(Bot::Discord::Components).to receive(:send_to).with(channel, anything, hash_including(subject: nil))
+      post
+    end
+
+    context "with a subject" do
+      subject(:post) do
+        described_class.post(
+          server_config,
+          bot:,
+          title: "Scam image removed",
+          body: "<@42> posted an image.",
+          meta: "The message was deleted automatically.",
+          subject: "<@&9>: Scam image removed"
+        )
+      end
+
+      it "passes it through to the send" do
+        expect(Bot::Discord::Components).to receive(:send_to).with(channel, anything, hash_including(subject: "<@&9>: Scam image removed"))
+        post
+      end
+    end
+
     context "with an image" do
       let(:upload) { Bot::Discord::FileUpload.new("fakebytes", "scam.png") }
 

--- a/spec/bot/discord/components_spec.rb
+++ b/spec/bot/discord/components_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "discordrb"
 
 RSpec.describe Bot::Discord::Components do
   describe ".action_row" do
@@ -14,22 +15,87 @@ RSpec.describe Bot::Discord::Components do
   end
 
   describe ".send_to" do
+    subject(:send_to) { described_class.send_to(channel, rendered, attachments:) }
+
     let(:rendered) { described_class.container([described_class.text("hello")]) }
     let(:channel) { double("channel", send_message: nil) }
+    let(:attachments) { nil }
 
     it "passes nil for attachments when none given" do
-      expect(channel).to receive(:send_message) do |_content, _tts, _embed, attachments, *_rest|
-        expect(attachments).to be_nil
+      expect(channel).to receive(:send_message) do |_content, _tts, _embed, sent_attachments, *_rest|
+        expect(sent_attachments).to be_nil
       end
-      described_class.send_to(channel, rendered)
+      send_to
     end
 
-    it "forwards attachments when given" do
-      io = Bot::Discord::FileUpload.new("bytes", "img.png")
-      expect(channel).to receive(:send_message) do |_content, _tts, _embed, attachments, *_rest|
-        expect(attachments).to eq([io])
+    it "does not edit the message when no subject is given" do
+      expect(Discordrb::API::Channel).not_to receive(:edit_message)
+      send_to
+    end
+
+    context "with attachments" do
+      let(:attachments) { [Bot::Discord::FileUpload.new("bytes", "img.png")] }
+
+      it "forwards them" do
+        expect(channel).to receive(:send_message) do |_content, _tts, _embed, sent_attachments, *_rest|
+          expect(sent_attachments).to eq(attachments)
+        end
+        send_to
       end
-      described_class.send_to(channel, rendered, attachments: [io])
+    end
+
+    context "with a subject" do
+      subject(:send_to) { described_class.send_to(channel, rendered, subject: "reminder: hello") }
+
+      let(:message) { double("message", id: 30) }
+      let(:channel) { double("channel", id: 20, send_message: message) }
+
+      before do
+        allow(Bot::Config).to receive(:rest_token).and_return("Bot tok")
+        allow(Discordrb::API::Channel).to receive(:edit_message)
+      end
+
+      it "sends the subject as a plain message so the push notification has a preview" do
+        expect(channel).to receive(:send_message).with(
+          "reminder: hello",
+          false,
+          nil,
+          nil,
+          nil,
+          nil,
+          nil,
+          0
+        ).and_return(message)
+        send_to
+      end
+
+      it "converts the message to components v2 with the content nulled out" do
+        expect(Discordrb::API::Channel).to receive(:edit_message).with(
+          "Bot tok",
+          20,
+          30,
+          nil,
+          nil,
+          nil,
+          rendered[:components],
+          rendered[:flags]
+        )
+        send_to
+      end
+
+      it "returns the sent message" do
+        expect(send_to).to eq(message)
+      end
+
+      context "when the conversion fails" do
+        before do
+          allow(Discordrb::API::Channel).to receive(:edit_message).and_raise("500 oops")
+        end
+
+        it "leaves the plain message standing and returns it" do
+          expect(send_to).to eq(message)
+        end
+      end
     end
   end
 

--- a/spec/bot/discord/components_spec.rb
+++ b/spec/bot/discord/components_spec.rb
@@ -69,13 +69,13 @@ RSpec.describe Bot::Discord::Components do
         send_to
       end
 
-      it "converts the message to components v2 with the content nulled out" do
+      it "converts the message to components v2 with the content nulled out and mention re-parsing suppressed" do
         expect(Discordrb::API::Channel).to receive(:edit_message).with(
           "Bot tok",
           20,
           30,
           nil,
-          nil,
+          {parse: []},
           nil,
           rendered[:components],
           rendered[:flags]

--- a/spec/bot/owner_broadcast_spec.rb
+++ b/spec/bot/owner_broadcast_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Bot::OwnerBroadcast do
     let(:bots) { [shard_one, shard_two] }
     let(:shard_one) { double("shard_one", servers: {1 => server(10), 2 => server(20)}) }
     let(:shard_two) { double("shard_two", servers: {3 => server(10), 4 => server(30)}) }
-    let(:channel) { double("channel", send_message: nil) }
+    let(:channel) { double("channel") }
 
     def server(owner_id)
       double("server", owner: double("owner", id: owner_id))
@@ -17,6 +17,7 @@ RSpec.describe Bot::OwnerBroadcast do
 
     before do
       allow(shard_one).to receive(:pm_channel).and_return(channel)
+      allow(Bot::Discord::Components).to receive(:send_to)
     end
 
     it "counts every server across all shards" do
@@ -35,14 +36,19 @@ RSpec.describe Bot::OwnerBroadcast do
     end
 
     it "sends a components-v2 message with the content and a footer below a separator" do
-      expect(channel).to receive(:send_message).at_least(:once) do |*args|
-        blocks = args[6].first[:components]
-        expect(args[7]).to eq(Bot::Discord::Components::COMPONENTS_V2)
+      expect(Bot::Discord::Components).to receive(:send_to).at_least(:once) do |_channel, rendered, **options|
+        expect(rendered[:flags]).to eq(Bot::Discord::Components::COMPONENTS_V2)
+        blocks = rendered[:components].first[:components]
         expect(blocks.map { |block| block[:type] }).to include(Bot::Discord::Components::SEPARATOR)
         body = blocks.filter_map { |block| block[:content] }
         expect(body).to include("hello owners")
         expect(body.join).to include("-# ").and include("you own at least one server")
       end
+      result
+    end
+
+    it "passes the broadcast content as the push-notification subject" do
+      expect(Bot::Discord::Components).to receive(:send_to).at_least(:once).with(channel, anything, subject: "hello owners")
       result
     end
 

--- a/spec/bot/owner_broadcast_spec.rb
+++ b/spec/bot/owner_broadcast_spec.rb
@@ -47,8 +47,8 @@ RSpec.describe Bot::OwnerBroadcast do
       result
     end
 
-    it "passes the broadcast content as the push-notification subject" do
-      expect(Bot::Discord::Components).to receive(:send_to).at_least(:once).with(channel, anything, subject: "hello owners")
+    it "passes a labelled push-notification subject carrying the content" do
+      expect(Bot::Discord::Components).to receive(:send_to).at_least(:once).with(channel, anything, subject: "New shrkbot announcement: hello owners")
       result
     end
 

--- a/spec/bot/server_onboarder_spec.rb
+++ b/spec/bot/server_onboarder_spec.rb
@@ -8,8 +8,12 @@ RSpec.describe Bot::ServerOnboarder do
   let(:config) { create(:server_configuration) }
   let(:owner) { double("owner", id: 999) }
   let(:server) { double("server", id: 77, name: "Dev Refuge", owner:) }
-  let(:pm_channel) { double("pm_channel", send_message: nil) }
+  let(:pm_channel) { double("pm_channel") }
   let(:bot) { double("bot", pm_channel:) }
+
+  before do
+    allow(Bot::Discord::Components).to receive(:send_to)
+  end
 
   context "when the server has not been onboarded" do
     before do
@@ -22,13 +26,20 @@ RSpec.describe Bot::ServerOnboarder do
     end
 
     it "sends a branded container with the deep dashboard link and server name" do
-      expect(pm_channel).to receive(:send_message) do |*args|
-        components = args[6]
-        flags = args[7]
-        expect(flags).to eq(Bot::Discord::Components::COMPONENTS_V2)
-        expect(components.to_s).to include("https://shrkbot.gg/servers/77")
-        expect(components.to_s).to include("Dev Refuge")
+      expect(Bot::Discord::Components).to receive(:send_to) do |_channel, rendered, **options|
+        expect(rendered[:flags]).to eq(Bot::Discord::Components::COMPONENTS_V2)
+        expect(rendered[:components].to_s).to include("https://shrkbot.gg/servers/77")
+        expect(rendered[:components].to_s).to include("Dev Refuge")
       end
+      notify
+    end
+
+    it "passes a plain summary as the push-notification subject" do
+      expect(Bot::Discord::Components).to receive(:send_to).with(
+        pm_channel,
+        anything,
+        subject: "Thanks for adding shrkbot! Set up Dev Refuge on the web dashboard."
+      )
       notify
     end
 

--- a/spec/bot/server_onboarder_spec.rb
+++ b/spec/bot/server_onboarder_spec.rb
@@ -34,11 +34,11 @@ RSpec.describe Bot::ServerOnboarder do
       notify
     end
 
-    it "passes a plain summary as the push-notification subject" do
+    it "passes a plain summary with the dashboard link as the push-notification subject" do
       expect(Bot::Discord::Components).to receive(:send_to).with(
         pm_channel,
         anything,
-        subject: "Thanks for adding shrkbot! Set up Dev Refuge on the web dashboard."
+        subject: "Thanks for adding shrkbot! Set up Dev Refuge here: https://shrkbot.gg/servers/77"
       )
       notify
     end

--- a/spec/jobs/reminders/deliver_job_spec.rb
+++ b/spec/jobs/reminders/deliver_job_spec.rb
@@ -18,12 +18,11 @@ RSpec.describe Reminders::DeliverJob do
   end
 
   context "in a channel" do
-    it "posts the reminder as plain content so the push notification has a preview, then deletes it" do
+    it "posts the reminder as a content-first subject so the push notification has a preview, then deletes it" do
       expect(Discordrb::API::Channel).to receive(:create_message) do |token, channel_id, content, _tts, _embeds, _nonce, _attachments, allowed_mentions, _message_reference, components, flags|
         expect(token).to eq("Bot tok")
         expect(channel_id).to eq(20)
-        expect(content).to include("<@10>")
-        expect(content).to include("hello")
+        expect(content).to eq("Reminder: hello <@10>")
         expect(allowed_mentions).to eq({parse: [], users: [10]})
         expect(components).to be_nil
         expect(flags).to be_nil

--- a/spec/jobs/reminders/deliver_job_spec.rb
+++ b/spec/jobs/reminders/deliver_job_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-require "discordrb" # the job sends over REST; load the client so we can stub it
+require "discordrb"
 
 RSpec.describe Reminders::DeliverJob do
   subject(:perform) { described_class.perform_now(reminder_id) }
@@ -13,22 +13,38 @@ RSpec.describe Reminders::DeliverJob do
 
   before do
     allow(Bot::Config).to receive(:token).and_return("tok")
+    allow(Discordrb::API::Channel).to receive(:create_message).and_return({id: 55}.to_json)
+    allow(Discordrb::API::Channel).to receive(:edit_message)
   end
 
   context "in a channel" do
-    it "posts the reminder as a branded container and then deletes it" do
+    it "posts the reminder as plain content so the push notification has a preview, then deletes it" do
       expect(Discordrb::API::Channel).to receive(:create_message) do |token, channel_id, content, _tts, _embeds, _nonce, _attachments, allowed_mentions, _message_reference, components, flags|
         expect(token).to eq("Bot tok")
         expect(channel_id).to eq(20)
-        expect(content).to be_nil
+        expect(content).to include("<@10>")
+        expect(content).to include("hello")
         expect(allowed_mentions).to eq({parse: [], users: [10]})
+        expect(components).to be_nil
+        expect(flags).to be_nil
+        {id: 55}.to_json
+      end
+      perform
+      expect(Reminders::Reminder.exists?(reminder.id)).to be(false)
+    end
+
+    it "converts the message to a branded container" do
+      expect(Discordrb::API::Channel).to receive(:edit_message) do |token, channel_id, message_id, content, _mentions, _embeds, components, flags|
+        expect(token).to eq("Bot tok")
+        expect(channel_id).to eq(20)
+        expect(message_id).to eq(55)
+        expect(content).to be_nil
         expect(flags).to eq(Bot::Discord::Components::COMPONENTS_V2)
         body = components.first[:components].first[:content]
         expect(body).to include("<@10>")
         expect(body).to include("hello")
       end
       perform
-      expect(Reminders::Reminder.exists?(reminder.id)).to be(false)
     end
   end
 
@@ -47,7 +63,7 @@ RSpec.describe Reminders::DeliverJob do
     end
 
     it "delivers to the original channel" do
-      expect(Discordrb::API::Channel).to receive(:create_message).with("Bot tok", 20, any_args)
+      expect(Discordrb::API::Channel).to receive(:create_message).with("Bot tok", 20, any_args).and_return({id: 55}.to_json)
       perform
     end
   end
@@ -59,7 +75,7 @@ RSpec.describe Reminders::DeliverJob do
     end
 
     it "delivers via DM" do
-      expect(Discordrb::API::Channel).to receive(:create_message).with("Bot tok", 77, any_args)
+      expect(Discordrb::API::Channel).to receive(:create_message).with("Bot tok", 77, any_args).and_return({id: 55}.to_json)
       perform
     end
   end
@@ -71,7 +87,7 @@ RSpec.describe Reminders::DeliverJob do
     end
 
     it "delivers via DM" do
-      expect(Discordrb::API::Channel).to receive(:create_message).with("Bot tok", 88, any_args)
+      expect(Discordrb::API::Channel).to receive(:create_message).with("Bot tok", 88, any_args).and_return({id: 55}.to_json)
       perform
     end
   end

--- a/spec/plugins/moderation/events/spam_guard_spec.rb
+++ b/spec/plugins/moderation/events/spam_guard_spec.rb
@@ -143,7 +143,8 @@ RSpec.describe Moderation::SpamGuard do
         log_channel,
         anything,
         allowed_mentions: hash_including(roles: array_including(staff_role_id)),
-        attachments: nil
+        attachments: nil,
+        subject: "<@&#{staff_role_id}>: #{I18n.t("moderation.spam_protection.notification.title.purge")}"
       )
 
       simulate_message(channel_id: 1, message_id: 10)
@@ -459,12 +460,13 @@ RSpec.describe Moderation::SpamGuard do
       allow(Bot::Discord::Components).to receive(:send_to)
     end
 
-    it "notifies with empty roles in allowed_mentions" do
+    it "notifies with empty roles in allowed_mentions and no mention in the subject" do
       expect(Bot::Discord::Components).to receive(:send_to).with(
         log_channel,
         anything,
         allowed_mentions: {parse: [], roles: []},
-        attachments: nil
+        attachments: nil,
+        subject: I18n.t("moderation.spam_protection.notification.title.notify_only")
       )
 
       simulate_message(channel_id: 1, message_id: 10)
@@ -498,8 +500,7 @@ RSpec.describe Moderation::SpamGuard do
       expect(Bot::Discord::Components).to receive(:send_to).with(
         log_channel,
         anything,
-        allowed_mentions: {parse: [], roles: []},
-        attachments: nil
+        hash_including(allowed_mentions: {parse: [], roles: []}, attachments: nil)
       )
 
       simulate_message(channel_id: 1, message_id: 1)

--- a/spec/plugins/moderation/image_scanning/verdict_executor_spec.rb
+++ b/spec/plugins/moderation/image_scanning/verdict_executor_spec.rb
@@ -115,6 +115,7 @@ RSpec.describe Moderation::ImageScanning::VerdictExecutor do
         server_configuration,
         hash_including(
           title: I18n.t("moderation.image_scanning.flag.title.flagged"),
+          subject: "<@&#{staff_role_id}>: #{I18n.t("moderation.image_scanning.flag.title.flagged")}",
           allowed_mentions: {parse: [], roles: [staff_role_id]}
         )
       ) do |_config, kwargs|


### PR DESCRIPTION
## Why

Components v2 messages have no `content`, so push notifications for them show an empty preview. That's fine for interaction responses (the user is present) but bad for proactive sends — a reminder firing in your DMs should tell you what it's about.

## How

Discord allows converting a plain message into a components-v2 message via edit (explicit `content: null` + the `IS_COMPONENTS_V2` flag — one-way, [documented](https://docs.discord.com/developers/components/reference)), and the push notification fires on create with the original content. So:

- `Bot::Discord::Components.send_to` gains an optional `subject:` — sends the subject as plain content first, then `convert_to_v2` edits the message into the branded container. A failed conversion is logged and leaves the readable plain message standing (the subject carries the vital info by design).
- `Reminders::DeliverJob` (raw REST, no gateway in the jobs process) sends the reminder text as content, then shares `convert_to_v2`. The `<@user>` mention now rides in the create content, so the channel ping behaviour is unchanged.
- Owner broadcast passes the broadcast text as subject; the onboarding DM passes a plain one-line summary.
- Role-picker posts and interaction responses intentionally stay subject-less (a notification there would be noise).

Cost: one extra REST call per proactive send, a sub-second plain-text flash, and a permanent "(edited)" badge on those messages. Workaround until Discord gives CV2 messages a notification preview.

## Testing

Full suite + standardrb + active_record_doctor + undercover green locally. Live push-notification behaviour needs a real device — worth a quick `/remind` smoke test after deploy.