### PR TITLE
Re-register guild commands when a plugin's own config page enables it

### DIFF
--- a/app/operations/lfg/configure.rb
+++ b/app/operations/lfg/configure.rb
@@ -34,7 +34,7 @@ module Ops
         transaction do
           settings.save!
           reconcile_pingable_roles(settings)
-          activation.save!
+          save_activation!(activation)
         end
         ok(activation)
       rescue ActiveRecord::RecordInvalid => error

--- a/app/operations/logging/configure.rb
+++ b/app/operations/logging/configure.rb
@@ -16,7 +16,7 @@ module Ops
         return failure(messages(settings, activation), value: activation) unless settings.valid? && activation.valid?
 
         settings.save!
-        activation.save!
+        save_activation!(activation)
         ok(activation)
       end
 

--- a/app/operations/moderation/configure.rb
+++ b/app/operations/moderation/configure.rb
@@ -19,7 +19,7 @@ module Ops
         return account_age_failure(settings, activation) unless settings.valid?
 
         settings.save!
-        activation.save!
+        save_activation!(activation)
         ok(activation)
       end
 

--- a/app/operations/moderation/image_scanning/configure.rb
+++ b/app/operations/moderation/image_scanning/configure.rb
@@ -36,7 +36,7 @@ module Ops
           return failure(messages(settings, activation), value: activation) unless settings.valid? && activation.valid?
 
           settings.save!
-          activation.save!
+          save_activation!(activation)
           ok(activation)
         end
 

--- a/app/operations/moderation/spam_protection/configure.rb
+++ b/app/operations/moderation/spam_protection/configure.rb
@@ -34,7 +34,7 @@ module Ops
           return failure(messages(settings, activation), value: activation) unless settings.valid? && activation.valid?
 
           settings.save!
-          activation.save!
+          save_activation!(activation)
           ok(activation)
         end
 

--- a/app/operations/plugin_configuration.rb
+++ b/app/operations/plugin_configuration.rb
@@ -14,6 +14,15 @@ module Ops
       activation
     end
 
+    def save_activation!(activation)
+      activation.save!
+      return unless activation.saved_change_to_enabled?
+
+      ActiveRecord.after_all_transactions_commit do
+        Bot::ConfigBus.sync_commands(server_configuration)
+      end
+    end
+
     def plugin_key
       raise AbstractMethodError, "#{self.class} must implement #plugin_key"
     end

--- a/app/operations/roles/configure.rb
+++ b/app/operations/roles/configure.rb
@@ -20,7 +20,7 @@ module Ops
         transaction do
           setting.save!
           reconcile_sets(setting)
-          activation.save!
+          save_activation!(activation)
         end
         plan.publish
         ok(activation)

--- a/app/operations/welcomes/configure.rb
+++ b/app/operations/welcomes/configure.rb
@@ -15,7 +15,7 @@ module Ops
         return failure(messages(settings, activation), value: activation) unless settings.valid? && activation.valid?
 
         settings.save!
-        activation.save!
+        save_activation!(activation)
         ok(activation)
       end
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -242,7 +242,11 @@ concept Discord can't express. A command with no declaration is available to eve
 Declared with `register_in`:
 
 - `:guild` (default) — bulk-overwritten per guild on ready (`Bot::CommandBackfill`),
-  server join (`Bot::CommandSetup`), and plugin toggle (Bot::ConfigBus `commands_sync`). A
+  server join (`Bot::CommandSetup`), and plugin toggle (Bot::ConfigBus `commands_sync`,
+  published by `Ops::ServerConfiguration::Plugins::Toggle` for the dashboard's plugin
+  cards and by `Ops::PluginConfiguration#save_activation!` for the enable switch on a
+  plugin's own config page — a plugin's Configure operation must persist its activation
+  through that helper, or its commands never appear). A
   command's `plugin :key` macro ties it to a `PluginCatalog` key; it only registers
   in guilds where that plugin (and its parent, if any) is enabled. Plugin-less guild
   commands register in every guild. Guild commands cannot appear in DMs.

--- a/spec/operations/lfg/configure_spec.rb
+++ b/spec/operations/lfg/configure_spec.rb
@@ -177,6 +177,19 @@ RSpec.describe Ops::Lfg::Configure do
       end
     end
 
