### PR TITLE
Add bespoke plugins, granted per server by the bot owner

### DIFF
--- a/app/bot/registration/guild_command_set.rb
+++ b/app/bot/registration/guild_command_set.rb
@@ -55,7 +55,7 @@ module Bot
     end
 
     def enabled_keys
-      @enabled_keys ||= server_configuration ? server_configuration.plugins.enabled.pluck(:key).map(&:to_sym) : []
+      @enabled_keys ||= server_configuration ? server_configuration.plugins.enabled.pluck(:key).map(&:to_sym).to_set : Set.new
     end
 
     def server_configuration

--- a/app/bot/registration/guild_command_set.rb
+++ b/app/bot/registration/guild_command_set.rb
@@ -37,19 +37,29 @@ module Bot
     def include_guild?(reg)
       return true if reg.plugin.nil?
 
-      parent_key = PluginCatalog.find(reg.plugin)&.parent
+      definition = PluginCatalog.find(reg.plugin)
+      return false unless bespoke_granted?(definition)
+
+      parent_key = definition&.parent
       enabled_keys.include?(reg.plugin) && (parent_key.nil? || enabled_keys.include?(parent_key))
     end
 
-    def enabled_keys
-      @enabled_keys ||= fetch_enabled_keys
+    def bespoke_granted?(definition)
+      return true unless definition&.bespoke
+
+      granted_keys.include?(definition.key)
     end
 
-    def fetch_enabled_keys
-      config = ServerConfiguration.find_by(discord_id: @discord_id)
-      return [] unless config
+    def granted_keys
+      @granted_keys ||= server_configuration ? BespokePluginGrant.granted_keys(server_configuration) : Set.new
+    end
 
-      config.plugins.enabled.pluck(:key).map(&:to_sym)
+    def enabled_keys
+      @enabled_keys ||= server_configuration ? server_configuration.plugins.enabled.pluck(:key).map(&:to_sym) : []
+    end
+
+    def server_configuration
+      @server_configuration ||= ServerConfiguration.find_by(discord_id: @discord_id)
     end
   end
 end

--- a/app/components/admin/bespoke_plugin_card.rb
+++ b/app/components/admin/bespoke_plugin_card.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+class Components::Admin::BespokePluginCard < Components::Base
+  include Phlex::Rails::Helpers::FormWith
+
+  def initialize(definition:, grants:, servers:)
+    @definition = definition
+    @grants = grants
+    @servers = servers
+  end
+
+  def view_template
+    render Components::Card.new do
+      header
+      grant_list
+      ungranted_servers.empty? ? all_granted_note : grant_form
+    end
+  end
+
+  private
+
+  def header
+    p(class: "text-sm font-semibold") { @definition.name }
+    p(class: "mt-0.5 text-sm text-text-secondary") { @definition.description }
+  end
+
+  def grant_list
+    p(class: "mt-4 text-[11px] font-semibold uppercase tracking-widest text-eyebrow") { t(".granted") }
+    return p(class: "mt-1 text-sm text-text-muted") { t(".none") } if @grants.empty?
+
+    div(class: "mt-1") do
+      @grants.each { |grant| render Components::Admin::BespokePluginGrantRow.new(grant:) }
+    end
+  end
+
+  def all_granted_note
+    p(class: "mt-4 text-sm text-text-muted") { t(".all_granted") }
+  end
+
+  def grant_form
+    form_with(url: admin_bespoke_plugin_grants_path, method: :post, class: "mt-4 flex items-end gap-2") do
+      input(type: "hidden", name: "plugin_key", value: @definition.key.to_s)
+      div(class: "flex-1") do
+        render Components::TomSelect.new(
+          name: "server_configuration_id",
+          options: server_options,
+          include_blank: true,
+          controller_data: {tom_select_placeholder_value: t(".placeholder")}
+        )
+      end
+      render Components::Button.new(label: t(".grant"), type: "submit")
+    end
+  end
+
+  def server_options
+    ungranted_servers.map do |config|
+      Components::TomSelect::Option.for(value: config.id, label: config.name.presence || config.discord_id.to_s)
+    end
+  end
+
+  def ungranted_servers
+    @ungranted_servers ||= @servers.reject { |config| granted_ids.include?(config.id) }
+  end
+
+  def granted_ids
+    @granted_ids ||= @grants.map(&:server_configuration_id).to_set
+  end
+end

--- a/app/components/admin/bespoke_plugin_grant_row.rb
+++ b/app/components/admin/bespoke_plugin_grant_row.rb
@@ -26,7 +26,7 @@ class Components::Admin::BespokePluginGrantRow < Components::Base
       admin_bespoke_plugin_grant_path(@grant),
       method: :delete,
       data: {turbo_confirm: t(".confirm")},
-      class: "flex-none rounded-control border border-danger px-2.5 py-1 text-xs font-semibold text-danger transition-colors hover:bg-danger-soft"
+      class: Components::Button.css(variant: :danger_outline, size: :sm, extra: "flex-none")
     ) { t(".revoke") }
   end
 end

