### PR TITLE
Add setup-help contact to onboarding DM

### DIFF
--- a/app/bot/server_onboarder.rb
+++ b/app/bot/server_onboarder.rb
@@ -18,6 +18,7 @@ module Bot
         [
           Discord::Components.text(body(server)),
           Discord::Components.separator,
+          Discord::Components.text("Need help with setup? Add **badBlackShark** on Discord."),
           Discord::Components.text("-# Sign in with Discord to enable plugins and manage settings.")
         ]
       )

--- a/spec/bot/server_onboarder_spec.rb
+++ b/spec/bot/server_onboarder_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Bot::ServerOnboarder do
         expect(rendered[:flags]).to eq(Bot::Discord::Components::COMPONENTS_V2)
         expect(rendered[:components].to_s).to include("https://shrkbot.gg/servers/77")
         expect(rendered[:components].to_s).to include("Dev Refuge")
+        expect(rendered[:components].to_s).to include("badBlackShark")
       end
       notify
     end


### PR DESCRIPTION
New server owners get a direct line for setup help (add **badBlackShark** on Discord), shown in the onboarding DM alongside the dashboard link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)