### PR TITLE
Fix the LFG config page not saving, and its spinner-arrow inputs

### DIFF
--- a/app/components/lfg/min_days_field.rb
+++ b/app/components/lfg/min_days_field.rb
@@ -13,20 +13,15 @@ class Components::Lfg::MinDaysField < Components::Base
   def view_template
     div do
       label(class: "mb-1.5 block text-sm font-semibold") { @label }
-      div(class: "flex items-center gap-2") do
-        input(
-          type: "number",
-          name: @name,
-          value: @value,
-          min: 0,
-          max: 3650,
-          step: 1,
-          placeholder: @placeholder,
-          class: "h-10 w-32 rounded-control border-[1.5px] border-border-strong bg-surface-card px-3 text-sm " \
-            "focus:border-accent focus:outline-none focus:ring-3 focus:ring-[var(--focus-ring)]"
-        )
-        span(class: "text-sm text-text-secondary") { @unit }
-      end
+      render Components::NumberStepper.new(
+        name: @name,
+        value: @value,
+        min: 0,
+        max: 3650,
+        unit: @unit,
+        placeholder: @placeholder,
+        input_class: "w-28"
+      )
       p(class: "mt-1.5 text-xs text-text-muted") { @help }
     end
   end

--- a/app/components/number_stepper.rb
+++ b/app/components/number_stepper.rb
@@ -1,19 +1,21 @@
 # frozen_string_literal: true
 
 class Components::NumberStepper < Components::Base
-  def initialize(name:, value:, min:, default:, unit: nil, max: nil)
+  def initialize(name:, value:, min:, default: nil, unit: nil, max: nil, placeholder: nil, input_class: "w-11")
     @name = name
     @value = value
     @min = min
     @default = default
     @unit = unit
     @max = max
+    @placeholder = placeholder
+    @input_class = input_class
   end
 
   def view_template
     div(class: "flex flex-col gap-1") do
       stepper_row
-      subscript
+      subscript if @default
     end
   end
 
@@ -65,7 +67,8 @@ class Components::NumberStepper < Components::Base
       min: @min,
       max: @max,
       step: 1,
-      class: "w-11 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none rounded-control border border-border-default bg-surface-card px-1 py-1 text-center font-mono text-sm text-text-primary focus:border-accent focus:outline-none",
+      placeholder: @placeholder,
+      class: "#{@input_class} [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none rounded-control border border-border-default bg-surface-card px-1 py-1 text-center font-mono text-sm text-text-primary focus:border-accent focus:outline-none",
       data: {number_stepper_target: "input"}
     )
   end

--- a/app/components/number_stepper.rb
+++ b/app/components/number_stepper.rb
@@ -40,22 +40,20 @@ class Components::NumberStepper < Components::Base
   end
 
   def decrement_button
-    button(
-      type: "button",
-      class: "flex size-8 items-center justify-center rounded-control border border-border-default bg-surface-card text-text-secondary transition-colors hover:bg-surface-sunken hover:text-text-primary",
-      data: {action: "click->number-stepper#decrement"}
-    ) do
-      render Components::Icon.new("minus", class: "size-4")
-    end
+    stepper_button("minus", "decrement")
   end
 
   def increment_button
+    stepper_button("plus", "increment")
+  end
+
+  def stepper_button(icon, method)
     button(
       type: "button",
       class: "flex size-8 items-center justify-center rounded-control border border-border-default bg-surface-card text-text-secondary transition-colors hover:bg-surface-sunken hover:text-text-primary",
-      data: {action: "click->number-stepper#increment"}
+      data: {action: "click->number-stepper##{method}"}
     ) do
