### PR TITLE
Recommend raising the bot role when it sits at the bottom

### DIFF
--- a/app/components/roles/config_form.rb
+++ b/app/components/roles/config_form.rb
@@ -8,12 +8,19 @@ class Components::Roles::ConfigForm < Components::Base
 
   def view_template
     div(id: "roles-config", class: "flex flex-col gap-5", data: {controller: "role-sets"}) do
+      bot_at_bottom_callout
       default_channel_card
       role_sets_section
     end
   end
 
   private
+
+  def bot_at_bottom_callout
+    return unless assignable_options.bot_at_bottom?
+
+    render Components::Callout.new(variant: :info) { t(".bot_at_bottom") }
+  end
 
   def default_channel_card
     render Components::ChannelCard.new(

--- a/app/plugins/roles/assignable_server_roles.rb
+++ b/app/plugins/roles/assignable_server_roles.rb
@@ -23,6 +23,12 @@ module Roles
       candidates.any? { |role| reason_for(role) }
     end
 
+    def bot_at_bottom?
+      return false unless bot_position
+
+      candidates.any? && candidates.none? { |role| role.position.to_i < bot_position }
+    end
+
     def assignable_ids
       candidates.reject { |role| reason_for(role) }.map(&:discord_id)
     end

--- a/app/presenters/assignable_role_options.rb
+++ b/app/presenters/assignable_role_options.rb
@@ -29,6 +29,10 @@ class AssignableRoleOptions
     @roles.any_unassignable?
   end
 
+  def bot_at_bottom?
+    @roles.bot_at_bottom?
+  end
+
   private
 
   def reason_text(role)

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -280,6 +280,9 @@ en:
           label: Force reminder delivery via DM
     roles:
       config_form:
+        bot_at_bottom: shrkbot's role sits at the very bottom of your server's role
+          list, so it can't assign any roles. Move it up in your server's role settings
+          to bring roles below it into reach.
         channel:
           help: Each role set posts here unless it has its own channel override.
           label: Default channel for role menus

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -280,9 +280,9 @@ en:
           label: Force reminder delivery via DM
     roles:
       config_form:
-        bot_at_bottom: shrkbot's role sits at the very bottom of your server's role
-          list, so it can't assign any roles. Move it up in your server's role settings
-          to bring roles below it into reach.
+        bot_at_bottom: shrkbot can only assign roles below its own, and it looks like
+          its role is at the very bottom. Please move shrkbot's role up if you want
+          it to be able to assign roles.
         channel:
           help: Each role set posts here unless it has its own channel override.
           label: Default channel for role menus

--- a/spec/components/roles/config_form_spec.rb
+++ b/spec/components/roles/config_form_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Components::Roles::ConfigForm do
   end
 
   it "renders no bot-position callout when roles sit below the bot" do
-    expect(html).not_to include("bottom of your server")
+    expect(html).not_to include("at the very bottom")
   end
 
   context "when the bot role sits at the bottom of the role list" do
@@ -34,7 +34,7 @@ RSpec.describe Components::Roles::ConfigForm do
     end
 
     it "recommends moving the bot role up" do
-      expect(html).to include("bottom of your server")
+      expect(html).to include("at the very bottom")
     end
   end
 

--- a/spec/components/roles/config_form_spec.rb
+++ b/spec/components/roles/config_form_spec.rb
@@ -22,6 +22,22 @@ RSpec.describe Components::Roles::ConfigForm do
     expect(html).to include("No channels have synced yet")
   end
 
+  it "renders no bot-position callout when roles sit below the bot" do
+    expect(html).not_to include("bottom of your server")
+  end
+
+  context "when the bot role sits at the bottom of the role list" do
+    let(:config) { create(:server_configuration, bot_role_position: 1) }
+
+    before do
+      create(:server_role, server_configuration: config, discord_id: 10, name: "Member", position: 2)
+    end
+
+    it "recommends moving the bot role up" do
+      expect(html).to include("bottom of your server")
+    end
+  end
+
   context "when a guild has a category with child text channels" do
     before do
       create(:server_channel, server_configuration: config, name: "General", channel_type: 4, discord_id: 900, position: 0)

--- a/spec/plugins/roles/assignable_server_roles_spec.rb
+++ b/spec/plugins/roles/assignable_server_roles_spec.rb
@@ -48,6 +48,42 @@ RSpec.describe Roles::AssignableServerRoles do
     end
   end
 
+  describe "#bot_at_bottom?" do
+    it "returns false when a candidate role sits below the bot" do
+      expect(query.bot_at_bottom?).to be(false)
+    end
+
+    context "when the bot role position is unknown" do
+      let(:config) { create(:server_configuration, discord_id: 900, bot_role_position: nil) }
+
+      it "returns false" do
+        expect(query.bot_at_bottom?).to be(false)
+      end
+    end
+
+    context "when every candidate role sits at or above the bot" do
+      let(:config) { create(:server_configuration, discord_id: 900, bot_role_position: 1) }
+
+      it "returns true" do
+        expect(query.bot_at_bottom?).to be(true)
+      end
+    end
+
+    context "when the guild has no candidate roles" do
+      let(:bare_config) { create(:server_configuration, discord_id: 800, bot_role_position: 1) }
+
+      subject(:bare_query) { described_class.new(bare_config) }
+
+      before do
+        create(:server_role, server_configuration: bare_config, discord_id: 800, name: "everyone", position: 0)
+      end
+
+      it "returns false" do
+        expect(bare_query.bot_at_bottom?).to be(false)
+      end
+    end
+  end
+
   describe "#any_unassignable?" do
     it "returns true when managed or above-bot candidates exist" do
       expect(query.any_unassignable?).to be(true)


### PR DESCRIPTION
When shrkbot's role is still in its spawn position (directly above @everyone), no role on the server is assignable. The role dropdown already grays out unassignable roles with a hover explanation, but that's easy to miss — this adds an info callout at the top of the roles config page recommending moving the role up.

- `Roles::AssignableServerRoles#bot_at_bottom?`: true when the bot role position is known, candidates exist, and none sit below the bot. Guilds with no roles besides @everyone don't get the callout (nothing to gain from moving up).
- `AssignableRoleOptions` delegates it; `ConfigForm` renders a `Components::Callout` (info variant) above the channel card when it's true.
- Specs for the query edge cases (nil position, all-above, no candidates) and callout rendering.

All gates green locally (rspec, standardrb, active_record_doctor, undercover, i18n-tasks).