--- a/app/components/admin/bespoke_plugin_grant_row.rb
+++ b/app/components/admin/bespoke_plugin_grant_row.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class Components::Admin::BespokePluginGrantRow < Components::Base
+  include Phlex::Rails::Helpers::ButtonTo
+
+  def initialize(grant:)
+    @grant = grant
+  end
+
+  def view_template
+    div(class: "flex items-center justify-between gap-3 border-b border-border-subtle py-2 last:border-b-0") do
+      span(class: "truncate text-sm") { server_label }
+      revoke_button
+    end
+  end
+
+  private
+
+  def server_label
+    config = @grant.server_configuration
+    config.name.presence || config.discord_id.to_s
+  end
+
+  def revoke_button
+    button_to(
+      admin_bespoke_plugin_grant_path(@grant),
+      method: :delete,
+      data: {turbo_confirm: t(".confirm")},
+      class: "flex-none rounded-control border border-danger px-2.5 py-1 text-xs font-semibold text-danger transition-colors hover:bg-danger-soft"
+    ) { t(".revoke") }
+  end
+end

--- a/app/components/app_shell.rb
+++ b/app/components/app_shell.rb
@@ -137,22 +137,11 @@ class Components::AppShell < Components::Base
         data: {dropdown_target: "menu"},
         class: "dropdown-menu absolute right-0 top-12 z-40 w-52 rounded-lg border border-border-default bg-surface-card p-1.5 shadow-lg"
       ) do
-        a(
-          href: account_path,
-          class: "flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-sm text-text-secondary transition-colors hover:bg-surface-sunken"
-        ) do
-          render Components::Icon.new("user", class: "size-4")
-          span { t(".account") }
-        end
+        render Components::AppShell::MenuItem.new(href: account_path, icon: "user", label: t(".account"))
         div(class: "mx-1 my-1 h-px bg-surface-sunken")
         if @user.owner?
