### PR TITLE
Keep the join mention resolvable when pinging is off

### DIFF
--- a/app/components/welcomes/config_form.rb
+++ b/app/components/welcomes/config_form.rb
@@ -4,6 +4,7 @@ class Components::Welcomes::ConfigForm < Components::Base
   FIELD = "w-full resize-none rounded-control border-[1.5px] border-border-strong bg-surface-card px-3 py-2 " \
     "text-sm text-text-primary placeholder:text-text-secondary focus:border-accent focus:outline-none " \
     "focus:ring-3 focus:ring-[var(--focus-ring)]"
+  PLACEHOLDERS = %w[user username displayname membercount].freeze
 
   def initialize(server_configuration:, enable_error: nil)
     @config = server_configuration
@@ -86,10 +87,10 @@ class Components::Welcomes::ConfigForm < Components::Base
   def placeholder_help
     render Components::Callout.new(variant: :neutral) do
       span(class: "font-semibold") { t(".placeholders.intro") }
-      whitespace
-      placeholder_chip("{user}", t(".placeholders.user"))
-      whitespace
-      placeholder_chip("{membercount}", t(".placeholders.membercount"))
+      PLACEHOLDERS.each do |name|
+        whitespace
+        placeholder_chip("{#{name}}", t(".placeholders.#{name}"))
+      end
     end
   end
 

--- a/app/javascript/controllers/welcome_preview_controller.js
+++ b/app/javascript/controllers/welcome_preview_controller.js
@@ -1,6 +1,6 @@
 import { Controller } from "@hotwired/stimulus"
 
