### PR TITLE
Move external links on /info and /donate to link buttons

### DIFF
--- a/app/bot/commands/donate.rb
+++ b/app/bot/commands/donate.rb
@@ -21,9 +21,6 @@ module Bot
         "You are never obligated to donate - just using shrkbot is more than enough :) " \
         "And please only ever give money you don't otherwise need."
 
-      LINKS = "**If you'd like to chip in:**\n" \
-        "[PayPal](https://paypal.me/trueblackshark) · [Liberapay](https://liberapay.com/badBlackShark)"
-
       FOOTER = "-# All donations are non-refundable. Thanks for the support! <3"
 
       def execute
@@ -39,9 +36,17 @@ module Bot
             Discord::Components.separator,
             Discord::Components.text(PLEDGE),
             Discord::Components.separator,
-            Discord::Components.text(LINKS),
-            Discord::Components.separator,
             Discord::Components.text(FOOTER)
+          ],
+          buttons: [
+            Discord::Components.link_button(
+              url: "https://www.paypal.com/ncp/payment/WD5EEL2SJPBRQ",
+              label: "PayPal"
+            ),
+            Discord::Components.link_button(
+              url: "https://liberapay.com/badBlackShark",
+              label: "Liberapay"
+            )
           ]
         )
       end

--- a/app/bot/commands/info.rb
+++ b/app/bot/commands/info.rb
@@ -29,20 +29,24 @@ module Bot
             ),
             Discord::Components.separator,
             Discord::Components.text("**Built with**\n#{credits}"),
-            *configuration_section,
             Discord::Components.separator,
             Discord::Components.text("-# Want to support the project? Use /donate.")
-          ]
+          ],
+          buttons:
         )
       end
 