-          a(
-            href: admin_settings_path,
-            class: "flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-sm text-text-secondary transition-colors hover:bg-surface-sunken"
-          ) do
-            render Components::Icon.new("shield", class: "size-4")
-            span { t(".admin_settings") }
-          end
+          render Components::AppShell::MenuItem.new(href: admin_settings_path, icon: "shield", label: t(".admin_settings"))
+          render Components::AppShell::MenuItem.new(href: admin_bespoke_plugin_grants_path, icon: "puzzle-piece", label: t(".admin_bespoke_plugins"))
           div(class: "mx-1 my-1 h-px bg-surface-sunken")
         end
         button_to(

--- a/app/components/app_shell/menu_item.rb
+++ b/app/components/app_shell/menu_item.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Components::AppShell::MenuItem < Components::Base
+  def initialize(href:, icon:, label:)
+    @href = href
+    @icon = icon
+    @label = label
+  end
+
+  def view_template
+    a(
+      href: @href,
+      class: "flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-sm text-text-secondary transition-colors hover:bg-surface-sunken"
+    ) do
+      render Components::Icon.new(@icon, class: "size-4")
+      span { @label }
+    end
+  end
+end

--- a/app/components/base.rb
+++ b/app/components/base.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class Components::Base < Phlex::HTML
-  # Include any helpers you want to be available across all components
   include Phlex::Rails::Helpers::Routes
   include Phlex::Rails::Helpers::Translate
 end

--- a/app/components/button.rb
+++ b/app/components/button.rb
@@ -7,7 +7,8 @@ class Components::Button < Components::Base
     primary: "chamfer-cta bg-accent-fill text-white hover:bg-accent-fill-hover font-semibold",
     secondary: "rounded-control border border-border-strong bg-surface-card hover:bg-surface-sunken font-semibold",
     ghost: "rounded-control text-text-secondary hover:bg-surface-sunken font-semibold",
-    danger: "rounded-control bg-danger text-white hover:bg-danger/90 font-semibold"
+    danger: "rounded-control bg-danger text-white hover:bg-danger/90 font-semibold",
+    danger_outline: "rounded-control border border-danger text-danger hover:bg-danger-soft font-semibold"
   }.freeze
 
   SIZES = {

--- a/app/controllers/admin/bespoke_plugin_grants_controller.rb
+++ b/app/controllers/admin/bespoke_plugin_grants_controller.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class Admin::BespokePluginGrantsController < ApplicationController
+  include RequiresOwner
+
+  def index
+    render Views::Admin::BespokePluginGrants::Index.new(
+      user: current_user,
+      definitions: PluginCatalog.bespoke,
+      grants: BespokePluginGrant.grouped_by_plugin_key,
+      servers: ServerConfiguration.order(:name)
+    )
+  end
+
+  def create
+    server_configuration = ServerConfiguration.find_by(id: params[:server_configuration_id])
+    return head :not_found unless server_configuration && bespoke_key?
+
+    Ops::ServerConfiguration::BespokePluginGrants::Create.call(
+      server_configuration:,
+      plugin_key: params[:plugin_key]
+    )
+    redirect_to admin_bespoke_plugin_grants_path, notice: t("admin.bespoke_plugin_grants.granted")
+  end
+
+  def destroy
+    grant = BespokePluginGrant.find_by(id: params[:id])
+    return head :not_found unless grant
+
+    Ops::ServerConfiguration::BespokePluginGrants::Destroy.call(bespoke_plugin_grant: grant)
+    redirect_to admin_bespoke_plugin_grants_path, notice: t("admin.bespoke_plugin_grants.revoked")
+  end
+
+  private
+
+  def bespoke_key?
+    PluginCatalog.bespoke.any? { |definition| definition.key.to_s == params[:plugin_key] }
+  end
+end

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Admin::SettingsController < ApplicationController
-  before_action :require_owner
+  include RequiresOwner
 
   def show
     render Views::Admin::Settings::Show.new(user: current_user)
@@ -15,11 +15,5 @@ class Admin::SettingsController < ApplicationController
       format.turbo_stream
       format.html { redirect_to admin_settings_path }
     end
-  end
-
-  private
-
-  def require_owner
-    redirect_to servers_path, alert: t("admin.owner_only") unless current_user.owner?
   end
 end

--- a/app/controllers/concerns/requires_owner.rb
+++ b/app/controllers/concerns/requires_owner.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module RequiresOwner
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :require_owner
+  end
+
+  private
+
+  def require_owner
+    redirect_to servers_path, alert: t("admin.owner_only") unless current_user.owner?
+  end
+end

--- a/app/models/bespoke_plugin_grant.rb
+++ b/app/models/bespoke_plugin_grant.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class BespokePluginGrant < ApplicationRecord
+  belongs_to :server_configuration
+
+  validates :plugin_key, presence: true, uniqueness: {scope: :server_configuration_id}
+
+  def self.granted_keys(server_configuration)
+    where(server_configuration:).pluck(:plugin_key).map(&:to_sym).to_set
+  end
+
+  def self.grouped_by_plugin_key
+    includes(:server_configuration).group_by { |grant| grant.plugin_key.to_sym }
+  end
+end

--- a/app/models/plugin_catalog.rb
+++ b/app/models/plugin_catalog.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class PluginCatalog
-  Definition = Data.define(:key, :name, :description, :channel_setting, :requires_plugin, :parent, :prerequisite) do
-    def initialize(key:, name:, description:, channel_setting: nil, requires_plugin: nil, parent: nil, prerequisite: nil)
+  Definition = Data.define(:key, :name, :description, :channel_setting, :requires_plugin, :parent, :prerequisite, :bespoke) do
+    def initialize(key:, name:, description:, channel_setting: nil, requires_plugin: nil, parent: nil, prerequisite: nil, bespoke: false)
       super
     end
 
@@ -11,6 +11,7 @@ class PluginCatalog
     end
 
     def prerequisites_met?(server_configuration, enabled_keys: nil)
+      return false unless granted?(server_configuration)
       return false unless required_plugins_enabled?(server_configuration, enabled_keys)
       return false unless channel_met?(server_configuration)
       return false unless prerequisite.nil? || prerequisite.call(server_configuration)
@@ -19,6 +20,12 @@ class PluginCatalog
     end
 
     private
+
+    def granted?(server_configuration)
+      return true unless bespoke
+
+      ::BespokePluginGrant.exists?(server_configuration:, plugin_key: key)
+    end
 
     def required_plugins_enabled?(server_configuration, enabled_keys)
       required = [requires_plugin, parent].compact
@@ -55,6 +62,15 @@ class PluginCatalog
 
   def self.channel_backed
     DEFINITIONS.select(&:channel_backed?)
+  end
+
+  def self.bespoke
+    DEFINITIONS.select(&:bespoke)
+  end
+
+  def self.visible_for(server_configuration)
+    granted = BespokePluginGrant.granted_keys(server_configuration)
+    DEFINITIONS.reject { |definition| definition.bespoke && !granted.include?(definition.key) }
   end
 
   def self.sub_plugin?(key)

--- a/app/models/server_configuration.rb
+++ b/app/models/server_configuration.rb
@@ -3,6 +3,7 @@
 class ServerConfiguration < ApplicationRecord
   has_many :plugin_activations, dependent: :delete_all
   has_many :plugins, through: :plugin_activations
+  has_many :bespoke_plugin_grants, dependent: :delete_all
 
   has_one :logging_setting, dependent: :delete
   has_one :role_setting, class_name: "Roles::Settings", dependent: :destroy

--- a/app/operations/server_configuration/bespoke_plugin_grants/create.rb
+++ b/app/operations/server_configuration/bespoke_plugin_grants/create.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Ops
+  module ServerConfiguration
+    module BespokePluginGrants
+      class Create < ApplicationOperation
+        receives :server_configuration, :plugin_key
+
+        def call
+          grant = ::BespokePluginGrant.find_or_create_by!(server_configuration:, plugin_key:)
+          Bot::ConfigBus.sync_commands(server_configuration)
+          ok(grant)
+        end
+      end
+    end
+  end
+end

--- a/app/operations/server_configuration/bespoke_plugin_grants/destroy.rb
+++ b/app/operations/server_configuration/bespoke_plugin_grants/destroy.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Ops
+  module ServerConfiguration
+    module BespokePluginGrants
+      class Destroy < ApplicationOperation
+        receives :bespoke_plugin_grant
+
+        def call
+          config = bespoke_plugin_grant.server_configuration
+          bespoke_plugin_grant.destroy!
+          disable_plugin(config)
+          ok(bespoke_plugin_grant)
+        end
+
+        private
+
+        def disable_plugin(config)
+          plugin = ::Plugin.find_by(key: bespoke_plugin_grant.plugin_key)
+          if plugin
+            Plugins::Toggle.call(server_configuration: config, plugin:, enabled: false)
+          else
+            Bot::ConfigBus.sync_commands(config)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/presenters/plugin_status.rb
+++ b/app/presenters/plugin_status.rb
@@ -14,7 +14,7 @@ class PluginStatus
   def self.rows(server_configuration)
     activations = server_configuration.plugin_activations.includes(:plugin).index_by { |activation| activation.plugin.key }
     enabled_keys = server_configuration.enabled_plugin_keys
-    catalog_rows = PluginCatalog.all.map do |definition|
+    catalog_rows = PluginCatalog.visible_for(server_configuration).map do |definition|
       Row.new(
         key: definition.key,
         enabled: activations[definition.key]&.enabled? || false,

--- a/app/views/accounts/show.rb
+++ b/app/views/accounts/show.rb
@@ -42,7 +42,7 @@ class Views::Accounts::Show < Views::Base
         account_path,
         method: :delete,
         data: {turbo_confirm: t(".confirm")},
-        class: "rounded-md border border-danger px-4 py-2 text-sm font-semibold text-danger transition-colors hover:bg-danger-soft"
+        class: Components::Button.css(variant: :danger_outline)
       ) { t(".button") }
     end
   end

--- a/app/views/admin/bespoke_plugin_grants/index.rb
+++ b/app/views/admin/bespoke_plugin_grants/index.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class Views::Admin::BespokePluginGrants::Index < Views::Base
+  def initialize(user:, definitions:, grants:, servers:)
+    @user = user
+    @definitions = definitions
+    @grants = grants
+    @servers = servers
+  end
+
+  def view_template
+    render Components::AppShell.new(user: @user) do
+      div(class: "mx-auto max-w-2xl px-6 py-10") do
+        render Components::PageHeading.new(title: t(".title"), subtitle: t(".subtitle"))
+        @definitions.empty? ? empty : cards
+      end
+    end
+  end
+
+  private
+
+  def empty
+    render Components::EmptyState.new(title: t(".empty_title"), body: t(".empty_body")) { nil }
+  end
+
+  def cards
+    div(class: "flex flex-col gap-4") do
+      @definitions.each { |definition| card(definition) }
+    end
+  end
+
+  def card(definition)
+    render Components::Admin::BespokePluginCard.new(
+      definition:,
+      grants: @grants.fetch(definition.key, []),
+      servers: @servers
+    )
+  end
+end

--- a/app/views/base.rb
+++ b/app/views/base.rb
@@ -1,12 +1,4 @@
 # frozen_string_literal: true
 
 class Views::Base < Components::Base
-  # The `Views::Base` is an abstract class for all your views.
-
-  # By default, it inherits from `Components::Base`, but you
-  # can change that to `Phlex::HTML` if you want to keep views and
-  # components independent.
-
-  # More caching options at https://www.phlex.fun/components/caching
-  def cache_store = Rails.cache
 end

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -533,8 +533,7 @@ en:
       bespoke_plugin_grants:
         index:
           empty_body: Bespoke plugins are hidden from every server until you grant
-            them here. None are built yet - this page fills up when the first one
-            ships.
+            them here. None are built yet.
           empty_title: No bespoke plugins yet
           subtitle: Plugins you activate by hand, one server at a time.
           title: Bespoke plugins

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -3,6 +3,9 @@ en:
   accounts:
     deleted: Your account and all associated data have been deleted.
   admin:
+    bespoke_plugin_grants:
+      granted: Plugin granted.
+      revoked: Plugin revoked.
     owner_only: Only the bot owner can open that page.
     settings:
       dms_disabled: Error DMs disabled.
@@ -14,12 +17,23 @@ en:
     login_required: Please sign in to continue.
   components:
     admin:
+      bespoke_plugin_card:
+        all_granted: Every server already has this plugin.
+        grant: Grant
+        granted: Granted to
+        none: Not granted to any server yet.
+        placeholder: Choose a server
+      bespoke_plugin_grant_row:
+        confirm: Revoke this plugin? The server loses the page and its commands, and
+          the plugin is switched off.
+        revoke: Revoke
       owner_dm_card:
         description: Sends you a Discord DM when shrkbot hits an unexpected error.
         label: DM me on errors
     app_shell:
       account: Account
       add_server: Add another server
+      admin_bespoke_plugins: Bespoke plugins
       admin_settings: Admin settings
       log_out: Log out
       notifications: Notifications
@@ -516,6 +530,14 @@ en:
         subtitle: What shrkbot stores about you.
         title: Account
     admin:
+      bespoke_plugin_grants:
+        index:
+          empty_body: Bespoke plugins are hidden from every server until you grant
+            them here. None are built yet - this page fills up when the first one
+            ships.
+          empty_title: No bespoke plugins yet
+          subtitle: Plugins you activate by hand, one server at a time.
+          title: Bespoke plugins
       settings:
         show:
           subtitle: Global settings for shrkbot's owner.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resource :settings, only: [:show, :update]
+    resources :bespoke_plugin_grants, only: [:index, :create, :destroy]
   end
 
   resources :servers, only: [:index, :show], param: :id do

--- a/db/migrate/20260725132816_create_bespoke_plugin_grants.rb
+++ b/db/migrate/20260725132816_create_bespoke_plugin_grants.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class CreateBespokePluginGrants < ActiveRecord::Migration[8.1]
+  def change
+    create_table :bespoke_plugin_grants, id: false do |t|
+      t.string :id, null: false, primary_key: true
+      t.references :server_configuration, null: false, foreign_key: true, type: :string, index: false
+      t.string :plugin_key, null: false
+      t.timestamps
+    end
+
+    add_index :bespoke_plugin_grants,
+      [:server_configuration_id, :plugin_key],
+      unique: true,
+      name: "index_bespoke_plugin_grants_on_server_and_plugin_key"
+
+    reversible do |dir|
+      dir.up { safety_assured { execute "ALTER TABLE bespoke_plugin_grants ALTER COLUMN id SET DEFAULT ('bpg_' || gen_random_uuid())" } }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_24_153009) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_25_132816) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -23,6 +23,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_24_153009) do
     t.string "role_set_id", null: false
     t.datetime "updated_at", null: false
     t.index ["role_set_id", "role_id"], name: "index_assignable_roles_on_role_set_id_and_role_id", unique: true
