### PR TITLE
Add Looking for Game to landing page plugin showcase

### DIFF
--- a/app/views/home.rb
+++ b/app/views/home.rb
@@ -67,7 +67,7 @@ class Views::Home < Views::Base
 
   def plugin_cards(decorative: false)
     div(class: "flex", aria_hidden: decorative ? "true" : nil) do
-      %i[roles welcomes logging moderation reminders].each { |key| plugin_card(key) }
+      %i[roles welcomes logging moderation reminders lfg].each { |key| plugin_card(key) }
     end
   end
 

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -523,6 +523,8 @@ en:
         one dashboard, and let shrkbot handle the rest.'
       more_plugins: More plugins are on the way.
       plugins:
+        lfg: Let members rally a group with a role ping, instantly or scheduled. Others
+          join with one click.
         logging: 'Record moderation events to a private staff channel: role changes,
           joins, leaves.'
         moderation: 'Automated moderation beyond Discord''s AutoMod: catch cross-channel


### PR DESCRIPTION
The LFG plugin shipped but never made it into the home-page plugin marquee. Its Phosphor icon (`game-controller`) and `plugin_row` name copy already existed — only the showcase array entry and a marketing-tone description were missing.

## Changes
- `app/views/home.rb` — add `:lfg` to the `plugin_cards` showcase array.
- `config/locales/web.en.yml` — add `views.home.plugins.lfg` description.

## Gates
`rspec` (home request spec) · `standardrb` · `i18n-tasks missing` + `check-normalized` · `undercover` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)