### PR TITLE
Add the 3.5.1 changelog section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ refactors, tooling, and CI changes are omitted; see the git history for those.
 
 This project follows [Semantic Versioning](https://semver.org).
 
+## [3.5.1] - 2026-07-23
+
+### Fixed
+- The Looking for Game config page silently discarded every save on the live bot. The `lfg` plugin row was missing from the production database (seeds only ran when the database was first created), so saves returned 404 and the page reloaded with nothing persisted. Plugin seeding now runs on every boot. ([#208](https://github.com/badBlackShark/shrkbot/pull/208))
+- The minimum-membership-age fields on the Looking for Game config page showed the browser's default spinner arrows instead of the site's +/- stepper controls. ([#208](https://github.com/badBlackShark/shrkbot/pull/208))
+
 ## [3.5.0] - 2026-07-23
 
 ### Added


### PR DESCRIPTION
Patch release. Both entries cover fixes to Looking for Game, which shipped in 3.5.0.

## Changelog

```markdown
## [3.5.1] - 2026-07-23

### Fixed
- The Looking for Game config page silently discarded every save on the live bot. The `lfg` plugin row was missing from the production database (seeds only ran when the database was first created), so saves returned 404 and the page reloaded with nothing persisted. Plugin seeding now runs on every boot. ([#208](https://github.com/badBlackShark/shrkbot/pull/208))
- The minimum-membership-age fields on the Looking for Game config page showed the browser's default spinner arrows instead of the site's +/- stepper controls. ([#208](https://github.com/badBlackShark/shrkbot/pull/208))
```

## Note

The saving fix needs to reach the live box to take effect: a deploy, or a one-off `kamal app exec 'bin/rails db:seed'`. The code on production is already correct; the `lfg` row is what is missing.

Documentation only, so no gates to run.