+  end
+
+  create_table "bespoke_plugin_grants", id: :string, default: -> { "('bpg_'::text || gen_random_uuid())" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "plugin_key", null: false
+    t.string "server_configuration_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["server_configuration_id", "plugin_key"], name: "index_bespoke_plugin_grants_on_server_and_plugin_key", unique: true
   end
 
   create_table "bot_settings", id: :string, default: -> { "('bst_'::text || gen_random_uuid())" }, force: :cascade do |t|
@@ -464,6 +472,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_24_153009) do
   end
 
   add_foreign_key "assignable_roles", "role_sets"
+  add_foreign_key "bespoke_plugin_grants", "server_configurations"
   add_foreign_key "channel_overwrites", "server_channels"
   add_foreign_key "image_scanning_settings", "server_configurations"
   add_foreign_key "lfg_messages", "server_configurations"

--- a/docs/adding-a-plugin.md
+++ b/docs/adding-a-plugin.md
@@ -92,6 +92,12 @@ before a child can enable. Both are folded into `prerequisites_met?` and backsto
 the `PluginActivation` validation. Example: the moderation group's sub-plugins set
 `parent: :moderation`, and `:moderation` sets `requires_plugin: :logging`.
 
+`bespoke: true` marks a plugin as bot-owner-granted: it's hidden from every server's
+dashboard and its guild commands aren't registered until the bot owner grants it to
+that server from the admin panel (`BespokePluginGrant`). The grant is folded into
+`prerequisites_met?` alongside the other checks, so the enable path is backstopped the
+same way as `requires_plugin:`/`parent:`.
+
 ## 4. Writes go through operations
 
 All settings writes and runtime mutations are operations under

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -206,6 +206,14 @@ that channel is configured. This is enforced in two places:
 `Ops::ServerConfiguration::TogglePlugin` gives the friendly failure, and a
 `PluginActivation` validation backstops any write that skips the op.
 