-      def configuration_section
-        return [] unless configurable?
-
-        [
-          Discord::Components.separator,
-          Discord::Components.text("**Configure me**\n[Manage this server's settings](#{Config.server_config_url(event.server_id)})")
+      def buttons
+        base = [
+          Discord::Components.link_button(url: ReleaseInfo::REPO_URL, label: "GitHub"),
+          Discord::Components.link_button(url: Config.invite_url, label: "Invite me")
         ]
+        return base unless configurable?
+
+        base << Discord::Components.link_button(
+          url: Config.server_config_url(event.server_id),
+          label: "Server settings"
+        )
       end
 
       def configurable?
@@ -53,8 +57,7 @@ module Bot
 
       def header
         "### #{event.bot.profile.username}\n" \
-          "I was written in [Ruby](https://www.ruby-lang.org/) by [badBlackShark](https://github.com/badBlackShark/).\n" \
-          "My code lives [here](#{ReleaseInfo::REPO_URL}). Want me on your server? [Invite me!](#{Config.invite_url})"
+          "I was written in [Ruby](https://www.ruby-lang.org/) by [badBlackShark](https://github.com/badBlackShark/)."
       end
 
       def credits

--- a/app/bot/config/config.rb
+++ b/app/bot/config/config.rb
@@ -36,7 +36,7 @@ module Bot
     end
 
     def invite_url
-      "https://discord.com/oauth2/authorize?client_id=#{client_id}"
+      "https://discord.com/oauth2/authorize?client_id=#{client_id}&scope=bot+applications.commands"
     end
 
     def web_base_url

--- a/app/bot/config/config.rb
+++ b/app/bot/config/config.rb
@@ -36,7 +36,7 @@ module Bot
     end
 
     def invite_url
-      "https://discord.com/oauth2/authorize?client_id=#{client_id}&scope=bot+applications.commands"
+      "https://discord.com/oauth2/authorize?client_id=#{client_id}"
     end
 
     def web_base_url

--- a/app/bot/discord/components.rb
+++ b/app/bot/discord/components.rb
@@ -11,9 +11,11 @@ module Bot
       THUMBNAIL = 11
       ACTION_ROW = 1
       BUTTON = 2
+      BUTTON_PRIMARY = 1
       BUTTON_SECONDARY = 2
       BUTTON_SUCCESS = 3
       BUTTON_DANGER = 4
+      BUTTON_LINK = 5
       COMPONENTS_V2 = 1 << 15
 
       module_function
@@ -22,12 +24,18 @@ module Bot
         {type: ACTION_ROW, components:}
       end
 
-      def button(custom_id:, label:, style: 1)
+      def button(custom_id:, label:, style: BUTTON_PRIMARY)
         {type: BUTTON, style:, label:, custom_id:}
       end
 
-      def container(blocks, accent_color: Config::ACCENT_COLOR)
-        {components: [{type: CONTAINER, accent_color:, components: blocks}], flags: COMPONENTS_V2}
+      def link_button(url:, label:)
+        {type: BUTTON, style: BUTTON_LINK, url:, label:}
+      end
+
+      def container(blocks, accent_color: Config::ACCENT_COLOR, buttons: [])
+        components = [{type: CONTAINER, accent_color:, components: blocks}]
+        components << action_row(buttons) if buttons.any?
+        {components:, flags: COMPONENTS_V2}
       end
 
       def text(body)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -354,6 +354,9 @@ the `CONTAINER`/`TEXT_DISPLAY`/`SEPARATOR` type ids, the `COMPONENTS_V2` flag, a
 `container`/`text`/`separator` builders — so every sender (role messages, `/info`, the
 owner broadcast, the onboarding DM, activity-log entries) renders the same way and the
 brand colour lives in one place (`Bot::Config::ACCENT_COLOR`, the container default).
+External links on a command response go in link buttons under the message, not inline
+markdown: `container(blocks, buttons: [Components.link_button(url:, label:), …])` appends
+an action row as a sibling after the container (see `/info` and `/donate`).
 `Components.send_to(channel, rendered, allowed_mentions:, subject:)` owns the positional
 `channel.send_message` shape (nil content + components + flags), so call sites never
 enumerate the discordrb signature; only `Reminders::DeliverJob` sends over raw REST

--- a/spec/bot/commands/donate_spec.rb
+++ b/spec/bot/commands/donate_spec.rb
@@ -18,14 +18,27 @@ RSpec.describe Bot::Commands::Donate do
 
   describe "the message content" do
     subject(:message) do
-      [described_class::COSTS, described_class::PLEDGE, described_class::LINKS, described_class::FOOTER].join("\n")
+      [described_class::COSTS, described_class::PLEDGE, described_class::FOOTER].join("\n")
     end
 
-    it { is_expected.to include("https://paypal.me/trueblackshark") }
-    it { is_expected.to include("https://liberapay.com/badBlackShark") }
     it { is_expected.to include("10.60€") }
     it { is_expected.to include("4.99€") }
     it { is_expected.to include("17.37€") }
     it { is_expected.not_to match(/yahoo/i) }
+  end
+
+  describe "the donation buttons" do
+    it "links PayPal and Liberapay" do
+      expect(event).to receive(:respond) do |components:, **|
+        urls = components.last[:components].map { |button| button[:url] }
+        expect(urls).to eq(
+          [
+            "https://www.paypal.com/ncp/payment/WD5EEL2SJPBRQ",
+            "https://liberapay.com/badBlackShark"
+          ]
+        )
+      end
+      execute
+    end
   end
 end

--- a/spec/bot/commands/info_spec.rb
+++ b/spec/bot/commands/info_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe Bot::Commands::Info do
     blocks(args).filter_map { |block| block[:content] }
   end
 
+  def button_urls(args)
+    args[:components].last[:components].map { |button| button[:url] }
+  end
+
   it "responds with an ephemeral components-v2 message" do
     expect(event).to receive(:respond) do |args|
       expect(args[:ephemeral]).to be(true)
@@ -44,14 +48,21 @@ RSpec.describe Bot::Commands::Info do
     execute
   end
 
-  it "credits the stack and links the code, invite, and donate command" do
+  it "credits the stack and links the donate command" do
     expect(event).to receive(:respond) do |args|
       body = texts(args).join("\n")
       expect(body).to include("shrkbot")
       expect(body).to include("Ruby")
-      expect(body).to include(Bot::Config.invite_url)
       expect(body).to include("discordrb").and include("Ruby on Rails")
       expect(body).to include("/donate")
+    end
+
+    execute
+  end
+
+  it "links the code and invite as buttons" do
+    expect(event).to receive(:respond) do |args|
+      expect(button_urls(args)).to eq([ReleaseInfo::REPO_URL, Bot::Config.invite_url])
     end
 
     execute
@@ -76,10 +87,9 @@ RSpec.describe Bot::Commands::Info do
     context "when the caller can manage the server" do
       let(:user) { double("member", id: 7, permission?: true) }
 
-      it "includes a link to the server's configuration page" do
+      it "includes a server settings button" do
         expect(event).to receive(:respond) do |args|
-          body = texts(args).join("\n")
-          expect(body).to include("https://shrk.test/servers/123")
+          expect(button_urls(args)).to include("https://shrk.test/servers/123")
         end
 
         execute
@@ -89,9 +99,9 @@ RSpec.describe Bot::Commands::Info do
     context "when the caller cannot manage the server" do
       let(:user) { double("member", id: 7, permission?: false) }
 
-      it "omits the configuration link" do
+      it "omits the server settings button" do
         expect(event).to receive(:respond) do |args|
-          expect(texts(args).join("\n")).not_to include("/servers/")
+          expect(button_urls(args)).not_to include("https://shrk.test/servers/123")
         end
 
         execute

--- a/spec/bot/config/config_spec.rb
+++ b/spec/bot/config/config_spec.rb
@@ -37,9 +37,9 @@ RSpec.describe Bot::Config do
   end
 
   describe ".invite_url" do
-    it "builds the OAuth authorize link from CLIENT_ID" do
+    it "builds the OAuth authorize link from CLIENT_ID with the bot and command scopes" do
       with_env("CLIENT_ID", "12345") do
-        expect(described_class.invite_url).to eq("https://discord.com/oauth2/authorize?client_id=12345")
+        expect(described_class.invite_url).to eq("https://discord.com/oauth2/authorize?client_id=12345&scope=bot+applications.commands")
       end
     end
   end

--- a/spec/bot/config/config_spec.rb
+++ b/spec/bot/config/config_spec.rb
@@ -37,9 +37,9 @@ RSpec.describe Bot::Config do
   end
 
   describe ".invite_url" do
-    it "builds the OAuth authorize link from CLIENT_ID with the bot and command scopes" do
+    it "builds the bare OAuth authorize link so Discord applies the app's default install settings" do
       with_env("CLIENT_ID", "12345") do
-        expect(described_class.invite_url).to eq("https://discord.com/oauth2/authorize?client_id=12345&scope=bot+applications.commands")
+        expect(described_class.invite_url).to eq("https://discord.com/oauth2/authorize?client_id=12345")
       end
     end
   end

--- a/spec/bot/discord/components_spec.rb
+++ b/spec/bot/discord/components_spec.rb
@@ -121,7 +121,41 @@ RSpec.describe Bot::Discord::Components do
       subject(:button) { described_class.button(custom_id: "mod:confirm:abc", label: "Confirm scam") }
 
       it "defaults to the primary style" do
-        expect(button[:style]).to eq(1)
+        expect(button[:style]).to eq(described_class::BUTTON_PRIMARY)
+      end
+    end
+  end
+
+  describe ".link_button" do
+    subject(:link_button) { described_class.link_button(url: "https://example.test", label: "Example") }
+
+    it "builds a link-style button carrying the url and label" do
+      expect(link_button).to eq(
+        type: described_class::BUTTON,
+        style: described_class::BUTTON_LINK,
+        url: "https://example.test",
+        label: "Example"
+      )
+    end
+  end
+
+  describe ".container" do
+    subject(:container) { described_class.container([described_class.text("hello")]) }
+
+    it "wraps the blocks in a single accented container" do
+      expect(container[:components].sole).to include(type: described_class::CONTAINER)
+    end
+
+    context "with buttons" do
+      subject(:container) { described_class.container([described_class.text("hello")], buttons: [button]) }
+
+      let(:button) { described_class.link_button(url: "https://example.test", label: "Example") }
+
+      it "appends an action row after the container" do
+        expect(container[:components].last).to eq(
+          type: described_class::ACTION_ROW,
+          components: [button]
+        )
       end
     end
   end


### PR DESCRIPTION
## What

- `Bot::Discord::Components` gains a `link_button(url:, label:)` builder (style 5) and `container` takes an optional `buttons:` kwarg that appends an action row after the container — the Emoji.gg-style buttons-under-the-message look.
- `/info`: the GitHub repo, invite, and (for callers with manage-server) server-settings links move from inline markdown to link buttons. Header keeps the Ruby/author credit.
- `/donate`: PayPal and Liberapay move to link buttons; the LINKS text block is gone. PayPal now points at the new payment URL (`paypal.com/ncp/payment/…` instead of `paypal.me`).
- `button` default style now uses a named `BUTTON_PRIMARY` constant instead of a bare `1`.
- `docs/architecture.md` documents the new convention: external links on command responses go in link buttons, not inline markdown.

## Testing

Full suite green (1942 examples), standardrb, active_record_doctor, undercover vs main all pass. Live `/info` + `/donate` render check is yours to run.