### PR TITLE
Upload test coverage to Qlty from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    # id-token lets the Qlty coverage upload authenticate via OIDC instead of a
+    # stored secret.
+    permissions:
+      contents: read
+      id-token: write
+
     services:
       postgres:
         image: postgres:18
@@ -157,6 +163,13 @@ jobs:
 
       - name: Run specs
         run: bundle exec rspec
+
+      # The lcov file is named after the checkout directory, hence the glob.
+      - name: Upload coverage to Qlty
+        uses: qltysh/qlty-action/coverage@v2
+        with:
+          oidc: true
+          files: coverage/lcov/*.lcov
 
       - name: Check coverage of changed lines
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
Uploads the SimpleCov lcov report to Qlty after the spec run, authenticated via GitHub OIDC (no stored token). Qlty's own analysis covers maintainability server-side; this closes the coverage half.

Badge links for the README will follow once the project ID is available from the Qlty UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)