+A **bespoke** plugin (`Definition#bespoke`) is hand-activated by the bot owner per
+server rather than self-serve. `bespoke_plugin_grants` (guild ↔ plugin key, cascaded
+off `ServerConfiguration`) records the grant; `PluginCatalog.visible_for` is the filter
+the dashboard/sidebar uses to hide ungranted bespoke plugins entirely, and
+`Bot::GuildCommandSet` requires a grant before registering a bespoke plugin's guild
+commands. `prerequisites_met?` gates on the grant first, so the enable path is
+backstopped the same way as the other prerequisite checks.
+
 ## Commands and events
 
 discordrb is `require: false` — only `bin/bot` and `bin/jobs` load it. Commands and

--- a/spec/bot/registration/guild_command_set_spec.rb
+++ b/spec/bot/registration/guild_command_set_spec.rb
@@ -99,9 +99,35 @@ RSpec.describe Bot::GuildCommandSet do
       end
     end
 
+    context "plugin command for a bespoke plugin" do
+      include_context "with a bespoke plugin definition"
+
+      let(:bespoke_plugin) { create(:plugin, key: "bespoke_thing", name: "Bespoke Thing") }
+      let(:bespoke_cmd) { make_command(name: :bespoke, plugin_key: :bespoke_thing) }
+      let(:commands) { [bespoke_cmd] }
+
+      it "is excluded without a grant" do
+        expect(payloads).to be_empty
+      end
+
+      context "when the server has been granted the plugin and the activation is enabled" do
+        before do
+          create(:bespoke_plugin_grant, server_configuration: server, plugin_key: bespoke_definition.key)
+          create(:plugin_activation, server_configuration: server, plugin: bespoke_plugin, enabled: true)
+        end
+
+        it "is included" do
+          expect(payloads.map { |p| p[:name] }).to include(:bespoke)
+        end
+      end
+    end
+
     context "when there is no ServerConfiguration row" do
+      include_context "with a bespoke plugin definition"
+
       let(:discord_id) { 999_999_999 }
-      let(:commands) { [plugin_less_cmd, image_scanning_cmd] }
+      let(:bespoke_cmd) { make_command(name: :bespoke, plugin_key: :bespoke_thing) }
+      let(:commands) { [plugin_less_cmd, image_scanning_cmd, bespoke_cmd] }
 
       it "includes only plugin-less commands" do
         expect(payloads.map { |p| p[:name] }).to eq([:ping])

--- a/spec/factories/bespoke_plugin_grants.rb
+++ b/spec/factories/bespoke_plugin_grants.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :bespoke_plugin_grant do
+    server_configuration
+    sequence(:plugin_key) { |n| "bespoke_#{n}" }
+  end
+end