-      render Components::Icon.new("plus", class: "size-4")
+      render Components::Icon.new(icon, class: "size-4")
     end
   end
 

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 if [ -n "${RUN_DB_PREPARE}" ]; then
-  ./bin/rails db:prepare
+  ./bin/rails db:prepare db:seed
 fi
 
 exec "${@}"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -111,7 +111,11 @@ bin/kamal setup
 first, see above), builds the amd64 app image, pushes it to GHCR, starts the
 web/bot/jobs processes, and has kamal-proxy provision the TLS certificate.
 Migrations run automatically on web boot via the entrypoint (`RUN_DB_PREPARE=1`
-is set on the web role only, so the three processes don't race).
+is set on the web role only, so the three processes don't race). Seeds run on
+every boot too, not just the first: `db/seeds.rb` upserts the `plugins` table
+from `PluginCatalog`, and `db:prepare` alone only seeds a database it just
+created — so a plugin added to the catalog after launch would never get its row,
+and every config-page save for it would 404 on `Plugin.find_by!`.
 
 ## Redeploys
 

--- a/spec/components/lfg/min_days_field_spec.rb
+++ b/spec/components/lfg/min_days_field_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::Lfg::MinDaysField do
+  subject(:html) do
+    described_class.new(
+      name: "lfg[default_min_membership_days]",
+      value: 7,
+      label: "Minimum membership",
+      help: "Leave blank for no minimum.",
+      placeholder: "No minimum",
+      unit: "days"
+    ).render_in(view_context)
+  end
+
+  let(:view_context) { ApplicationController.new.view_context }
+
+  it "renders the label, help, unit, and the given value" do
+    expect(html).to include("Minimum membership")
+    expect(html).to include("Leave blank for no minimum.")
+    expect(html).to include("days")
+    expect(html).to include('name="lfg[default_min_membership_days]"')
+    expect(html).to include('value="7"')
+  end
+
+  it "steps through the custom buttons rather than the browser's spinners" do
+    expect(html).to include("click->number-stepper#decrement")
+    expect(html).to include("click->number-stepper#increment")
+    expect(html).to include("[&::-webkit-inner-spin-button]:appearance-none")
+  end
+
+  it "bounds the input to the range the model allows" do
+    expect(html).to include('min="0"')
+    expect(html).to include('max="3650"')
+  end
+
+  it "keeps the blank-means-no-minimum hint on the input" do
+    expect(html).to include('placeholder="No minimum"')
+  end
+
+  it "omits the recommended-default subscript, since blank is the default" do
+    expect(html).not_to include("Recommended default")
+  end
+end

--- a/spec/components/number_stepper_spec.rb
+++ b/spec/components/number_stepper_spec.rb
@@ -51,4 +51,29 @@ RSpec.describe Components::NumberStepper do
       expect(html).not_to include("data-number-stepper-max-value")
     end
   end
+
+  context "when default is omitted" do
+    let(:options) { {name: "lfg[default_min_membership_days]", value: nil, min: 0} }
+
+    it "omits the recommended default subscript" do
+      expect(html).not_to include("Recommended default")
+    end
+  end
+
+  context "when a placeholder is given" do
+    let(:options) { {name: "lfg[default_min_membership_days]", value: nil, min: 0, placeholder: "No minimum"} }
+
+    it "renders it on the input" do
+      expect(html).to include('placeholder="No minimum"')
+    end
+  end
+
+  context "when an input width is given" do
+    let(:options) { {name: "lfg[default_min_membership_days]", value: nil, min: 0, input_class: "w-28"} }
+
+    it "uses it instead of the default width" do
+      expect(html).to include("w-28")
+      expect(html).not_to include("w-11")
+    end
+  end
 end


### PR DESCRIPTION
Two fixes for the Looking for Game config page.

## 1. Saving 404'd on the live box

The page rendered fine but every save silently failed — Turbo can't do anything with a 404 form response, so it falls back to a full page reload, which trips the save bar's unsaved-changes warning and then reloads with nothing persisted. It reproduced only in production, never locally.

Root cause: `Ops::PluginConfiguration#staged_activation` calls `Plugin.find_by!(key: :lfg)`, and the live database has no `lfg` row. The entrypoint runs `db:prepare`, which only runs seeds for a database it *just created* — so `db/seeds.rb`, which upserts the `plugins` table from `PluginCatalog`, has not run since the box was set up. Every plugin added to the catalog after launch hits this; LFG is the first one.

Local databases are freshly created and therefore seeded, which is why it worked there.

The entrypoint now runs `db:prepare db:seed`. The seed file is a `find_or_initialize_by` + `update!` upsert, so re-running it every boot is a no-op once the table is in step. Rationale recorded in `docs/deployment.md`.

Reproduced in a request spec against the current code: with the `lfg` row deleted, `GET` the config page returns 200 and `PATCH` returns 404.

**This needs a deploy (or a one-off `kamal app exec 'bin/rails db:seed'`) to take effect on the live box** — the code on production is already correct, the database row is what's missing.

## 2. Minimum-membership inputs showed the browser's spinners

Both membership-age fields (the default, and the per-role override) were hand-rolled `<input type="number">`s rather than the `NumberStepper` every other numeric setting on the site uses, so they got the browser's default up/down arrows instead of the custom +/- buttons.

`Components::Lfg::MinDaysField` now renders `Components::NumberStepper`. The stepper gained an optional `placeholder:` and `input_class:`, and skips its "recommended default" subscript when no default is passed — blank here means "no minimum", so there is nothing to recommend.

## Boyscout

`NumberStepper`'s decrement and increment buttons were identical apart from the icon and the Stimulus action; folded into one builder.

## Gates

`rspec` (2251), `standardrb`, `active_record_doctor`, `undercover --compare origin/main` all green.