### PR TITLE
LFG plugin — chunk A: config schema, models, operations, privacy

### DIFF
--- a/.active_record_doctor.rb
+++ b/.active_record_doctor.rb
@@ -36,7 +36,8 @@ ActiveRecordDoctor.configure do
       "channel_overwrites.target_id",
       "moderation_settings.staff_role_id",
       "moderation_verdicts.log_channel_id",
-      "moderation_verdicts.log_message_id"
+      "moderation_verdicts.log_message_id",
+      "lfg_pingable_roles.role_id"
     ]
 
   # These are NOT NULL with a DB default, so they're never nil — presence is wrong

--- a/app/models/lfg/pingable_role.rb
+++ b/app/models/lfg/pingable_role.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Lfg
+  class PingableRole < ApplicationRecord
+    self.table_name = "lfg_pingable_roles"
+
+    include Lfg::SnowflakeArrayLimit
+
+    belongs_to :lfg_settings,
+      class_name: "Lfg::Settings",
+      inverse_of: :pingable_roles
+
+    validates :role_id, presence: true, uniqueness: {scope: :lfg_settings_id}
+    validates :min_membership_days,
+      numericality: {only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 3_650},
+      allow_nil: true
+    validate :allowed_channel_ids_not_explicitly_empty
+    limits_snowflake_arrays :required_role_ids, :excluded_role_ids, :allowed_channel_ids
+
+    private
+
+    def allowed_channel_ids_not_explicitly_empty
+      return if allowed_channel_ids.nil? || allowed_channel_ids.any?
+
+      errors.add(:allowed_channel_ids, "must name at least one channel or inherit the default")
+    end
+  end
+end

--- a/app/models/lfg/settings.rb
+++ b/app/models/lfg/settings.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Lfg
+  class Settings < ApplicationRecord
+    self.table_name = "lfg_settings"
+
+    include Lfg::SnowflakeArrayLimit
+
+    belongs_to :server_configuration
+    has_many :pingable_roles,
+      class_name: "Lfg::PingableRole",
+      foreign_key: "lfg_settings_id",
+      inverse_of: :lfg_settings,
+      dependent: :delete_all
+
+    validates :cooldown_seconds,
+      numericality: {only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 86_400}
+    validates :post_lifetime_minutes,
+      numericality: {only_integer: true, greater_than_or_equal_to: 5, less_than_or_equal_to: 10_080}
+    validates :default_min_membership_days,
+      numericality: {only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 3_650},
+      allow_nil: true
+    limits_snowflake_arrays :default_required_role_ids, :default_excluded_role_ids, :allowed_channel_ids
+  end
+end

--- a/app/models/lfg/snowflake_array_limit.rb
+++ b/app/models/lfg/snowflake_array_limit.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Lfg
+  module SnowflakeArrayLimit
+    extend ActiveSupport::Concern
+
+    MAX_SNOWFLAKES = 50
+
+    class_methods do
+      def limits_snowflake_arrays(*attributes)
+        validate do
+          attributes.each do |attribute|
+            values = public_send(attribute)
+            next if values.nil? || values.size <= MAX_SNOWFLAKES
+
+            errors.add(attribute, "can have at most #{MAX_SNOWFLAKES} entries")
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/plugin_catalog.rb
+++ b/app/models/plugin_catalog.rb
@@ -42,7 +42,7 @@ class PluginCatalog
     Definition.new(key: :moderation, name: "Server Shield", description: "Your server's aegis: automated moderation beyond Discord's AutoMod.", requires_plugin: :logging, prerequisite: ->(c) { c.logging_setting&.channel_id.present? }),
     Definition.new(key: :spam_protection, name: "Cross-Channel Spam Guard", description: "Detects the same message blasted across multiple channels within seconds and purges it before it spreads. Matching is fingerprint-based — message content is never stored.", parent: :moderation, prerequisite: ->(c) { c.moderation_settings&.staff_role_id.present? }),
     Definition.new(key: :image_scanning, name: "Scam Image Detection", description: "Reads the text inside posted images and checks it against known scam patterns and previously confirmed scam images. Staff confirm or dismiss every catch, and the bot remembers.", parent: :moderation, prerequisite: ->(c) { c.moderation_settings&.staff_role_id.present? }),
-    Definition.new(key: :lfg, name: "Looking for Game", description: "Members rally a group with /lfg: it pings a game's role — instantly or scheduled — and others join with one click. Only the bot can ping the roles, so they stay quiet otherwise.")
+    Definition.new(key: :lfg, name: "Looking for Game", description: "Let members find people to play with both on the fly and scheduled in the future. Only shrkbot will ping, allowing you to turn off generally available role pings.")
   ].freeze
 
   def self.all