--- a/spec/models/bespoke_plugin_grant_spec.rb
+++ b/spec/models/bespoke_plugin_grant_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BespokePluginGrant do
+  describe "validations" do
+    let(:server_configuration) { create(:server_configuration) }
+
+    it "requires a plugin_key" do
+      grant = build(:bespoke_plugin_grant, server_configuration:, plugin_key: nil)
+
+      expect(grant).not_to be_valid
+      expect(grant.errors[:plugin_key]).to be_present
+    end
+
+    it "requires plugin_key to be unique within a server_configuration" do
+      create(:bespoke_plugin_grant, server_configuration:, plugin_key: "lfg")
+      duplicate = build(:bespoke_plugin_grant, server_configuration:, plugin_key: "lfg")
+
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:plugin_key]).to be_present
+    end
+
+    it "allows the same plugin_key across different server_configurations" do
+      create(:bespoke_plugin_grant, server_configuration:, plugin_key: "lfg")
+      other = build(:bespoke_plugin_grant, server_configuration: create(:server_configuration), plugin_key: "lfg")
+
+      expect(other).to be_valid
+    end
+  end
+
+  describe ".granted_keys" do
+    subject(:granted_keys) { described_class.granted_keys(server_configuration) }
+
+    let(:server_configuration) { create(:server_configuration) }
+    let(:other_server_configuration) { create(:server_configuration) }
+
+    before do
+      create(:bespoke_plugin_grant, server_configuration:, plugin_key: "lfg")
+      create(:bespoke_plugin_grant, server_configuration:, plugin_key: "spam_protection")
+      create(:bespoke_plugin_grant, server_configuration: other_server_configuration, plugin_key: "moderation")
+    end
+
+    it "returns a Set of symbols for that server_configuration only" do
+      expect(granted_keys).to eq(Set[:lfg, :spam_protection])
+    end
+  end
+end

--- a/spec/models/plugin_catalog_spec.rb
+++ b/spec/models/plugin_catalog_spec.rb
@@ -33,6 +33,52 @@ RSpec.describe PluginCatalog do
     end
   end
 
+  describe ".bespoke" do
+    include_context "with a bespoke plugin definition"
+
+    it "selects only bespoke definitions" do
+      expect(described_class.bespoke).to eq([bespoke_definition])
+    end
+  end
+
+  describe ".visible_for" do
+    include_context "with a bespoke plugin definition"
+
+    let(:config) { create(:server_configuration) }
+
+    it "hides an ungranted bespoke definition" do
+      expect(described_class.visible_for(config)).not_to include(bespoke_definition)
+    end
+
+    it "includes a granted bespoke definition" do
+      create(:bespoke_plugin_grant, server_configuration: config, plugin_key: bespoke_definition.key)
+
+      expect(described_class.visible_for(config)).to include(bespoke_definition)
+    end
+
+    it "always includes non-bespoke definitions" do
+      expect(described_class.visible_for(config)).to include(described_class.find(:logging))
+    end
+  end
+
+  describe "bespoke definitions and prerequisites_met?" do
+    subject(:check) { bespoke_definition.prerequisites_met?(config) }
+
+    include_context "with a bespoke plugin definition"
+
+    let(:config) { create(:server_configuration) }
+
+    context "when ungranted" do
+      it { is_expected.to be(false) }
+    end
+
+    context "when granted" do
+      before { create(:bespoke_plugin_grant, server_configuration: config, plugin_key: bespoke_definition.key) }
+
+      it { is_expected.to be(true) }
+    end
+  end
+
   describe ".sub_plugin?" do
     it "returns true for :spam_protection" do
       expect(described_class.sub_plugin?(:spam_protection)).to be(true)

--- a/spec/operations/server_configuration/bespoke_plugin_grants/create_spec.rb
+++ b/spec/operations/server_configuration/bespoke_plugin_grants/create_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Ops::ServerConfiguration::BespokePluginGrants::Create do
+  subject(:result) { described_class.call(server_configuration:, plugin_key:) }
+
+  let(:server_configuration) { create(:server_configuration) }
+  let(:plugin_key) { "lfg" }
+
+  before do
+    allow(Bot::ConfigBus).to receive(:sync_commands)
+  end
+
+  it "creates the grant" do
+    expect(result.value).to be_a(BespokePluginGrant)
+    expect(result.value.server_configuration).to eq(server_configuration)
+    expect(result.value.plugin_key).to eq("lfg")
+  end
+
+  it "succeeds" do
+    expect(result.success?).to be(true)
+  end
+
+  it "publishes sync_commands" do
+    result
+
+    expect(Bot::ConfigBus).to have_received(:sync_commands).with(server_configuration)
+  end
+
+  context "when called again for the same server_configuration and plugin_key" do
+    before { described_class.call(server_configuration:, plugin_key:) }
+
+    it "does not create a duplicate row" do
+      expect { result }.not_to change(BespokePluginGrant, :count)
+    end
+
+    it "returns the existing grant" do
+      existing = BespokePluginGrant.find_by(server_configuration:, plugin_key:)
+
+      expect(result.value).to eq(existing)
+    end
+  end
+end

