### PR TITLE
Add strong_migrations to guard rolling-deploy schema changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,8 @@ gem "omniauth-rails_csrf_protection"
 gem "redis"
 # Phosphor Icons as inline SVG for the web UI
 gem "phosphor_icons"
+# Catches migrations unsafe under rolling deploys (dropped columns, renames)
+gem "strong_migrations"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -542,6 +542,8 @@ GEM
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.2.0)
+    strong_migrations (2.8.0)
+      activerecord (>= 7.2)
     tailwindcss-rails (4.6.0)
       railties (>= 7.0.0)
       tailwindcss-ruby (~> 4.0)
@@ -642,6 +644,7 @@ DEPENDENCIES
   solid_queue
   standard
   stimulus-rails
+  strong_migrations
   tailwindcss-rails
   thruster
   turbo-rails
@@ -841,6 +844,7 @@ CHECKSUMS
   standard-performance (1.9.0) sha256=49483d31be448292951d80e5e67cdcb576c2502103c7b40aec6f1b6e9c88e3f2
   stimulus-rails (1.3.4) sha256=765676ffa1f33af64ce026d26b48e8ffb2e0b94e0f50e9119e11d6107d67cb06
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
+  strong_migrations (2.8.0) sha256=cb9c0f8160e60f3e9c0e76098d57a6f61825b9618e8eb41cebbd1c1079874439
   tailwindcss-rails (4.6.0) sha256=d99512867173d55c5ef8890427682299d8539f550cec1408b3d8667a538bd365
   tailwindcss-ruby (4.3.1) sha256=ced3198e057da98f21cb281f4821ac8882a2899047066895ba181caf312620c1
   tailwindcss-ruby (4.3.1-aarch64-linux-gnu) sha256=b42af5fdb7ade3f3f70cda217c288986cc6b773601437b8deb80ea229a96680c

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+StrongMigrations.start_after = 20260718220438
+StrongMigrations.lock_timeout = 10.seconds
+StrongMigrations.statement_timeout = 1.hour
+StrongMigrations.auto_analyze = true
+StrongMigrations.target_version = 18


### PR DESCRIPTION
## Why

Kamal deploys migrate via `bin/docker-entrypoint` (`db:prepare`, web role) before old `web`/`bot`/`jobs` containers are replaced — a window where old code runs against the new schema. Nothing enforced the two-step `ignored_columns` dance for column drops/renames.

## What

- `strong_migrations` gem: blocks unsafe migrations (drops without `ignored_columns`, renames, blocking DDL) at migration-write time; genuinely-safe cases go through `safety_assured`.
- Initializer: `start_after` marks all existing migrations safe, `target_version = 18` matches the production Postgres accessory, plus lock/statement timeouts so a migration can't hold locks indefinitely.

No runtime behavior change; checks run only when migrations run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)