### PR TITLE
Move the API docs jobs off the deprecated Node 20 action runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,9 +211,9 @@ jobs:
           bundler-cache: true
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
 
       # bin/openapi merges the schema fragments with plain Ruby (no app boot, no
       # DB), so this job stays a lightweight Ruby+Node runner like the other jobs.
@@ -227,14 +227,14 @@ jobs:
 
       - name: Upload the API docs as a build artifact
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: twilight-struggle-api-docs
           path: _site/index.html
 
       - name: Upload the API docs for GitHub Pages
         if: github.event_name == 'push'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: _site
 
@@ -259,5 +259,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 


### PR DESCRIPTION
The `deploy_docs` job on `main` logs `Node 20 is being deprecated. This workflow is running with Node 24 by default.` for every action still shipping a node20 runtime. Bumped the four in the docs jobs to their node24 majors:

| action | before | after |
| --- | --- | --- |
| `actions/setup-node` | v4 | v7 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/upload-pages-artifact` | v3 | v5 |
| `actions/deploy-pages` | v4 | v5 |

Both Pages majors are runtime-only bumps (`deploy-pages` v5 = "Update Node.js version to 24.x"; `upload-pages-artifact` v5 = internal `upload-artifact` v7) — no input changes, so the job definitions are untouched. `node-version` for the Redocly build goes 20 → 24 as well, since Node 20 is out of maintenance.

Does **not** fix the `deploy_docs` failure on run 30159408328 — that one is `Failed to create deployment (status: 404)` because GitHub Pages has never been enabled on this repo (`GET /repos/badBlackShark/shrkbot/pages` 404s). `deploy-pages` can't create the site itself; it needs Settings → Pages → Source: **GitHub Actions** once, by hand.

The docs build itself (`api_docs`) passed on that run — only the deploy step failed.