--- a/app/models/plugin_catalog.rb
+++ b/app/models/plugin_catalog.rb
@@ -41,7 +41,8 @@ class PluginCatalog
     Definition.new(key: :welcomes, name: "Welcomes", description: "Join and leave messages.", channel_setting: :welcome_settings),
     Definition.new(key: :moderation, name: "Server Shield", description: "Your server's aegis: automated moderation beyond Discord's AutoMod.", requires_plugin: :logging, prerequisite: ->(c) { c.logging_setting&.channel_id.present? }),
     Definition.new(key: :spam_protection, name: "Cross-Channel Spam Guard", description: "Detects the same message blasted across multiple channels within seconds and purges it before it spreads. Matching is fingerprint-based — message content is never stored.", parent: :moderation, prerequisite: ->(c) { c.moderation_settings&.staff_role_id.present? }),
-    Definition.new(key: :image_scanning, name: "Scam Image Detection", description: "Reads the text inside posted images and checks it against known scam patterns and previously confirmed scam images. Staff confirm or dismiss every catch, and the bot remembers.", parent: :moderation, prerequisite: ->(c) { c.moderation_settings&.staff_role_id.present? })
+    Definition.new(key: :image_scanning, name: "Scam Image Detection", description: "Reads the text inside posted images and checks it against known scam patterns and previously confirmed scam images. Staff confirm or dismiss every catch, and the bot remembers.", parent: :moderation, prerequisite: ->(c) { c.moderation_settings&.staff_role_id.present? }),
+    Definition.new(key: :lfg, name: "Looking for Game", description: "Members rally a group with /lfg: it pings a game's role — instantly or scheduled — and others join with one click. Only the bot can ping the roles, so they stay quiet otherwise.")
   ].freeze
 
   def self.all

--- a/app/models/server_configuration.rb
+++ b/app/models/server_configuration.rb
@@ -10,6 +10,7 @@ class ServerConfiguration < ApplicationRecord
   has_one :moderation_settings, class_name: "Moderation::Settings", dependent: :delete
   has_one :spam_protection_settings, class_name: "Moderation::SpamProtection::Settings", dependent: :delete
   has_one :image_scanning_settings, class_name: "Moderation::ImageScanning::Settings", dependent: :delete
+  has_one :lfg_settings, class_name: "Lfg::Settings", dependent: :destroy
 
   has_many :phash_confirmations, class_name: "Moderation::PhashConfirmation", dependent: :delete_all
 

--- a/app/operations/lfg/configure.rb
+++ b/app/operations/lfg/configure.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module Ops
+  module Lfg
+    class Configure < ApplicationOperation
+      include Ops::PluginConfiguration
+
+      self.transactional = false
+
+      receives :server_configuration,
+        :enabled,
+        :cooldown_seconds,
+        :post_lifetime_minutes,
+        :default_min_membership_days,
+        :default_required_role_ids,
+        :default_excluded_role_ids,
+        :allowed_channel_ids,
+        :pingable_roles
+
+      def call
+        settings = server_configuration.lfg_settings
+        settings.assign_attributes(
+          cooldown_seconds:,
+          post_lifetime_minutes:,
+          default_min_membership_days: default_min_membership_days.presence,
+          default_required_role_ids:,
+          default_excluded_role_ids:,
+          allowed_channel_ids:
+        )
+        activation = staged_activation
+
+        return failure(messages(settings, activation), value: activation) unless settings.valid? && activation.valid?
+
+        transaction do
+          settings.save!
+          reconcile_pingable_roles(settings)
+          activation.save!
+        end
+        ok(activation)
+      rescue ActiveRecord::RecordInvalid => error
+        failure([error.record.errors.full_messages.to_sentence], value: activation)
+      end
+
+      private
+
+      def reconcile_pingable_roles(settings)
+        kept = pingable_roles.reject { |attrs| truthy?(attrs[:_destroy]) }.filter_map do |attrs|
+          role_id = attrs[:role_id].to_i
+          next if role_id.zero?
+
+          role = settings.pingable_roles.find_or_initialize_by(role_id:)
+          role.assign_attributes(
+            min_membership_days: attrs[:min_membership_days].presence,
+            required_role_ids: attrs[:required_role_ids],
+            excluded_role_ids: attrs[:excluded_role_ids],
+            allowed_channel_ids: attrs[:allowed_channel_ids]
+          )
+          role.save!
+          role_id
+        end
+        settings.pingable_roles.where.not(role_id: kept).destroy_all
+      end
+
+      def plugin_key
+        :lfg
+      end
+
+      def truthy?(value)
+        ActiveModel::Type::Boolean.new.cast(value)
+      end
+    end
+  end
+end

--- a/app/operations/server_configuration/ensure.rb
+++ b/app/operations/server_configuration/ensure.rb
@@ -35,6 +35,7 @@ module Ops
         config.moderation_settings || config.create_moderation_settings!
         config.spam_protection_settings || config.create_spam_protection_settings!
         config.image_scanning_settings || config.create_image_scanning_settings!
