### PR TITLE
Add the 3.5.2 changelog section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ refactors, tooling, and CI changes are omitted; see the git history for those.
 
 This project follows [Semantic Versioning](https://semver.org).
 
+## [3.5.2] - 2026-07-24
+
+### Fixed
+- Enabling a plugin from its own config page, rather than from the dashboard plugin card, left its slash commands unregistered on Discord until the next bot restart. Turning Looking for Game on from the LFG page enabled it everywhere except Discord's command list, so `/lfg` never showed up. Every plugin config page now registers and unregisters its commands as the enable switch changes. ([#210](https://github.com/badBlackShark/shrkbot/pull/210))
+
 ## [3.5.1] - 2026-07-23
 
 ### Fixed


### PR DESCRIPTION
Patch release. One user-facing change since 3.5.1: the plugin command-sync fix from #210.

## Changelog section

```markdown
## [3.5.2] - 2026-07-24

### Fixed
- Enabling a plugin from its own config page, rather than from the dashboard plugin card, left its slash commands unregistered on Discord until the next bot restart. Turning Looking for Game on from the LFG page enabled it everywhere except Discord's command list, so `/lfg` never showed up. Every plugin config page now registers and unregisters its commands as the enable switch changes. ([#210](https://github.com/badBlackShark/shrkbot/pull/210))
```

Patch rather than minor: no new features, and the bug was in released code (Looking for Game shipped in 3.5.0), so it earns its own entry rather than being folded into a feature bullet.

CHANGELOG-only, no code rides along, so there were no gates to run. Once this merges, say the word and I'll tag and publish the release with these notes as the body.