### PR TITLE
Harden CI workflow against token misuse

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,33 @@
 version: 2
 updates:
-- package-ecosystem: bundler
-  directory: "/"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 10
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    # Minor + patch bumps arrive as one weekly PR; majors stay separate so
+    # breaking changes get individual review.
+    groups:
+      ruby-minor-and-patch:
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      actions:
+        patterns: ["*"]
+
+  # Base images in Dockerfile, Dockerfile.dev, Dockerfile.prod. Ungrouped:
+  # image majors (Ruby, Postgres) deserve individual review.
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: docker-compose
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,6 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
-    # Minor + patch bumps arrive as one weekly PR; majors stay separate so
-    # breaking changes get individual review.
     groups:
       ruby-minor-and-patch:
         update-types: ["minor", "patch"]
@@ -20,8 +18,6 @@ updates:
       actions:
         patterns: ["*"]
 
-  # Base images in Dockerfile, Dockerfile.dev, Dockerfile.prod. Ungrouped:
-  # image majors (Ruby, Postgres) deserve individual review.
   - package-ecosystem: docker
     directory: "/"
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,8 +131,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    # id-token lets the Qlty coverage upload authenticate via OIDC instead of a
-    # stored secret.
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
     # new advisory must not surface as a red check on an unrelated PR.
     - cron: '0 6 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   scan_ruby:
     runs-on: ubuntu-latest
@@ -16,9 +19,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.319.0
         with:
           bundler-cache: true
 
@@ -33,9 +38,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.319.0
         with:
           bundler-cache: true
 
@@ -50,9 +57,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.319.0
         with:
           bundler-cache: true
 
@@ -65,9 +74,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.319.0
         with:
           bundler-cache: true
 
@@ -86,9 +97,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.319.0
         with:
           bundler-cache: true
 
@@ -100,9 +113,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.319.0
         with:
           bundler-cache: true
 
@@ -146,9 +161,10 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.319.0
         with:
           bundler-cache: true
 
@@ -166,7 +182,7 @@ jobs:
 
       # The lcov file is named after the checkout directory, hence the glob.
       - name: Upload coverage to Qlty
-        uses: qltysh/qlty-action/coverage@v2
+        uses: qltysh/qlty-action/coverage@08a0a862c159eae9b9003081da6663d96efef637 # v2.3.0
         with:
           oidc: true
           files: coverage/lcov/*.lcov


### PR DESCRIPTION
Fixes the three zizmor findings from Qlty's check, then extends Dependabot so the new SHA pins stay fresh.

**zizmor fixes (`ci.yml`):**
- **unpinned action reference (High):** `ruby/setup-ruby` and `qltysh/qlty-action/coverage` are now pinned to commit SHAs (with the version tag as a trailing comment). `actions/checkout` stays on its tag — zizmor's default policy trusts GitHub-owned actions.
- **overly broad permissions (Medium):** workflow-level `permissions: contents: read`; the test job keeps its explicit `id-token: write` for the Qlty OIDC upload.
- **credential persistence (Medium):** `persist-credentials: false` on all seven checkouts — no job pushes back to the repo.

Qlty's check on this PR re-ran zizmor and reports no blocking issues.

**Dependabot (`dependabot.yml`):**
- Gem minor/patch bumps grouped into one weekly PR; majors stay individual.
- Action bumps grouped into one weekly PR (this is what keeps the SHA pins updated).
- New: `docker` (Dockerfile base images) and `docker-compose` (postgres/redis service images) ecosystems, weekly, ungrouped so image majors get individual review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)