### PR TITLE
Echo the reminder message in /remind confirmation

### DIFF
--- a/app/plugins/reminders/commands/remind.rb
+++ b/app/plugins/reminders/commands/remind.rb
@@ -23,7 +23,8 @@ module Reminders
       )
 
       if result.success?
-        event.respond(content: "I'll remind you <t:#{result.value.remind_at.to_i}:R>.", ephemeral: true)
+        reminder = result.value
+        event.respond(content: "I'll remind you <t:#{reminder.remind_at.to_i}:R>:\n>>> #{reminder.message}", ephemeral: true)
       else
         event.respond(content: "⚠️ #{result.errors.first}", ephemeral: true)
       end

--- a/spec/plugins/reminders/commands/remind_spec.rb
+++ b/spec/plugins/reminders/commands/remind_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Reminders::Remind do
   let(:event) do
     double("event", user: double(id: 1), channel_id: 2, server_id: 3, options:, respond: nil)
   end
-  let(:success_result) { Ops::ApplicationOperation::Result.new(true, double(remind_at: Time.at(1_000)), []) }
+  let(:success_result) { Ops::ApplicationOperation::Result.new(true, double(remind_at: Time.at(1_000), message: "hi"), []) }
 
   context "with valid options" do
     it "calls Ops::Reminders::Create with the event's options and confirms" do
@@ -17,6 +17,12 @@ RSpec.describe Reminders::Remind do
         .with(hash_including(user_id: 1, channel_id: 2, server_id: 3, message: "hi", duration: "1h", deliver_via_dm: false))
         .and_return(success_result)
       expect(event).to receive(:respond).with(hash_including(ephemeral: true, content: a_string_including("remind you")))
+      execute
+    end
+
+    it "echoes the reminder message in the confirmation" do
+      allow(Ops::Reminders::Create).to receive(:call).and_return(success_result)
+      expect(event).to receive(:respond).with(hash_including(content: a_string_including("hi")))
       execute
     end
   end


### PR DESCRIPTION
## What

`/remind` now repeats the reminder text in its confirmation:

```
I'll remind you <t:...:R>:
>>> your message here
```

## Why

Slash-command users don't always recall exactly what they typed. Echoing the stored message lets them verify it landed correctly.

## Notes

- Uses `>>>` block quote so multi-line messages stay fully quoted.
- Echoes the sanitized/stored `reminder.message`, not raw input.
- Confirmation is ephemeral, so no echo to other users.