+        config.lfg_settings || config.create_lfg_settings!
       end
     end
   end

--- a/config/locales/legal.en.yml
+++ b/config/locales/legal.en.yml
@@ -61,6 +61,12 @@ en:
         configure - including any custom scam-keyword list.'
       data_h: What we store and why
       data_lead: 'We store only what the enabled features need:'
+      data_lfg: 'Looking for Game: the roles you make pingable and the policy limits
+        you set for each of them (which roles or channels may use them, minimum membership
+        age, cooldowns and post lifetime). This is server configuration only — the
+        LFG posts themselves and who joins them live entirely in the Discord messages,
+        under Discord''s retention, and are never stored in our database. A short-lived
+        in-memory cooldown (minutes) throttles spam and is never written down.'
       data_notifications: 'Dashboard notifications: short activity entries (an event
         type plus details such as a plugin or channel name) so admins can see recent
         changes.'
@@ -125,6 +131,10 @@ en:
       retention_infra: Caches, background-job records and logs are cleared automatically
         (at most 60 days, 30 days and briefly, respectively). Deleted data also drops
         out of database backups as they rotate.
+      retention_lfg: 'Looking for Game configuration: deleted automatically with the
+        rest of the server''s configuration the moment the bot is removed. Cooldowns
+        live in memory only and vanish on restart; LFG posts are ordinary Discord
+        messages, kept by Discord until they expire or are deleted.'
       retention_phash: 'Confirmed scam-image fingerprints: pruned 180 days after they
         were last matched, and removed once every server that confirmed them has removed
         the bot. Global scam fingerprints set by the bot owner are retained indefinitely.'
@@ -147,7 +157,7 @@ en:
         and our hosting provider Hetzner (Helsinki, Finland, within the EEA), where
         the Service and its database run. We may disclose data where required by law.'
       title: Privacy policy
-      updated: 'Last updated: July 17th, 2026'
+      updated: 'Last updated: July 19th, 2026'
     terms_of_service:
       admin_h: Your responsibilities as a server admin
       admin_p: If you add shrkbot to a server or configure it, you're responsible

--- a/db/migrate/20260719103610_create_lfg_settings.rb
+++ b/db/migrate/20260719103610_create_lfg_settings.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class CreateLfgSettings < ActiveRecord::Migration[8.1]
+  def change
+    create_table :lfg_settings, id: false do |t|
+      t.string :id, null: false, primary_key: true
+      t.references :server_configuration, null: false, foreign_key: true, type: :string, index: {unique: true}
+      t.integer :cooldown_seconds, null: false, default: 300
+      t.integer :post_lifetime_minutes, null: false, default: 360
+      t.integer :default_min_membership_days
+      t.bigint :default_required_role_ids, array: true, null: false, default: []
+      t.bigint :default_excluded_role_ids, array: true, null: false, default: []
+      t.bigint :allowed_channel_ids, array: true, null: false, default: []
+      t.timestamps
+    end
+
+    add_check_constraint :lfg_settings, "cooldown_seconds >= 0 AND cooldown_seconds <= 86400", name: "lfg_settings_cooldown_seconds_check"
+    add_check_constraint :lfg_settings, "post_lifetime_minutes >= 5 AND post_lifetime_minutes <= 10080", name: "lfg_settings_post_lifetime_minutes_check"
+    add_check_constraint :lfg_settings, "default_min_membership_days IS NULL OR (default_min_membership_days >= 0 AND default_min_membership_days <= 3650)", name: "lfg_settings_min_membership_days_check"
+    add_check_constraint :lfg_settings, "cardinality(default_required_role_ids) <= 50", name: "lfg_settings_required_role_ids_count_check"
+    add_check_constraint :lfg_settings, "cardinality(default_excluded_role_ids) <= 50", name: "lfg_settings_excluded_role_ids_count_check"
+    add_check_constraint :lfg_settings, "cardinality(allowed_channel_ids) <= 50", name: "lfg_settings_allowed_channel_ids_count_check"
+
+    reversible do |dir|
+      dir.up { safety_assured { execute "ALTER TABLE lfg_settings ALTER COLUMN id SET DEFAULT ('lfs_' || gen_random_uuid())" } }
+    end
+  end
+end