--- a/spec/operations/server_configuration/bespoke_plugin_grants/destroy_spec.rb
+++ b/spec/operations/server_configuration/bespoke_plugin_grants/destroy_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Ops::ServerConfiguration::BespokePluginGrants::Destroy do
+  subject(:result) { described_class.call(bespoke_plugin_grant:) }
+
+  let(:server_configuration) { create(:server_configuration) }
+  let(:plugin) { create(:plugin, key: "lfg", name: "Looking for Game") }
+  let(:bespoke_plugin_grant) { create(:bespoke_plugin_grant, server_configuration:, plugin_key: "lfg") }
+
+  before do
+    allow(Bot::ConfigBus).to receive(:sync_commands)
+  end
+
+  it "destroys the grant" do
+    bespoke_plugin_grant
+    expect { result }.to change(BespokePluginGrant, :count).by(-1)
+  end
+
+  it "succeeds" do
+    expect(result.success?).to be(true)
+  end
+
+  it "publishes sync_commands" do
+    result
+
+    expect(Bot::ConfigBus).to have_received(:sync_commands).with(server_configuration)
+  end
+
+  context "with a matching enabled PluginActivation on that server" do
+    let!(:activation) { create(:plugin_activation, server_configuration:, plugin:, enabled: true) }
+
+    it "flips the activation to disabled" do
+      result
+
+      expect(activation.reload.enabled).to be(false)
+    end
+  end
+
+  context "with an activation for the same plugin on a different server" do
+    let(:other_server_configuration) { create(:server_configuration) }
+    let!(:other_activation) { create(:plugin_activation, server_configuration: other_server_configuration, plugin:, enabled: true) }
+
+    it "leaves the other server's activation alone" do
+      result
+
+      expect(other_activation.reload.enabled).to be(true)
+    end
+  end
+
+  context "with an activation for a different plugin on the same server" do
+    let(:other_plugin) { create(:plugin, key: "custom_other", name: "Custom Other") }
+    let!(:other_activation) { create(:plugin_activation, server_configuration:, plugin: other_plugin, enabled: true) }
+
+    it "leaves the other plugin's activation alone" do
+      result
+
+      expect(other_activation.reload.enabled).to be(true)
+    end
+  end
+end

--- a/spec/presenters/plugin_status_spec.rb
+++ b/spec/presenters/plugin_status_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PluginStatus do
+  describe ".rows" do
+    subject(:rows) { described_class.rows(server_configuration) }
+
+    include_context "with a bespoke plugin definition"
+
+    let(:server_configuration) { create(:server_configuration) }
+
+    it "omits an ungranted bespoke plugin" do
+      expect(rows.map(&:key)).not_to include(:bespoke_thing)
+    end
+
+    context "when the bespoke plugin is granted" do
+      before { create(:bespoke_plugin_grant, server_configuration:, plugin_key: bespoke_definition.key) }
+
+      it "includes it" do
+        expect(rows.map(&:key)).to include(:bespoke_thing)
+      end
+    end
+  end
+end

--- a/spec/requests/admin/bespoke_plugin_grants_spec.rb
+++ b/spec/requests/admin/bespoke_plugin_grants_spec.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin bespoke plugin grants", type: :request do
+  include_context "discord auth"
+
+  include_context "with a bespoke plugin definition"
+
+  let(:server) { create(:server_configuration, name: "Test Guild") }
+
+  before do
+    allow(Bot::ConfigBus).to receive(:sync_commands)
+  end
+
+  context "when signed out" do
+    it "redirects to the sign-in page" do
+      get admin_bespoke_plugin_grants_path
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  context "when signed in as a non-owner" do
+    before do
+      allow(Bot::Config).to receive(:owner_id).and_return("99999")
+      post "/auth/discord/callback"
+    end
+
+    describe "GET /admin/bespoke_plugin_grants" do
+      it "redirects to the server picker with an alert" do
+        get admin_bespoke_plugin_grants_path
+        expect(response).to redirect_to(servers_path)
+        expect(flash[:alert]).to be_present
+      end
+    end
+
+    describe "POST /admin/bespoke_plugin_grants" do
+      it "redirects without granting" do
+        post admin_bespoke_plugin_grants_path, params: {plugin_key: "bespoke_thing", server_configuration_id: server.id}
+        expect(response).to redirect_to(servers_path)
+        expect(BespokePluginGrant.count).to eq(0)
+      end
+    end
+
+    describe "DELETE /admin/bespoke_plugin_grants/:id" do
+      let!(:grant) { create(:bespoke_plugin_grant, server_configuration: server, plugin_key: "bespoke_thing") }
+
+      it "redirects without revoking" do
+        delete admin_bespoke_plugin_grant_path(grant)
+        expect(response).to redirect_to(servers_path)
+        expect(BespokePluginGrant.exists?(grant.id)).to be(true)
+      end
+    end
+  end
+
+  context "when signed in as the owner" do
+    before do
+      allow(Bot::Config).to receive(:owner_id).and_return("12345")
+      post "/auth/discord/callback"
+    end
+
+    describe "GET /admin/bespoke_plugin_grants" do
+      subject(:index_page) { get admin_bespoke_plugin_grants_path }
+
+      before { server }
+
+      it "lists the bespoke plugin and offers the ungranted server" do
+        index_page
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Bespoke Thing")
+        expect(response.body).to include("Test Guild")
+        expect(response.body).to include(I18n.t("components.admin.bespoke_plugin_card.none"))
+      end
+
+      context "when the only server is already granted" do
+        let!(:grant) { create(:bespoke_plugin_grant, server_configuration: server, plugin_key: "bespoke_thing") }
+
+        it "lists the grant and says there is nothing left to grant" do
+          index_page
+          expect(response.body).to include(I18n.t("components.admin.bespoke_plugin_card.all_granted"))
+          expect(response.body).to include(I18n.t("components.admin.bespoke_plugin_grant_row.revoke"))
+        end
+      end
+
+      context "when the granted server has no name synced yet" do
+        let(:server) { create(:server_configuration, name: nil) }
+        let!(:grant) { create(:bespoke_plugin_grant, server_configuration: server, plugin_key: "bespoke_thing") }
+
+        it "falls back to the guild id" do
+          index_page
+          expect(response.body).to include(server.discord_id.to_s)
+        end
+      end
+
+      context "when no bespoke plugins exist" do
+        let(:catalog_definitions) { PluginCatalog::DEFINITIONS }
+
+        it "renders the empty state" do
+          index_page
+          expect(response.body).to include(I18n.t("views.admin.bespoke_plugin_grants.index.empty_title"))
+        end
+      end
+    end
+
+    describe "POST /admin/bespoke_plugin_grants" do
+      subject(:grant_plugin) do
+        post admin_bespoke_plugin_grants_path, params: {plugin_key:, server_configuration_id:}
+      end
+
+      let(:plugin_key) { "bespoke_thing" }
+      let(:server_configuration_id) { server.id }
+
+      it "grants the plugin to the server" do
+        grant_plugin
+        expect(response).to redirect_to(admin_bespoke_plugin_grants_path)
+        expect(BespokePluginGrant.where(server_configuration: server, plugin_key: "bespoke_thing")).to exist
+      end
+
+      context "with a plugin key that is not bespoke" do
+        let(:plugin_key) { "roles" }
+
+        it "returns not found and grants nothing" do
+          grant_plugin
+          expect(response).to have_http_status(:not_found)
+          expect(BespokePluginGrant.count).to eq(0)
+        end
+      end
+
+      context "with an unknown server" do
+        let(:server_configuration_id) { "srv_missing" }
+
+        it "returns not found" do
+          grant_plugin
+          expect(response).to have_http_status(:not_found)
+          expect(BespokePluginGrant.count).to eq(0)
+        end
+      end
+    end
+
+    describe "DELETE /admin/bespoke_plugin_grants/:id" do
+      subject(:revoke) { delete admin_bespoke_plugin_grant_path(id) }
+
+      let!(:grant) { create(:bespoke_plugin_grant, server_configuration: server, plugin_key: "bespoke_thing") }
+      let(:id) { grant.id }
+
+      it "revokes the grant" do
+        revoke
+        expect(response).to redirect_to(admin_bespoke_plugin_grants_path)
+        expect(BespokePluginGrant.exists?(grant.id)).to be(false)
+      end
+
+      context "with an unknown grant" do
+        let(:id) { "bpg_missing" }
+
+        it "returns not found" do
+          revoke
+          expect(response).to have_http_status(:not_found)
+          expect(BespokePluginGrant.exists?(grant.id)).to be(true)
+        end
+      end
+    end
+  end
+end

