### PR TITLE
Defer welcome messages until onboarding completes

### DIFF
--- a/app/plugins/welcomes/events/member_join.rb
+++ b/app/plugins/welcomes/events/member_join.rb
@@ -5,18 +5,14 @@ module Welcomes
     on :member_join
 
     def handle
-      setting = Settings.active_for(event.server.id)
-      return unless setting&.channel_id.present?
-      return if setting.join_message.blank?
+      announcement = JoinAnnouncement.new(bot: event.bot, server: event.server, member: event.user)
+      return unless announcement.enabled?
 
-      content = Message.render(setting.join_message, user: event.user.mention, member_count: event.server.member_count)
-      event.bot.send_message(setting.channel_id, content, false, nil, nil, mention_suppression(setting))
-    end
-
-    private
-
-    def mention_suppression(setting)
-      {parse: []} unless setting.ping_on_join
+      if event.user.pending
+        PendingJoins.instance.remember(guild_id: event.server.id, user_id: event.user.id)
+      else
+        announcement.deliver
+      end
     end
   end
 end

--- a/app/plugins/welcomes/events/member_leave.rb
+++ b/app/plugins/welcomes/events/member_leave.rb
@@ -5,6 +5,8 @@ module Welcomes
     on :member_leave
 
     def handle
+      PendingJoins.instance.forget(guild_id: event.server.id, user_id: event.user.id)
+
       setting = Settings.active_for(event.server.id)
       return unless setting&.channel_id.present?
       return if setting.leave_message.blank?

--- a/app/plugins/welcomes/events/onboarding_complete.rb
+++ b/app/plugins/welcomes/events/onboarding_complete.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Welcomes
+  class OnboardingComplete < Bot::BaseEvent
+    on :member_update
+
+    def handle
+      member = event.user
+      return if member.nil? || member.pending
+      return unless PendingJoins.instance.forget(guild_id: event.server.id, user_id: member.id)
+
+      JoinAnnouncement.new(bot: event.bot, server: event.server, member:).deliver
+    end
+  end
+end

--- a/app/plugins/welcomes/join_announcement.rb
+++ b/app/plugins/welcomes/join_announcement.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Welcomes
+  class JoinAnnouncement
+    def initialize(bot:, server:, member:)
+      @bot = bot
+      @server = server
+      @member = member
+    end
+
+    def enabled?
+      setting&.channel_id.present? && setting.join_message.present?
+    end
+
+    def deliver
+      return unless enabled?
+
+      @bot.send_message(setting.channel_id, content, false, nil, nil, mention_suppression)
+    end
+
+    private
+
+    def setting
+      @setting ||= Settings.active_for(@server.id)
+    end
+
+    def content
+      Message.render(setting.join_message, user: @member.mention, member_count: @server.member_count)
+    end
+
+    def mention_suppression
+      {parse: []} unless setting.ping_on_join
+    end
+  end
+end

--- a/app/plugins/welcomes/pending_joins.rb
+++ b/app/plugins/welcomes/pending_joins.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Welcomes
+  class PendingJoins
+    RETENTION = 24.hours
+
+    INSTANCE_MUTEX = Mutex.new
+
+    def self.instance
+      INSTANCE_MUTEX.synchronize { @instance ||= new }
+    end
+
+    def initialize
+      @mutex = Mutex.new
+      @expiries = {}
+    end
+
+    def remember(guild_id:, user_id:, at: Time.current)
+      @mutex.synchronize do
+        sweep(at)
+        @expiries[key(guild_id, user_id)] = at + RETENTION
+      end
+      nil
+    end
+
+    def forget(guild_id:, user_id:, at: Time.current)
+      @mutex.synchronize do
+        sweep(at)
+        !@expiries.delete(key(guild_id, user_id)).nil?
+      end
+    end
+
+    private
+
+    def key(guild_id, user_id)
+      [guild_id, user_id]
+    end
+
+    def sweep(at)
+      @expiries.delete_if { |_key, expiry| expiry <= at }
+    end
+  end
+end

--- a/app/views/privacy_policy.rb
+++ b/app/views/privacy_policy.rb
@@ -45,6 +45,8 @@ class Views::PrivacyPolicy < Views::Base
       t(".data_guild"),
       t(".data_account"),
       t(".data_reminders"),