--- a/db/migrate/20260719103614_create_lfg_pingable_roles.rb
+++ b/db/migrate/20260719103614_create_lfg_pingable_roles.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class CreateLfgPingableRoles < ActiveRecord::Migration[8.1]
+  def change
+    create_table :lfg_pingable_roles, id: false do |t|
+      t.string :id, null: false, primary_key: true
+      t.references :lfg_settings, null: false, foreign_key: true, type: :string, index: false
+      t.bigint :role_id, null: false
+      t.integer :min_membership_days
+      t.bigint :required_role_ids, array: true
+      t.bigint :excluded_role_ids, array: true
+      t.bigint :allowed_channel_ids, array: true
+      t.timestamps
+    end
+
+    add_index :lfg_pingable_roles, [:lfg_settings_id, :role_id], unique: true
+
+    add_check_constraint :lfg_pingable_roles, "min_membership_days IS NULL OR (min_membership_days >= 0 AND min_membership_days <= 3650)", name: "lfg_pingable_roles_min_membership_days_check"
+    add_check_constraint :lfg_pingable_roles, "required_role_ids IS NULL OR cardinality(required_role_ids) <= 50", name: "lfg_pingable_roles_required_role_ids_count_check"
+    add_check_constraint :lfg_pingable_roles, "excluded_role_ids IS NULL OR cardinality(excluded_role_ids) <= 50", name: "lfg_pingable_roles_excluded_role_ids_count_check"
+    add_check_constraint :lfg_pingable_roles, "allowed_channel_ids IS NULL OR (cardinality(allowed_channel_ids) >= 1 AND cardinality(allowed_channel_ids) <= 50)", name: "lfg_pingable_roles_allowed_channel_ids_check"
+
+    reversible do |dir|
+      dir.up { safety_assured { execute "ALTER TABLE lfg_pingable_roles ALTER COLUMN id SET DEFAULT ('lfr_' || gen_random_uuid())" } }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_13_204954) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_19_103614) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -66,6 +66,41 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_13_204954) do
     t.check_constraint "punishment::text = ANY (ARRAY['none'::character varying, 'timeout'::character varying, 'kick'::character varying, 'ban'::character varying]::text[])", name: "image_scanning_settings_punishment_check"
     t.check_constraint "sensitivity::text = ANY (ARRAY['relaxed'::character varying, 'standard'::character varying, 'strict'::character varying]::text[])", name: "image_scanning_settings_sensitivity_check"
     t.check_constraint "timeout_seconds >= 60 AND timeout_seconds <= 2419200", name: "image_scanning_settings_timeout_seconds_check"
+  end
+
+  create_table "lfg_pingable_roles", id: :string, default: -> { "('lfr_'::text || gen_random_uuid())" }, force: :cascade do |t|
+    t.bigint "allowed_channel_ids", array: true
+    t.datetime "created_at", null: false
+    t.bigint "excluded_role_ids", array: true
+    t.string "lfg_settings_id", null: false
+    t.integer "min_membership_days"
+    t.bigint "required_role_ids", array: true
+    t.bigint "role_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["lfg_settings_id", "role_id"], name: "index_lfg_pingable_roles_on_lfg_settings_id_and_role_id", unique: true
+    t.check_constraint "allowed_channel_ids IS NULL OR cardinality(allowed_channel_ids) >= 1 AND cardinality(allowed_channel_ids) <= 50", name: "lfg_pingable_roles_allowed_channel_ids_check"
+    t.check_constraint "excluded_role_ids IS NULL OR cardinality(excluded_role_ids) <= 50", name: "lfg_pingable_roles_excluded_role_ids_count_check"
+    t.check_constraint "min_membership_days IS NULL OR min_membership_days >= 0 AND min_membership_days <= 3650", name: "lfg_pingable_roles_min_membership_days_check"
+    t.check_constraint "required_role_ids IS NULL OR cardinality(required_role_ids) <= 50", name: "lfg_pingable_roles_required_role_ids_count_check"
+  end
+
+  create_table "lfg_settings", id: :string, default: -> { "('lfs_'::text || gen_random_uuid())" }, force: :cascade do |t|
+    t.bigint "allowed_channel_ids", default: [], null: false, array: true
+    t.integer "cooldown_seconds", default: 300, null: false
+    t.datetime "created_at", null: false
+    t.bigint "default_excluded_role_ids", default: [], null: false, array: true
+    t.integer "default_min_membership_days"
+    t.bigint "default_required_role_ids", default: [], null: false, array: true
+    t.integer "post_lifetime_minutes", default: 360, null: false
+    t.string "server_configuration_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["server_configuration_id"], name: "index_lfg_settings_on_server_configuration_id", unique: true
+    t.check_constraint "cardinality(allowed_channel_ids) <= 50", name: "lfg_settings_allowed_channel_ids_count_check"
+    t.check_constraint "cardinality(default_excluded_role_ids) <= 50", name: "lfg_settings_excluded_role_ids_count_check"
+    t.check_constraint "cardinality(default_required_role_ids) <= 50", name: "lfg_settings_required_role_ids_count_check"
+    t.check_constraint "cooldown_seconds >= 0 AND cooldown_seconds <= 86400", name: "lfg_settings_cooldown_seconds_check"
+    t.check_constraint "default_min_membership_days IS NULL OR default_min_membership_days >= 0 AND default_min_membership_days <= 3650", name: "lfg_settings_min_membership_days_check"
+    t.check_constraint "post_lifetime_minutes >= 5 AND post_lifetime_minutes <= 10080", name: "lfg_settings_post_lifetime_minutes_check"
   end
 
   create_table "logging_settings", id: :string, default: -> { "('lgs_'::text || gen_random_uuid())" }, force: :cascade do |t|
