### PR TITLE
Return the streamed body from AttachmentDownload

### DIFF
--- a/app/plugins/moderation/attachment_download.rb
+++ b/app/plugins/moderation/attachment_download.rb
@@ -20,14 +20,16 @@ module Moderation
         open_timeout: 5,
         read_timeout: 30
       ) do |http|
+        body = nil
         http.request_get(uri) do |response|
           unless response.code.to_i.between?(200, 299)
             raise Error, "download failed: #{response.code}"
           end
           raise Error, "attachment too large" if (response.content_length || 0) > max_bytes
 
-          read_capped(response, max_bytes)
+          body = read_capped(response, max_bytes)
         end
+        body
       end
     rescue Net::OpenTimeout, Net::ReadTimeout, SocketError => e
       raise Error, e.message

--- a/spec/plugins/moderation/attachment_download_spec.rb
+++ b/spec/plugins/moderation/attachment_download_spec.rb
@@ -12,7 +12,10 @@ RSpec.describe Moderation::AttachmentDownload do
 
   before do
     allow(Net::HTTP).to receive(:start) { |*_args, &block| block.call(http) }
-    allow(http).to receive(:request_get) { |_uri, &block| block.call(response) }
+    allow(http).to receive(:request_get) do |_uri, &block|
+      block.call(response)
+      response
+    end
     allow(response).to receive(:read_body) { |&block| chunks.each { |chunk| block.call(chunk) } }
   end
 


### PR DESCRIPTION
## Why

Live regression from #shrkbot testing: posting a scam image raised `TypeError: no implicit conversion of Net::HTTPOK into String` in `SpamGuard#attachment_fingerprint`.

The byte-budget rewrite (ffb3411) switched `AttachmentDownload.call` to `http.request_get(uri) { |response| ... }` — but with a block, `request_get` returns the **response object**, not the block's value. `read_capped`'s string was computed and discarded, and both callers (spam-guard attachment fingerprints, image-scan `ImageDownload`) received a `Net::HTTPOK`. Every attachment fingerprint and image scan has been broken since that commit — spam guard raised, image scans hashed the wrong thing.

## How

Capture the body inside the block, return it from the `Net::HTTP.start` block.

The spec never caught it because its `request_get` stub returned the block's value — modeling the seam wrong. The stub now returns the response like the real API, which makes the "returns the streamed body" example a true regression test: verified it fails against the old production code and passes with the fix.

## Testing

Full suite + standardrb + undercover green locally. Live check: post a scam image / spam attachments — fingerprinting and image scan should work again.