-const SAMPLE = { user: "newmember", membercount: "1,234" }
+const SAMPLE = { username: "newmember", displayname: "New Member", membercount: "1,234" }
 
 export default class extends Controller {
   static targets = ["joinMessage", "leaveMessage", "joinOutput", "leaveOutput"]
@@ -30,28 +30,28 @@ export default class extends Controller {
 
   nodes(text, kind) {
     const out = []
-    const pattern = /\{user\}|\{membercount\}/g
+    const pattern = /\{(user|username|displayname|membercount)\}/g
     let last = 0
     let match
     while ((match = pattern.exec(text))) {
       if (match.index > last) out.push(document.createTextNode(text.slice(last, match.index)))
-      out.push(this.token(match[0], kind))
+      out.push(this.token(match[1], kind))
       last = pattern.lastIndex
     }
     if (last < text.length) out.push(document.createTextNode(text.slice(last)))
     return out
   }
 
-  token(token, kind) {
-    if (token === "{membercount}") return document.createTextNode(SAMPLE.membercount)
+  token(name, kind) {
+    if (name !== "user") return document.createTextNode(SAMPLE[name])
 
     if (kind === "join") {
       const pill = document.createElement("span")
       pill.className = "discord-mention"
-      pill.textContent = "@" + SAMPLE.user
+      pill.textContent = "@" + SAMPLE.username
       return pill
     }
 
-    return document.createTextNode("@" + SAMPLE.user)
+    return document.createTextNode("@" + SAMPLE.username)
   }
 }

--- a/app/plugins/welcomes/events/member_leave.rb
+++ b/app/plugins/welcomes/events/member_leave.rb
@@ -11,8 +11,19 @@ module Welcomes
       return unless setting&.channel_id.present?
       return if setting.leave_message.blank?
 
-      content = Message.render(setting.leave_message, user: "@#{event.user.username}", member_count: event.server.member_count)
-      event.bot.send_message(setting.channel_id, content, false, nil, nil, {parse: []})
+      event.bot.send_message(setting.channel_id, content(setting.leave_message), false, nil, nil, {parse: []})
+    end
+
+    private
+
+    def content(template)
+      Message.render(
+        template,
+        user: "@#{event.user.username}",
+        username: event.user.username,
+        displayname: event.user.display_name,
+        member_count: event.server.member_count
+      )
     end
   end
 end

--- a/app/plugins/welcomes/join_announcement.rb
+++ b/app/plugins/welcomes/join_announcement.rb
@@ -2,6 +2,10 @@
 
 module Welcomes
   class JoinAnnouncement
+    # Stripping the mention drops the user object from the payload, so clients that have not lazily
+    # loaded the member render it as @unknown-user. Keep the mention real and silence the message.
+    SUPPRESS_NOTIFICATIONS = 1 << 12
+
     def initialize(bot:, server:, member:)
       @bot = bot
       @server = server
@@ -15,7 +19,7 @@ module Welcomes
     def deliver
       return unless enabled?
 
-      @bot.send_message(setting.channel_id, content, false, nil, nil, mention_suppression)
+      @bot.send_message(setting.channel_id, content, false, nil, nil, allowed_mentions, nil, nil, flags)
     end
 
     private
@@ -25,11 +29,21 @@ module Welcomes
     end
 
     def content
-      Message.render(setting.join_message, user: @member.mention, member_count: @server.member_count)
+      Message.render(
+        setting.join_message,
+        user: @member.mention,
+        username: @member.username,
+        displayname: @member.display_name,
+        member_count: @server.member_count
+      )
     end
 
-    def mention_suppression
-      {parse: []} unless setting.ping_on_join
+    def allowed_mentions
+      {parse: [], users: [@member.id]} unless setting.ping_on_join
+    end
+
+    def flags
+      setting.ping_on_join ? 0 : SUPPRESS_NOTIFICATIONS
     end
   end
 end

--- a/app/plugins/welcomes/message.rb
+++ b/app/plugins/welcomes/message.rb
@@ -4,10 +4,13 @@ module Welcomes
   module Message
     module_function
 
-    def render(template, user:, member_count:)
-      template.to_s
-        .gsub("{user}", user.to_s)
-        .gsub("{membercount}", member_count.to_s)
+    def render(template, user:, username:, displayname:, member_count:)
+      {
+        "{user}" => user,
+        "{username}" => username,
+        "{displayname}" => displayname,
+        "{membercount}" => member_count
+      }.reduce(template.to_s) { |text, (token, value)| text.gsub(token) { value.to_s } }
     end
   end
 end

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -443,13 +443,18 @@ en:
           label: Leave message
           placeholder: "{user} has left the server."
         ping_on_join:
-          help: Ping new members when the join message mentions them. Off shows the
-            mention without sending a notification.
+          help: Off delivers silently - the mention badge still shows, but no sound
+            or push. The mention itself stays real, because stripping it risks rendering
+            as "@unknown-user".
           label: Ping on join
         placeholders:
+          displayname: Expands to the member's nickname on this server, or their display
+            name if they have none.
           intro: 'Placeholders:'
           membercount: Expands to the server's current member count.
-          user: Expands to the member who joined or left.
+          user: Expands to a mention of the member on join, and to their plain @handle
+            on leave.
+          username: Expands to the member's Discord username, without a mention.
         preview:
           empty: This message is off.
           label: Live preview

--- a/spec/plugins/welcomes/events/member_join_spec.rb
+++ b/spec/plugins/welcomes/events/member_join_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Welcomes::MemberJoin do
   subject(:handle) { described_class.new(event).handle }
 
   let(:server) { double("server", id: 123, member_count: 10) }
-  let(:user) { double("user", mention: "<@7>", id: 7, pending: false) }
+  let(:user) { double("user", mention: "<@7>", id: 7, username: "newmember", display_name: "New Member", pending: false) }
   let(:bot) { double("bot", send_message: nil) }
   let(:event) { double("event", server:, user:, bot:) }
   let(:pending_joins) { Welcomes::PendingJoins.new }
@@ -21,7 +21,7 @@ RSpec.describe Welcomes::MemberJoin do
     it "welcomes them straight away" do
       handle
 
-      expect(bot).to have_received(:send_message).with(555, "Welcome <@7>!", false, nil, nil, nil)
+      expect(bot).to have_received(:send_message).with(555, "Welcome <@7>!", false, nil, nil, nil, nil, nil, 0)
     end
 
     it "holds nothing back" do
@@ -32,7 +32,7 @@ RSpec.describe Welcomes::MemberJoin do
   end
 
   context "when the member still has onboarding to finish" do
-    let(:user) { double("user", mention: "<@7>", id: 7, pending: true) }
+    let(:user) { double("user", mention: "<@7>", id: 7, username: "newmember", display_name: "New Member", pending: true) }
 
     it "holds the welcome back so the mention resolves later" do
       handle
@@ -49,7 +49,7 @@ RSpec.describe Welcomes::MemberJoin do
 
   context "when welcomes is inactive" do
     let(:setting) { nil }
-    let(:user) { double("user", mention: "<@7>", id: 7, pending: true) }
+    let(:user) { double("user", mention: "<@7>", id: 7, username: "newmember", display_name: "New Member", pending: true) }
 
     it "remembers nothing, since no welcome will ever be sent" do
       handle

--- a/spec/plugins/welcomes/events/member_leave_spec.rb
+++ b/spec/plugins/welcomes/events/member_leave_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Welcomes::MemberLeave do
   subject(:handle) { described_class.new(event).handle }
 
   let(:server) { double("server", id: 123, member_count: 9) }
-  let(:user) { double("user", username: "ghost", id: 7) }
+  let(:user) { double("user", username: "ghost", display_name: "Ghost", id: 7) }
   let(:bot) { double("bot") }
   let(:event) { double("event", server:, user:, bot:) }
   let(:pending_joins) { Welcomes::PendingJoins.new }
@@ -21,6 +21,15 @@ RSpec.describe Welcomes::MemberLeave do
 
     it "posts the rendered message with the @handle and suppresses all mentions" do
       expect(bot).to receive(:send_message).with(555, "@ghost left. 9 remain.", false, nil, nil, {parse: []})
+      handle
+    end
+  end
+
+  context "with the name placeholders in the leave message" do
+    let(:setting) { double("settings", channel_id: 555, leave_message: "{displayname} ({username}) left.") }
+
+    it "renders the display name and username" do
+      expect(bot).to receive(:send_message).with(555, "Ghost (ghost) left.", false, nil, nil, {parse: []})
       handle
     end
   end

--- a/spec/plugins/welcomes/events/onboarding_complete_spec.rb
+++ b/spec/plugins/welcomes/events/onboarding_complete_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Welcomes::OnboardingComplete do
   subject(:handle) { described_class.new(event).handle }
 
   let(:server) { double("server", id: 123, member_count: 10) }
-  let(:user) { double("user", mention: "<@7>", id: 7, pending: false) }
+  let(:user) { double("user", mention: "<@7>", id: 7, username: "newmember", display_name: "New Member", pending: false) }
   let(:bot) { double("bot", send_message: nil) }
   let(:event) { double("event", server:, user:, bot:) }
   let(:pending_joins) { Welcomes::PendingJoins.new }
@@ -23,7 +23,7 @@ RSpec.describe Welcomes::OnboardingComplete do
     it "posts the welcome it held back" do
       handle
 
-      expect(bot).to have_received(:send_message).with(555, "Welcome <@7>! Members: 10", false, nil, nil, nil)
+      expect(bot).to have_received(:send_message).with(555, "Welcome <@7>! Members: 10", false, nil, nil, nil, nil, nil, 0)
     end
 
     it "posts it only once, however many updates follow" do
@@ -43,7 +43,7 @@ RSpec.describe Welcomes::OnboardingComplete do
   end
 
   context "when the member has onboarding left to finish" do
-    let(:user) { double("user", mention: "<@7>", id: 7, pending: true) }
+    let(:user) { double("user", mention: "<@7>", id: 7, username: "newmember", display_name: "New Member", pending: true) }
 
     before { pending_joins.remember(guild_id: 123, user_id: 7) }
 

--- a/spec/plugins/welcomes/join_announcement_spec.rb
+++ b/spec/plugins/welcomes/join_announcement_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Welcomes::JoinAnnouncement do
   subject(:deliver) { described_class.new(bot:, server:, member:).deliver }
 
   let(:server) { double("server", id: 123, member_count: 10) }
-  let(:member) { double("member", mention: "<@7>") }
+  let(:member) { double("member", id: 7, mention: "<@7>", username: "newmember", display_name: "New Member") }
   let(:bot) { double("bot") }
 
   before do
@@ -17,7 +17,16 @@ RSpec.describe Welcomes::JoinAnnouncement do
     let(:setting) { double("settings", channel_id: 555, join_message: "Welcome {user}! Members: {membercount}", ping_on_join: true) }
 
     it "posts the rendered message to the configured channel" do
-      expect(bot).to receive(:send_message).with(555, "Welcome <@7>! Members: 10", false, nil, nil, nil)
+      expect(bot).to receive(:send_message).with(555, "Welcome <@7>! Members: 10", false, nil, nil, nil, nil, nil, 0)
+      deliver
+    end
+  end
+
+  context "with the name placeholders in the join message" do
+    let(:setting) { double("settings", channel_id: 555, join_message: "{username} aka {displayname}", ping_on_join: true) }
+
+    it "renders the username and display name" do
+      expect(bot).to receive(:send_message).with(555, "newmember aka New Member", false, nil, nil, nil, nil, nil, 0)
       deliver
     end
   end
@@ -25,8 +34,18 @@ RSpec.describe Welcomes::JoinAnnouncement do
   context "when pinging on join is disabled" do
     let(:setting) { double("settings", channel_id: 555, join_message: "Welcome {user}!", ping_on_join: false) }
 
-    it "suppresses the mention so no ping fires" do
-      expect(bot).to receive(:send_message).with(555, "Welcome <@7>!", false, nil, nil, {parse: []})
+    it "keeps the mention resolvable but sends the message silently" do
+      expect(bot).to receive(:send_message).with(
+        555,
+        "Welcome <@7>!",
+        false,
+        nil,
+        nil,
+        {parse: [], users: [7]},
+        nil,
+        nil,
+        described_class::SUPPRESS_NOTIFICATIONS
+      )
       deliver
     end
   end

--- a/spec/plugins/welcomes/message_spec.rb
+++ b/spec/plugins/welcomes/message_spec.rb
@@ -3,14 +3,24 @@
 require "rails_helper"
 
 RSpec.describe Welcomes::Message do
-  subject(:rendered) { described_class.render(template, user:, member_count:) }
+  subject(:rendered) { described_class.render(template, user:, username:, displayname:, member_count:) }
 
   let(:template) { "Welcome {user}! You are member {membercount}." }
   let(:user) { "<@1>" }
+  let(:username) { "newmember" }
+  let(:displayname) { "New Member" }
   let(:member_count) { 42 }
 
   it "substitutes {user} and {membercount}" do
     expect(rendered).to eq("Welcome <@1>! You are member 42.")
+  end
+
+  context "with the name placeholders" do
+    let(:template) { "{username} joins as {displayname}" }
+
+    it "substitutes {username} and {displayname}" do
+      expect(rendered).to eq("newmember joins as New Member")
+    end
   end
 
   context "with a placeholder repeated" do
@@ -19,6 +29,15 @@ RSpec.describe Welcomes::Message do
 
     it "replaces every occurrence" do
       expect(rendered).to eq("X X")
+    end
+  end
+
+  context "with a backreference sequence in the substituted value" do
+    let(:template) { "Hi {displayname}" }
+    let(:displayname) { 'Sm\\0key' }
+
+    it "inserts the value literally instead of expanding the sequence" do
+      expect(rendered).to eq('Hi Sm\\0key')
     end
   end
 


### PR DESCRIPTION
Follow-up to #206. That PR fixed welcomes firing while a member was still pending onboarding; this one fixes the second, unrelated way a join mention ends up as `@unknown-user`.

## The bug

Live on the community server: a member joined overnight and their mention rendered as `@unknown-user`. Copying their ID out of the message and searching them in the members tab repaired the mention **in place, without a reload** — which rules out anything being baked into the message at send time.

Discord clients resolve `<@id>` against a local member store that is populated lazily. Two things can fill it: a `GUILD_MEMBER_ADD` over the gateway while you are connected, or the user objects that ship in the message payload's `mentions` array. Suppressing mentions via `allowed_mentions` removes the user from that array, so with ping-on-join off the payload carries nothing. Whether the mention resolves then comes down to whether each individual viewer happened to be online when the member joined. Anyone asleep sees `@unknown-user`.

## The fix

On the ping-off path, allow the joiner's own mention and set the `SUPPRESS_NOTIFICATIONS` message flag (`1 << 12`) instead of stripping mentions:

- the user object ships in the payload, so the mention resolves for everyone, always;
- the joiner gets no notification sound and no push — only an unread mention badge;
- the allowlist is scoped to the joiner, so a template containing `@everyone` is no longer pingable on this path (it previously relied on the blanket `{parse: []}`).

The ping-on path is untouched.

This is a deliberate, small behaviour change: "off" used to mean *no mention indicator at all*, and now means *silent mention*. That is the trade being made — a badge is the price of the mention resolving for people who were not online. The toggle's help copy now states it, and names the `@unknown-user` risk that stripping the mention would carry. The mechanism behind that risk stays in a comment on the constant rather than in dashboard copy.

## Placeholders

Adds `{username}` and `{displayname}` alongside `{user}` and `{membercount}`, in both join and leave messages, so a greeting can name someone without mentioning them at all. `{displayname}` is the server nickname where one is set. The dashboard chips, tooltips, and live preview cover all four.

## Notes

- `Welcomes::Message.render` switched to `gsub(token) { value }` — the string-replacement form expands `\0`-style backreferences, and nicknames can contain backslashes. Covered by a spec.
- No new stored data, so no privacy-policy or purge changes.
- Gates green locally: rspec (2259), standardrb, active_record_doctor, undercover, i18n-tasks missing + check-normalized.

The staff-facing angle discussed alongside this — mentions in the log channel for account-age triage — was dropped deliberately: it would flood the logging channel that carries scam-image reports.

<sub>Implemented with Claude Code.</sub>