@@ -393,6 +428,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_13_204954) do
   add_foreign_key "assignable_roles", "role_sets"
   add_foreign_key "channel_overwrites", "server_channels"
   add_foreign_key "image_scanning_settings", "server_configurations"
+  add_foreign_key "lfg_pingable_roles", "lfg_settings", column: "lfg_settings_id"
+  add_foreign_key "lfg_settings", "server_configurations"
   add_foreign_key "logging_settings", "server_configurations"
   add_foreign_key "moderation_settings", "server_configurations"
   add_foreign_key "moderation_verdicts", "server_configurations"

--- a/spec/factories/lfg_pingable_roles.rb
+++ b/spec/factories/lfg_pingable_roles.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :lfg_pingable_role, class: "Lfg::PingableRole" do
+    association :lfg_settings
+    sequence(:role_id) { |n| 1_000 + n }
+  end
+end

--- a/spec/factories/lfg_settings.rb
+++ b/spec/factories/lfg_settings.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :lfg_settings, class: "Lfg::Settings" do
+    association :server_configuration
+  end
+end

--- a/spec/models/lfg/pingable_role_spec.rb
+++ b/spec/models/lfg/pingable_role_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Lfg::PingableRole do
+  subject(:pingable_role) { build(:lfg_pingable_role) }
+
+  it "is valid from the factory" do
+    expect(pingable_role).to be_valid
+  end
+
+  describe "role_id" do
+    it "is invalid when nil" do
+      pingable_role.role_id = nil
+      expect(pingable_role).not_to be_valid
+    end
+  end
+
+  describe "uniqueness" do
+    let(:lfg_settings) { create(:lfg_settings) }
+    let!(:existing) { create(:lfg_pingable_role, lfg_settings:, role_id: 777) }
+
+    it "is invalid for the same role_id under the same settings" do
+      duplicate = build(:lfg_pingable_role, lfg_settings:, role_id: 777)
+      expect(duplicate).not_to be_valid
+    end
+
+    it "is valid for the same role_id under a different settings" do
+      other_settings = create(:lfg_settings)
+      duplicate = build(:lfg_pingable_role, lfg_settings: other_settings, role_id: 777)
+      expect(duplicate).to be_valid
+    end
+  end
+
+  describe "min_membership_days" do
+    it "is valid when nil" do
+      pingable_role.min_membership_days = nil
+      expect(pingable_role).to be_valid
+    end
+
+    it "is valid at 0" do
+      pingable_role.min_membership_days = 0
+      expect(pingable_role).to be_valid
+    end
+
+    it "is valid at 3_650" do
+      pingable_role.min_membership_days = 3_650
+      expect(pingable_role).to be_valid
+    end
+
+    it "is invalid at -1" do
+      pingable_role.min_membership_days = -1
+      expect(pingable_role).not_to be_valid
+    end
+
+    it "is invalid at 3_651" do
+      pingable_role.min_membership_days = 3_651
+      expect(pingable_role).not_to be_valid
+    end
+  end
+
+  describe "allowed_channel_ids" do
+    it "is valid when nil" do
+      pingable_role.allowed_channel_ids = nil
+      expect(pingable_role).to be_valid
+    end
+
+    it "is invalid when empty" do
+      pingable_role.allowed_channel_ids = []
+      expect(pingable_role).not_to be_valid
+      expect(pingable_role.errors[:allowed_channel_ids]).to be_present
+    end
+
+    it "is valid with an id" do
+      pingable_role.allowed_channel_ids = [123]
+      expect(pingable_role).to be_valid
+    end
+  end
+
+  describe "required_role_ids" do
+    it "is valid when nil" do
+      pingable_role.required_role_ids = nil
+      expect(pingable_role).to be_valid
+    end
+
+    it "is valid when empty" do
+      pingable_role.required_role_ids = []
+      expect(pingable_role).to be_valid
+    end
+
+    it "is invalid at 51 entries" do
+      pingable_role.required_role_ids = Array.new(51) { |i| i + 1 }
+      expect(pingable_role).not_to be_valid
+      expect(pingable_role.errors[:required_role_ids]).to be_present
+    end
+  end
+
+  describe "excluded_role_ids" do
+    it "is valid when nil" do
+      pingable_role.excluded_role_ids = nil
+      expect(pingable_role).to be_valid
+    end
+
+    it "is valid when empty" do
+      pingable_role.excluded_role_ids = []
+      expect(pingable_role).to be_valid
+    end
+
+    it "is invalid at 51 entries" do
+      pingable_role.excluded_role_ids = Array.new(51) { |i| i + 1 }
+      expect(pingable_role).not_to be_valid
+      expect(pingable_role.errors[:excluded_role_ids]).to be_present
+    end
+  end
+end

