### PR TITLE
Allow discord.com as a form-action CSP target

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -5,7 +5,7 @@ Rails.application.configure do
     policy.default_src :self
     policy.base_uri :self
     policy.font_src :self, :data
-    policy.form_action :self
+    policy.form_action :self, "https://discord.com"
     policy.img_src :self, :data, "https://cdn.discordapp.com", "https://media.discordapp.net"
     policy.object_src :none
     policy.script_src :self

--- a/spec/requests/content_security_policy_spec.rb
+++ b/spec/requests/content_security_policy_spec.rb
@@ -15,7 +15,10 @@ RSpec.describe "Content Security Policy", type: :request do
     expect(header).to include("default-src 'self'")
     expect(header).to include("object-src 'none'")
     expect(header).to include("base-uri 'self'")
-    expect(header).to include("form-action 'self'")
+  end
+
+  it "allows the sign-in form to reach Discord's OAuth redirect target" do
+    expect(header).to include("form-action 'self' https://discord.com")
   end
 
   it "allows Discord's CDN for images and inline styles for dynamic colours" do


### PR DESCRIPTION
Sign-in was dead in Safari: tapping the button did nothing at all. Surfaced as "mobile is broken, desktop is fine", but the split is really Gecko vs everyone else.

## Cause

`config/initializers/content_security_policy.rb` set `form-action 'self'`. The sign-in button is a `button_to` POSTing to `/auth/discord`; OmniAuth's request phase answers that with a 302 to `https://discord.com/api/oauth2/authorize`.

Whether `form-action` applies across a redirect chain is [still undefined in the spec](https://github.com/w3c/webappsec-csp/issues/8), and browsers diverge: Chrome and Safari enforce the directive against every hop, Firefox does not apply it to redirects at all. So the submission was blocked in Safari (and would be in any Chromium browser) while Firefox worked — which reads as "mobile-only" if desktop happens to be Firefox and mobile happens to be iOS. No error surfaces to the user; the block is console-only, hence "nothing happens".

## Fix

`policy.form_action :self, "https://discord.com"`, plus a request spec pinning it so it cannot regress.

Affects all three sign-in entry points (`Components::PublicShell`, `Views::Home`, `Views::Reauth`) — they all POST to the same path.

## Verification

Confirmable in desktop Chrome or Safari on `main` (button dead, console shows the `form-action` refusal) versus this branch. Firefox will not reproduce it.