+    context "when the plugin is switched back off" do
+      let(:enabled) { "0" }
+
+      before do
+        create(:plugin_activation, server_configuration: config, plugin:, enabled: true)
+      end
+
+      it "asks the bot to drop the guild's commands again" do
+        result
+        expect(Bot::ConfigBus).to have_received(:sync_commands).with(config)
+      end
+    end
+
     context "when the save fails" do
       let(:cooldown_seconds) { -1 }
 

--- a/spec/operations/lfg/configure_spec.rb
+++ b/spec/operations/lfg/configure_spec.rb
@@ -154,6 +154,39 @@ RSpec.describe Ops::Lfg::Configure do
     end
   end
 
+  context "guild command registration" do
+    before do
+      allow(Bot::ConfigBus).to receive(:sync_commands)
+    end
+
+    it "asks the bot to re-register the guild's commands when the plugin is switched on" do
+      result
+      expect(Bot::ConfigBus).to have_received(:sync_commands).with(config)
+    end
+
+    context "when the plugin was already enabled and only a setting changed" do
+      let(:cooldown_seconds) { 900 }
+
+      before do
+        create(:plugin_activation, server_configuration: config, plugin:, enabled: true)
+      end
+
+      it "leaves the registered commands alone" do
+        result
+        expect(Bot::ConfigBus).not_to have_received(:sync_commands)
+      end
+    end
+
+    context "when the save fails" do
+      let(:cooldown_seconds) { -1 }
+
+      it "does not ask the bot to re-register anything" do
+        expect(result).to be_failure
+        expect(Bot::ConfigBus).not_to have_received(:sync_commands)
+      end
+    end
+  end
+
   context "atomicity: an invalid pingable role rolls back settings changes too" do
     let(:enabled) { "0" }
     let(:cooldown_seconds) { 900 }


### PR DESCRIPTION
Follow-up to #208: with the plugin row seeded, the LFG config page saves — but `/lfg` still doesn't appear in the server.

## The bug

Guild commands tied to a plugin (`plugin :lfg` on `Lfg::Post`, `plugin :image_scanning` on the two scam commands) only reach Discord when something publishes `Bot::ConfigBus.sync_commands` for the guild. Only `Ops::ServerConfiguration::Plugins::Toggle` — the plugin cards on the server dashboard — ever did.

The enable switch on a plugin's *own* config page goes through `Ops::<Plugin>::Configure` instead, which saved the `PluginActivation` and told the bot nothing. So enabling Looking for Game the obvious way — from the LFG page, where you're already configuring it — enabled the plugin everywhere except Discord's command list, until the next bot restart happened to run `Bot::CommandBackfill`.

## The fix

`Ops::PluginConfiguration#save_activation!` saves the activation and publishes `sync_commands`. All seven Configure operations persist through it now.

Two details worth the review:

- **It only publishes when `enabled` actually changed.** Editing a cooldown shouldn't bulk-overwrite the guild's command set on Discord's API.
- **The publish is wrapped in `ActiveRecord.after_all_transactions_commit`.** Five of the seven ops run inside `ApplicationOperation`'s implicit transaction; `Ops::Lfg::Configure` and `Ops::Roles::Configure` open their own. Publishing inline would let the bot re-read the activation before the commit landed and register the old set — the same missing-command symptom, just rarer and harder to pin down.

Side effects stay in the operations. (I tried a `PluginActivation` `after_commit` hook first, since it's forget-proof across all seven call sites; Tim rejected it — writes and their consequences belong in operations. `docs/architecture.md` now states the invariant instead, so the next plugin's Configure op has something to follow.)

## Right now, without waiting on this

Toggling LFG off and on from the **dashboard plugin card** publishes the sync and registers `/lfg` immediately. A bot restart does it too.

## Deferred

`convention-reviewer` flagged two pre-existing duplications in the ops this touches, both past rule-of-two and both bigger than this fix: the identical `rescue ActiveRecord::RecordInvalid` clause in `Ops::Lfg::Configure` / `Ops::Roles::Configure`, and the "add a field error, wrap in `failure`" shape repeated five times across the logging and moderation ops. Both want a shared helper on `Ops::PluginConfiguration`. Not folded in here.

## Gates

`rspec` (2255), `standardrb`, `active_record_doctor`, `undercover --compare origin/main` all green.