--- a/spec/models/lfg/settings_spec.rb
+++ b/spec/models/lfg/settings_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Lfg::Settings do
+  subject(:settings) { build(:lfg_settings) }
+
+  it "is valid from the factory" do
+    expect(settings).to be_valid
+  end
+
+  describe "cooldown_seconds" do
+    it "is valid at 0" do
+      settings.cooldown_seconds = 0
+      expect(settings).to be_valid
+    end
+
+    it "is valid at 86_400" do
+      settings.cooldown_seconds = 86_400
+      expect(settings).to be_valid
+    end
+
+    it "is invalid at -1" do
+      settings.cooldown_seconds = -1
+      expect(settings).not_to be_valid
+    end
+
+    it "is invalid at 86_401" do
+      settings.cooldown_seconds = 86_401
+      expect(settings).not_to be_valid
+    end
+  end
+
+  describe "post_lifetime_minutes" do
+    it "is valid at 5" do
+      settings.post_lifetime_minutes = 5
+      expect(settings).to be_valid
+    end
+
+    it "is valid at 10_080" do
+      settings.post_lifetime_minutes = 10_080
+      expect(settings).to be_valid
+    end
+
+    it "is invalid at 4" do
+      settings.post_lifetime_minutes = 4
+      expect(settings).not_to be_valid
+    end
+
+    it "is invalid at 10_081" do
+      settings.post_lifetime_minutes = 10_081
+      expect(settings).not_to be_valid
+    end
+  end
+
+  describe "default_min_membership_days" do
+    it "is valid when nil" do
+      settings.default_min_membership_days = nil
+      expect(settings).to be_valid
+    end
+
+    it "is valid at 0" do
+      settings.default_min_membership_days = 0
+      expect(settings).to be_valid
+    end
+
+    it "is valid at 3_650" do
+      settings.default_min_membership_days = 3_650
+      expect(settings).to be_valid
+    end
+
+    it "is invalid at -1" do
+      settings.default_min_membership_days = -1
+      expect(settings).not_to be_valid
+    end
+
+    it "is invalid at 3_651" do
+      settings.default_min_membership_days = 3_651
+      expect(settings).not_to be_valid
+    end
+  end
+
+  describe "default_required_role_ids" do
+    it "is valid when empty" do
+      settings.default_required_role_ids = []
+      expect(settings).to be_valid
+    end
+
+    it "is valid with a few ids" do
+      settings.default_required_role_ids = [1, 2, 3]
+      expect(settings).to be_valid
+    end
+
+    it "is invalid at 51 entries" do
+      settings.default_required_role_ids = Array.new(51) { |i| i + 1 }
+      expect(settings).not_to be_valid
+      expect(settings.errors[:default_required_role_ids]).to be_present
+    end
+  end
+
+  describe "default_excluded_role_ids" do
+    it "is valid when empty" do
+      settings.default_excluded_role_ids = []
+      expect(settings).to be_valid
+    end
+
+    it "is valid with a few ids" do
+      settings.default_excluded_role_ids = [1, 2, 3]
+      expect(settings).to be_valid
+    end
+
+    it "is invalid at 51 entries" do
+      settings.default_excluded_role_ids = Array.new(51) { |i| i + 1 }
+      expect(settings).not_to be_valid
+      expect(settings.errors[:default_excluded_role_ids]).to be_present
+    end
+  end
+
+  describe "allowed_channel_ids" do
+    it "is valid when empty" do
+      settings.allowed_channel_ids = []
+      expect(settings).to be_valid
+    end
+
+    it "is valid with a few ids" do
+      settings.allowed_channel_ids = [1, 2, 3]
+      expect(settings).to be_valid
+    end
+
+    it "is invalid at 51 entries" do
+      settings.allowed_channel_ids = Array.new(51) { |i| i + 1 }
+      expect(settings).not_to be_valid
+      expect(settings.errors[:allowed_channel_ids]).to be_present
+    end
+  end
+end

--- a/spec/operations/lfg/configure_spec.rb
+++ b/spec/operations/lfg/configure_spec.rb
@@ -95,6 +95,18 @@ RSpec.describe Ops::Lfg::Configure do
     end
   end
 
+  context "with a blank pingable role row" do
+    let(:enabled) { "0" }
+    let(:pingable_roles) do
+      [{role_id: "", min_membership_days: nil, required_role_ids: [], excluded_role_ids: [], allowed_channel_ids: nil}]
+    end
+
+    it "skips the row without creating a pingable role" do
+      expect(result).to be_success
+      expect(settings.pingable_roles.count).to eq(0)
+    end
+  end
+
   context "with an existing pingable role updated" do
     let(:enabled) { "0" }
     let!(:existing) do