--- a/spec/support/bespoke_plugin_definition.rb
+++ b/spec/support/bespoke_plugin_definition.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.shared_context "with a bespoke plugin definition" do
+  let(:bespoke_definition) do
+    PluginCatalog::Definition.new(
+      key: :bespoke_thing,
+      name: "Bespoke Thing",
+      description: "Owner-granted.",
+      bespoke: true
+    )
+  end
+  let(:catalog_definitions) { PluginCatalog::DEFINITIONS + [bespoke_definition] }
+
+  before do
+    stub_const("PluginCatalog::DEFINITIONS", catalog_definitions)
+  end
+end


### PR DESCRIPTION
Chunk 2 of the Twilight Struggle work: the general grant system that gates everything user-facing in TS (the config UI and posting activation both need it). Nothing here is TS-specific — TS is just its first consumer.

A **bespoke** plugin is one you hand-activate for a specific server. It stays invisible to everyone else: hidden from the plugin list and sidebar, its guild commands aren't registered, and its config page never appears.

## How it works

- `PluginCatalog::Definition` gains `bespoke: true` (default false).
- `bespoke_plugin_grants` — guild ↔ plugin key, unique on the pair, cascaded off `ServerConfiguration` so the guild purge covers it.
- `PluginCatalog.visible_for` is the single filter the dashboard and the sidebar share (both already went through `PluginStatus.rows`).
- The grant is the **first** check in `prerequisites_met?`, so `Plugins::Toggle` and the `PluginActivation` validation both inherit it — no separate toggle guard to keep in sync.
- `GuildCommandSet#include_guild?` additionally requires a grant for bespoke keys; `enabled_keys` mechanics are otherwise unchanged. Both ops publish on the ConfigBus, so the bot re-syncs commands live.
- Revoking a grant also switches the plugin off. Commands and pages are hidden by the grant, but event-driven plugins gate on `enabled_plugin_keys`, which knows nothing about grants — leaving the activation on would keep handlers firing for a server that can no longer see the plugin.

## Admin panel

`/admin/bespoke_plugin_grants` — standard index/create/destroy, one card per bespoke plugin listing its granted servers with a picker to add more. Owner-only via a new `RequiresOwner` concern, extracted from `Admin::SettingsController` now that there are two admin pages. No bespoke plugin ships yet, so the live page is currently the empty state.

## Privacy

A grant is a guild id and a plugin key — no personal data, so the policy is untouched. The `dependent:` cascade off `ServerConfiguration` *is* the purge coverage.

## Boyscout (separate commit)

Stripped the phlex-rails generator scaffold comments from `Views::Base` / `Components::Base`, dropping the unused `cache_store` override with them. Also extracted `Components::AppShell::MenuItem` — this PR would otherwise have added the third copy-pasted dropdown link.

## Deferred

`Definition#granted?` re-queries per bespoke definition even though `visible_for` just built the granted set. Rejected for now: unlike `enabled_keys:`, the loop is bounded by the number of *granted* bespoke plugins (visible_for already dropped the rest), so it's one query, not a catalog-sized N+1. Flagged in the build plan if they ever multiply.

## Gates

rspec (2374 examples, 0 failures), standardrb, active_record_doctor, undercover vs main, i18n-tasks missing + check-normalized — all green locally. Convention-reviewer pass run; four of its five findings are applied above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)