+      t(".data_welcomes"),
+      t(".data_lfg"),
       t(".data_notifications"),
       t(".data_operational")
     )
@@ -79,6 +81,8 @@ class Views::PrivacyPolicy < Views::Base
     bullets(
       t(".retention_guild"),
       t(".retention_reminders"),
+      t(".retention_welcomes"),
+      t(".retention_lfg"),
       t(".retention_phash"),
       t(".retention_account"),
       t(".retention_infra")

--- a/config/locales/legal.en.yml
+++ b/config/locales/legal.en.yml
@@ -79,6 +79,11 @@ en:
       data_reminders: 'Reminders: the reminder text you write, your Discord ID, the
         target channel and server, whether to deliver by DM, and the due time - kept
         until delivered or deleted by you with /unremind.'
+      data_welcomes: 'Welcome messages: on servers that use Discord''s membership
+        screening, a short-lived in-memory note that a member has joined but not yet
+        finished onboarding - the server ID and their Discord ID, nothing else. It
+        exists so the welcome can wait until they finish, which is what makes the
+        greeting name them correctly. It is never written to disk.'
       deletion_account: Delete your dashboard account and your reminders with the
         "Delete my account" button on your account page.
       deletion_contact: Or contact us (see below) and we'll take care of it.
@@ -144,6 +149,9 @@ en:
         the bot. Global scam fingerprints set by the bot owner are retained indefinitely.'
       retention_reminders: 'Reminders: deleted once delivered, or earlier if you delete
         them.'
+      retention_welcomes: 'Pending-join notes: discarded the moment the welcome is
+        sent or the member leaves, after 24 hours either way, and on every restart.
+        They live in memory only and are never written down.'
       rights_h: Your rights
       rights_p: Under the GDPR you have the right to access, correct, delete, restrict
         or object to our use of your personal data, and the right to data portability.
@@ -161,7 +169,7 @@ en:
         and our hosting provider Hetzner (Helsinki, Finland, within the EEA), where
         the Service and its database run. We may disclose data where required by law.'
       title: Privacy policy
-      updated: 'Last updated: July 20th, 2026'
+      updated: 'Last updated: July 23rd, 2026'
     terms_of_service:
       admin_h: Your responsibilities as a server admin
       admin_p: If you add shrkbot to a server or configure it, you're responsible

--- a/spec/plugins/welcomes/events/member_join_spec.rb
+++ b/spec/plugins/welcomes/events/member_join_spec.rb
@@ -6,56 +6,55 @@ RSpec.describe Welcomes::MemberJoin do
   subject(:handle) { described_class.new(event).handle }
 
   let(:server) { double("server", id: 123, member_count: 10) }
-  let(:user) { double("user", mention: "<@7>") }
-  let(:bot) { double("bot") }
+  let(:user) { double("user", mention: "<@7>", id: 7, pending: false) }
+  let(:bot) { double("bot", send_message: nil) }
   let(:event) { double("event", server:, user:, bot:) }
+  let(:pending_joins) { Welcomes::PendingJoins.new }
+  let(:setting) { double("settings", channel_id: 555, join_message: "Welcome {user}!", ping_on_join: true) }
 
   before do
+    allow(Welcomes::PendingJoins).to receive(:instance).and_return(pending_joins)
     allow(Welcomes::Settings).to receive(:active_for).with(123).and_return(setting)
   end
 
-  context "with an active setting and a join message" do
-    let(:setting) { double("settings", channel_id: 555, join_message: "Welcome {user}! Members: {membercount}", ping_on_join: true) }
-
-    it "posts the rendered message to the configured channel" do
-      expect(bot).to receive(:send_message).with(555, "Welcome <@7>! Members: 10", false, nil, nil, nil)
+  context "when the member is already through onboarding" do
+    it "welcomes them straight away" do
       handle
+
+      expect(bot).to have_received(:send_message).with(555, "Welcome <@7>!", false, nil, nil, nil)
+    end
+
+    it "holds nothing back" do
+      handle
+
+      expect(pending_joins.forget(guild_id: 123, user_id: 7)).to be(false)
     end
   end
 
-  context "when pinging on join is disabled" do
-    let(:setting) { double("settings", channel_id: 555, join_message: "Welcome {user}!", ping_on_join: false) }
+  context "when the member still has onboarding to finish" do
+    let(:user) { double("user", mention: "<@7>", id: 7, pending: true) }
 
-    it "suppresses the mention so no ping fires" do
-      expect(bot).to receive(:send_message).with(555, "Welcome <@7>!", false, nil, nil, {parse: []})
+    it "holds the welcome back so the mention resolves later" do
       handle
+
+      expect(bot).not_to have_received(:send_message)
+    end
+
+    it "remembers the join so finishing onboarding can trigger it" do
+      handle
+
+      expect(pending_joins.forget(guild_id: 123, user_id: 7)).to be(true)
     end
   end
 
   context "when welcomes is inactive" do
     let(:setting) { nil }
+    let(:user) { double("user", mention: "<@7>", id: 7, pending: true) }
 
-    it "does nothing" do
-      expect(bot).not_to receive(:send_message)
+    it "remembers nothing, since no welcome will ever be sent" do
       handle
-    end
-  end
 
-  context "when the join message is blank" do
-    let(:setting) { double("settings", channel_id: 555, join_message: "") }
-
-    it "does nothing" do
-      expect(bot).not_to receive(:send_message)
-      handle
-    end
-  end
-
-  context "when no channel is set" do
-    let(:setting) { double("settings", channel_id: nil, join_message: "hi") }
-
-    it "does nothing" do
-      expect(bot).not_to receive(:send_message)
-      handle
+      expect(pending_joins.forget(guild_id: 123, user_id: 7)).to be(false)
     end
   end
 end

--- a/spec/plugins/welcomes/events/member_leave_spec.rb
+++ b/spec/plugins/welcomes/events/member_leave_spec.rb
@@ -6,11 +6,13 @@ RSpec.describe Welcomes::MemberLeave do
   subject(:handle) { described_class.new(event).handle }
 
   let(:server) { double("server", id: 123, member_count: 9) }
-  let(:user) { double("user", username: "ghost") }
+  let(:user) { double("user", username: "ghost", id: 7) }
   let(:bot) { double("bot") }
   let(:event) { double("event", server:, user:, bot:) }
+  let(:pending_joins) { Welcomes::PendingJoins.new }
 
   before do
+    allow(Welcomes::PendingJoins).to receive(:instance).and_return(pending_joins)
     allow(Welcomes::Settings).to receive(:active_for).with(123).and_return(setting)
   end
 
@@ -38,6 +40,18 @@ RSpec.describe Welcomes::MemberLeave do
     it "does nothing" do
       expect(bot).not_to receive(:send_message)
       handle
+    end
+  end
+
+  context "when the member leaves before finishing onboarding" do
+    let(:setting) { nil }
+
+    before { pending_joins.remember(guild_id: 123, user_id: 7) }
+
+    it "drops the held-back join instead of waiting out its retention" do
+      handle
+
+      expect(pending_joins.forget(guild_id: 123, user_id: 7)).to be(false)
     end
   end
 end

--- a/spec/plugins/welcomes/events/onboarding_complete_spec.rb
+++ b/spec/plugins/welcomes/events/onboarding_complete_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Welcomes::OnboardingComplete do
+  subject(:handle) { described_class.new(event).handle }
+
+  let(:server) { double("server", id: 123, member_count: 10) }
+  let(:user) { double("user", mention: "<@7>", id: 7, pending: false) }
+  let(:bot) { double("bot", send_message: nil) }
+  let(:event) { double("event", server:, user:, bot:) }
+  let(:pending_joins) { Welcomes::PendingJoins.new }
+  let(:setting) { double("settings", channel_id: 555, join_message: "Welcome {user}! Members: {membercount}", ping_on_join: true) }
+
+  before do
+    allow(Welcomes::PendingJoins).to receive(:instance).and_return(pending_joins)
+    allow(Welcomes::Settings).to receive(:active_for).with(123).and_return(setting)
+  end
+
+  context "when the member finished onboarding after a held-back join" do
+    before { pending_joins.remember(guild_id: 123, user_id: 7) }
+
+    it "posts the welcome it held back" do
+      handle
+
+      expect(bot).to have_received(:send_message).with(555, "Welcome <@7>! Members: 10", false, nil, nil, nil)
+    end
+
+    it "posts it only once, however many updates follow" do
+      handle
+      described_class.new(event).handle
+
+      expect(bot).to have_received(:send_message).once
+    end
+  end
+
+  context "when the update is an ordinary nickname or role change" do
+    it "does nothing" do
+      handle
+
+      expect(bot).not_to have_received(:send_message)
+    end
+  end
+
+  context "when the member has onboarding left to finish" do
+    let(:user) { double("user", mention: "<@7>", id: 7, pending: true) }
+
+    before { pending_joins.remember(guild_id: 123, user_id: 7) }
+
+    it "keeps holding the welcome back" do
+      handle
+
+      expect(bot).not_to have_received(:send_message)
+    end
+
+    it "leaves the held-back join in place" do
+      handle
+
+      expect(pending_joins.forget(guild_id: 123, user_id: 7)).to be(true)
+    end
+  end
+
+  context "when the server is not cached" do
+    let(:user) { nil }
+
+    it "does nothing" do
+      handle
+
+      expect(bot).not_to have_received(:send_message)
+    end
+  end
+end

--- a/spec/plugins/welcomes/join_announcement_spec.rb
+++ b/spec/plugins/welcomes/join_announcement_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Welcomes::JoinAnnouncement do
+  subject(:deliver) { described_class.new(bot:, server:, member:).deliver }
+
+  let(:server) { double("server", id: 123, member_count: 10) }
+  let(:member) { double("member", mention: "<@7>") }
+  let(:bot) { double("bot") }
+
+  before do
+    allow(Welcomes::Settings).to receive(:active_for).with(123).and_return(setting)
+  end
+
+  context "with an active setting and a join message" do
+    let(:setting) { double("settings", channel_id: 555, join_message: "Welcome {user}! Members: {membercount}", ping_on_join: true) }
+
+    it "posts the rendered message to the configured channel" do
+      expect(bot).to receive(:send_message).with(555, "Welcome <@7>! Members: 10", false, nil, nil, nil)
+      deliver
+    end
+  end
+
+  context "when pinging on join is disabled" do
+    let(:setting) { double("settings", channel_id: 555, join_message: "Welcome {user}!", ping_on_join: false) }
+
+    it "suppresses the mention so no ping fires" do
+      expect(bot).to receive(:send_message).with(555, "Welcome <@7>!", false, nil, nil, {parse: []})
+      deliver
+    end
+  end
+
+  context "when welcomes is inactive" do
+    let(:setting) { nil }
+
+    it "does nothing" do
+      expect(bot).not_to receive(:send_message)
+      deliver
+    end
+  end
+
+  context "when the join message is blank" do
+    let(:setting) { double("settings", channel_id: 555, join_message: "") }
+
+    it "does nothing" do
+      expect(bot).not_to receive(:send_message)
+      deliver
+    end
+  end
+
+  context "when no channel is set" do
+    let(:setting) { double("settings", channel_id: nil, join_message: "hi") }
+
+    it "does nothing" do
+      expect(bot).not_to receive(:send_message)
+      deliver
+    end
+  end
+end

--- a/spec/plugins/welcomes/pending_joins_spec.rb
+++ b/spec/plugins/welcomes/pending_joins_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Welcomes::PendingJoins do
+  subject(:forget) { store.forget(guild_id: 1, user_id: 7, at:) }
+
+  let(:store) { described_class.new }
+  let(:now) { Time.utc(2026, 7, 23, 12, 0, 0) }
+  let(:at) { now }
+
+  context "when the join is pending" do
+    before { store.remember(guild_id: 1, user_id: 7, at: now) }
+
+    it "reports the pending join" do
+      expect(forget).to be(true)
+    end
+
+    it "reports it only once" do
+      forget
+
+      expect(store.forget(guild_id: 1, user_id: 7, at:)).to be(false)
+    end
+
+    context "just before the retention window closes" do
+      let(:at) { now + described_class::RETENTION - 1.second }
+
+      it "still reports the pending join" do
+        expect(forget).to be(true)
+      end
+    end
+
+    context "once the retention window has closed" do
+      let(:at) { now + described_class::RETENTION }
+
+      it "has dropped the join" do
+        expect(forget).to be(false)
+      end
+    end
+
+    context "when the same user is pending on another server" do
+      subject(:forget) { store.forget(guild_id: 2, user_id: 7, at:) }
+
+      it "leaves the other server's join alone" do
+        expect(forget).to be(false)
+      end
+    end
+  end
+
+  context "when no join is pending" do
+    it "reports nothing to do" do
+      expect(forget).to be(false)
+    end
+  end
+end

--- a/spec/plugins/welcomes/pending_joins_spec.rb
+++ b/spec/plugins/welcomes/pending_joins_spec.rb
@@ -9,6 +9,13 @@ RSpec.describe Welcomes::PendingJoins do
   let(:now) { Time.utc(2026, 7, 23, 12, 0, 0) }
   let(:at) { now }
 
+  describe ".instance" do
+    it "returns a memoized singleton" do
+      expect(described_class.instance).to be_a(described_class)
+      expect(described_class.instance).to equal(described_class.instance)
+    end
+  end
+
   context "when the join is pending" do
     before { store.remember(guild_id: 1, user_id: 7, at: now) }
 


### PR DESCRIPTION
## The bug

Welcome messages very often render `@unknown-user`, including for members who are plainly in the server.

Not the ping toggle, and not members leaving — a departed member still renders fine, because Discord persists the resolved user on the message forever. The cause is the other end: on servers with **membership screening**, `GUILD_MEMBER_ADD` fires while the member is still `pending`. A mention of a pending member does not resolve, and a message keeps whatever resolution it got at send time. So the welcome is broken permanently, even after they finish onboarding minutes later.

That also explains the shape of the symptom: intermittent, independent of `ping_on_join`, and unaffected by a client reload.

## The fix

Hold the welcome back until `pending` clears via `GUILD_MEMBER_UPDATE` — Discord has no dedicated "screening completed" event, and discordrb mutates the cached member *before* raising the event, so the transition can't be read off the event itself. Pending joins are tracked in an in-memory store keyed by server and user.

The entry is dropped when the welcome goes out, when the member leaves, and after 24 hours either way. Nothing is written to disk, so a restart at worst loses a greeting for someone mid-onboarding.

Servers without screening are unaffected — `pending` is false at join and the message goes out immediately, exactly as before.

Side effect worth knowing: on screening servers the welcome now lands *after* Discord's built-in join message instead of before it.

## Privacy

New per-user data, so the policy moves in the same PR:

- `data_welcomes` — what the pending-join note holds (server ID + Discord ID, nothing else) and why
- `retention_welcomes` — dropped on send, on leave, after 24h, and on restart
- "Last updated" bumped to July 23rd, 2026

No `Ops::Users::Destroy` or guild-purge wiring: the data lives only in the bot process, is unreachable from the web/job process where those ops run, and self-expires well inside any erasure timeframe. The TTL *is* the erasure mechanism. Same treatment as the existing `Lfg::Cooldown`.

## Boyscout

`data_lfg` and `retention_lfg` were added to the locale file but never rendered by any section of the privacy policy view — the LFG data handling was documented and then not shown to anyone. Wired both into the existing bullet lists. Revert those four lines if the omission was deliberate.

## Structure

Posting moved out of `MemberJoin` into `Welcomes::JoinAnnouncement`, since two events now need it. `enabled?` is public so `MemberJoin` can skip remembering a pending join on servers where no welcome would ever be sent — data minimisation, not just tidiness.

`Welcomes::PendingJoins` is deliberately *not* built on a shared abstraction with `Lfg::Cooldown`. Same hash shape, different intent: one is a rate limiter that answers "how long left", the other is a work set that answers "was this pending, and take it". Coincidental shape, so no extraction.

## Gates

`rspec` 2242 examples / 0 failures · `standardrb` · `active_record_doctor` · `undercover --compare origin/main` · `i18n-tasks missing` + `check-normalized` — all clean.

Live behaviour is untested here (no Discord network in the dev container) — this needs a real join on a screening-enabled server to confirm.