--- a/spec/operations/lfg/configure_spec.rb
+++ b/spec/operations/lfg/configure_spec.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Ops::Lfg::Configure do
+  subject(:result) do
+    described_class.call(
+      server_configuration: config,
+      enabled:,
+      cooldown_seconds:,
+      post_lifetime_minutes:,
+      default_min_membership_days:,
+      default_required_role_ids:,
+      default_excluded_role_ids:,
+      allowed_channel_ids:,
+      pingable_roles:
+    )
+  end
+
+  let(:config) { create(:server_configuration) }
+  let!(:plugin) { create(:plugin, key: "lfg", name: "Looking for Game") }
+  let!(:settings) { config.create_lfg_settings! }
+  let(:enabled) { "1" }
+  let(:cooldown_seconds) { 300 }
+  let(:post_lifetime_minutes) { 360 }
+  let(:default_min_membership_days) { nil }
+  let(:default_required_role_ids) { [] }
+  let(:default_excluded_role_ids) { [] }
+  let(:allowed_channel_ids) { [] }
+  let(:pingable_roles) { [] }
+
+  context "happy path (enabled)" do
+    let(:cooldown_seconds) { 900 }
+    let(:post_lifetime_minutes) { 720 }
+
+    it "succeeds" do
+      expect(result).to be_success
+    end
+
+    it "saves the settings values" do
+      result
+      reloaded = settings.reload
+      expect(reloaded.cooldown_seconds).to eq(900)
+      expect(reloaded.post_lifetime_minutes).to eq(720)
+    end
+
+    it "enables the lfg activation" do
+      result
+      expect(config.plugin_activations.find_by(plugin:).enabled).to be(true)
+    end
+  end
+
+  context "when saving without enabling" do
+    let(:enabled) { "0" }
+
+    it "succeeds" do
+      expect(result).to be_success
+    end
+
+    it "does not enable the activation" do
+      result
+      expect(config.plugin_activations.find_by(plugin:)&.enabled).to be_falsey
+    end
+  end
+
+  context "with an invalid settings value" do
+    let(:cooldown_seconds) { 90_000 }
+    let(:enabled) { "0" }
+
+    it "fails" do
+      expect(result).to be_failure
+    end
+
+    it "persists nothing" do
+      result
+      expect(config.plugin_activations.find_by(plugin:)&.enabled).to be_falsey
+    end
+  end
+
+  context "with a new pingable role" do
+    let(:enabled) { "0" }
+    let(:pingable_roles) do
+      [{role_id: "77", min_membership_days: "30", required_role_ids: [10], excluded_role_ids: [], allowed_channel_ids: nil}]
+    end
+
+    it "creates one pingable role with the given attributes" do
+      result
+      role = settings.pingable_roles.sole
+      expect(role).to have_attributes(
+        role_id: 77,
+        min_membership_days: 30,
+        required_role_ids: [10],
+        allowed_channel_ids: nil
+      )
+    end
+  end
+
+  context "with an existing pingable role updated" do
+    let(:enabled) { "0" }
+    let!(:existing) do
+      settings.pingable_roles.create!(role_id: 77, min_membership_days: 10, required_role_ids: [1], excluded_role_ids: [], allowed_channel_ids: nil)
+    end
+    let(:pingable_roles) do
+      [{role_id: "77", min_membership_days: "60", required_role_ids: [2, 3], excluded_role_ids: [], allowed_channel_ids: [55]}]
+    end
+
+    it "updates the role in place without changing the count" do
+      expect { result }.not_to change { settings.pingable_roles.count }
+      expect(existing.reload).to have_attributes(
+        min_membership_days: 60,
+        required_role_ids: [2, 3],
+        allowed_channel_ids: [55]
+      )
+    end
+  end
+
+  context "with a dropped pingable role" do
+    let(:enabled) { "0" }
+    let!(:kept_role) { settings.pingable_roles.create!(role_id: 77, excluded_role_ids: [], required_role_ids: []) }
+    let!(:dropped_role) { settings.pingable_roles.create!(role_id: 88, excluded_role_ids: [], required_role_ids: []) }
+    let(:pingable_roles) do
+      [{role_id: "77", min_membership_days: nil, required_role_ids: [], excluded_role_ids: [], allowed_channel_ids: nil}]
+    end
+
+    it "destroys the omitted role" do
+      result
+      expect(Lfg::PingableRole.find_by(id: dropped_role.id)).to be_nil
+      expect(Lfg::PingableRole.find_by(id: kept_role.id)).to be_present
+    end
+  end
+
+  context "with _destroy truthy on an existing role" do
+    let(:enabled) { "0" }
+    let!(:existing) { settings.pingable_roles.create!(role_id: 77, excluded_role_ids: [], required_role_ids: []) }
+    let(:pingable_roles) do
+      [{role_id: "77", min_membership_days: nil, required_role_ids: [], excluded_role_ids: [], allowed_channel_ids: nil, _destroy: "1"}]
+    end
+
+    it "removes the role" do
+      result
+      expect(Lfg::PingableRole.find_by(id: existing.id)).to be_nil
+    end
+  end
+
+  context "atomicity: an invalid pingable role rolls back settings changes too" do
+    let(:enabled) { "0" }
+    let(:cooldown_seconds) { 900 }
+    let(:pingable_roles) do
+      [{role_id: "77", min_membership_days: nil, required_role_ids: [], excluded_role_ids: [], allowed_channel_ids: []}]
+    end
+
+    it "fails" do
+      expect(result).to be_failure
+    end
+
+    it "does not persist the settings changes from the same call" do
+      result
+      expect(settings.reload.cooldown_seconds).to eq(300)
+    end
+  end
+end

--- a/spec/operations/server_configuration/destroy_spec.rb
+++ b/spec/operations/server_configuration/destroy_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe Ops::ServerConfiguration::Destroy do
     let!(:role_setting) { create(:role_setting, server_configuration: config) }
     let!(:role_set) { create(:role_set, role_setting:) }
     let!(:assignable_role) { create(:assignable_role, role_set:) }
+    let!(:lfg_settings) { create(:lfg_settings, server_configuration: config) }
+    let!(:lfg_pingable_role) { create(:lfg_pingable_role, lfg_settings:) }
 
     it "removes all associated rows" do
       result
@@ -41,6 +43,8 @@ RSpec.describe Ops::ServerConfiguration::Destroy do
       expect(Roles::Settings.find_by(id: role_setting.id)).to be_nil
       expect(Roles::Set.find_by(id: role_set.id)).to be_nil
       expect(Roles::AssignableRole.find_by(id: assignable_role.id)).to be_nil
+      expect(Lfg::Settings.find_by(id: lfg_settings.id)).to be_nil
+      expect(Lfg::PingableRole.find_by(id: lfg_pingable_role.id)).to be_nil
     end
   end
 

--- a/spec/operations/server_configuration/ensure_spec.rb
+++ b/spec/operations/server_configuration/ensure_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe Ops::ServerConfiguration::Ensure do
     expect(config.moderation_settings).to be_present
     expect(config.spam_protection_settings).to be_present
     expect(config.image_scanning_settings).to be_present
+    expect(config.lfg_settings).to be_present
   end
 
   context "when a concurrent insert wins the race" do


### PR DESCRIPTION
First of three chunks for the **Looking for Game** plugin (BUILD_PLAN LFG v1). Guild configuration only — no commands, events, or jobs yet (chunk B), no website page yet (chunk C). Crucially, **LFG stores no runtime post state**: posts and joins live in Discord messages under Discord's retention; our DB only holds per-guild config.

## What's here
- **Schema** — `lfg_settings` (`lfs_`) + `lfg_pingable_roles` (`lfr_`). DB check constraints mirror every model validation (active_record_doctor gate). Composite unique index `[lfg_settings_id, role_id]` serves both uniqueness and the FK (reference index omitted to avoid an extraneous index).
- **Models** — `Lfg::Settings`, `Lfg::PingableRole`. Per-role policy overrides: `null` = inherit the guild default, `[]` = explicitly none; `[]` is rejected for `allowed_channel_ids` (inherit or name channels — no "zero channels" trap). Array-cardinality cap (≤50) extracted to a shared `Lfg::SnowflakeArrayLimit` concern.
- **Ops::Lfg::Configure** — settings write + staged activation + nested pingable-role reconciliation, mirroring `Ops::Roles::Configure` (transactional, atomic rollback on an invalid nested row).
- **PluginCatalog** entry (`:lfg`, no channel-backing, no parent/prereq); `Ensure` pre-creates the settings row per server.
- **Privacy (same chunk)** — dedicated `data_lfg` / `retention_lfg` entries documenting the zero-DB-retention model + in-memory-only cooldowns; policy `updated` date bumped. `Ops::Users::Destroy` needs **nothing**: there is no per-user data — LFG stores only guild config, and the guild purge covers it via `ServerConfiguration has_one :lfg_settings, dependent: :destroy` cascading to `pingable_roles`.

## Gates
rspec 2002/0 · standardrb clean · active_record_doctor clean · undercover no missing coverage · i18n-tasks missing + check-normalized clean.

## Deferred (flagged, not done here — would widen scope beyond LFG)
`truthy?` and the identical `rescue ActiveRecord::RecordInvalid` now recur across `roles`/`bot_settings`/`lfg` Configure ops; hoisting them into `Ops::ApplicationOperation` is its own focused base-class PR touching all three, kept out of this LFG-scoped change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)