### PR TITLE
Add a public bespoke plugins page

### DIFF
--- a/app/components/app_shell.rb
+++ b/app/components/app_shell.rb
@@ -44,6 +44,7 @@ class Components::AppShell < Components::Base
       render Components::VersionBadge.new
       server_switcher if @current_server
       div(class: "flex-1")
+      render Components::BespokePluginsLink.new
       notification_frame
       render Components::ThemeToggle.new
       user_menu

--- a/app/components/bespoke_plugins_link.rb
+++ b/app/components/bespoke_plugins_link.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Components::BespokePluginsLink < Components::Base
+  def view_template
+    a(
+      href: bespoke_plugins_path,
+      class: "hidden items-center gap-2 rounded-md px-2.5 py-2 text-sm font-medium text-text-secondary transition-colors hover:bg-surface-sunken hover:text-text-primary sm:flex"
+    ) do
+      render Components::Icon.new("puzzle-piece", class: "size-4")
+      span { t(".label") }
+    end
+  end
+end

--- a/app/components/legal_page.rb
+++ b/app/components/legal_page.rb
@@ -3,9 +3,6 @@
 class Components::LegalPage < Components::Base
   include Components::LegalProse
 
-  CONTACT_EMAIL = "info@shrkbot.com"
-  SUPPORT_URL = "https://discord.gg/3gwFMTY"
-
   def initialize(title:, updated: nil, user: nil, contact: true)
     @title = title
     @updated = updated
@@ -30,9 +27,9 @@ class Components::LegalPage < Components::Base
     h2(class: "mb-3 mt-10 font-display text-xl font-semibold") { t(".contact_h") }
     p(class: "mb-4 leading-relaxed text-text-secondary") do
       plain "#{t(".contact_operator")} - "
-      a(href: "mailto:#{CONTACT_EMAIL}", class: link_classes) { CONTACT_EMAIL }
+      a(href: "mailto:#{SupportContact::EMAIL}", class: link_classes) { SupportContact::EMAIL }
       plain " / "
-      a(href: SUPPORT_URL, class: link_classes) { t(".contact_support") }
+      a(href: SupportContact::SERVER_URL, class: link_classes) { t(".contact_support") }
     end
   end
 end

--- a/app/components/public_shell.rb
+++ b/app/components/public_shell.rb
@@ -28,6 +28,7 @@ class Components::PublicShell < Components::Base
       end
       render Components::VersionBadge.new
       div(class: "flex-1")
+      render Components::BespokePluginsLink.new
       render Components::ThemeToggle.new
       @user ? dashboard_link : sign_in_button
     end

--- a/app/controllers/bespoke_plugins_controller.rb
+++ b/app/controllers/bespoke_plugins_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class BespokePluginsController < ApplicationController
+  skip_before_action :require_login
+
+  def show
+    render Views::BespokePlugins.new(user: current_user)
+  end
+end

--- a/app/models/support_contact.rb
+++ b/app/models/support_contact.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module SupportContact
+  EMAIL = "info@shrkbot.com"
+  SERVER_URL = "https://discord.gg/3gwFMTY"
+end

--- a/app/views/bespoke_plugins.rb
+++ b/app/views/bespoke_plugins.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class Views::BespokePlugins < Views::Base
+  include Components::LegalProse
+
+  def initialize(user:)
+    @user = user
+  end
+
+  def view_template
+    render Components::LegalPage.new(title: t(".title"), user: @user) do
+      intro_section
+      example_section
+      process_section
+      cost_section
+    end
+  end
+
+  private
+
+  def intro_section
+    paragraph(t(".intro_1"))
+    paragraph(t(".intro_2"))
+  end
+
+  def example_section
+    heading(t(".example_h"))
+    paragraph(t(".example_p"))
+  end
+
+  def process_section
+    heading(t(".process_h"))
+    bullets(t(".process_ask"), t(".process_scope"), t(".process_ship"))
+  end
+
+  def cost_section
+    heading(t(".cost_h"))
+    paragraph(t(".cost_p"))
+  end
+end

--- a/app/views/bespoke_plugins.rb
+++ b/app/views/bespoke_plugins.rb
@@ -23,7 +23,11 @@ class Views::BespokePlugins < Views::Base
   def hero
     section(class: "mx-auto max-w-3xl px-6 pb-14 pt-20") do
       eyebrow(t(".eyebrow"))
-      h1(class: "mb-5 font-display text-4xl font-bold leading-tight tracking-tight") { t(".headline") }
+      h1(class: "mb-5 font-display text-4xl font-bold leading-tight tracking-tight") do
+        render Components::Wordmark.new
+        whitespace
+        plain t(".headline")
+      end
       p(class: "mb-8 text-lg leading-relaxed text-text-secondary") { t(".lede") }
       contact_actions
     end

--- a/app/views/bespoke_plugins.rb
+++ b/app/views/bespoke_plugins.rb
@@ -1,40 +1,96 @@
 # frozen_string_literal: true
 
 class Views::BespokePlugins < Views::Base
-  include Components::LegalProse
+  include Components::PluginNav
+
+  STEPS = %i[ask fit ship].freeze
 
   def initialize(user:)
     @user = user
   end
 
   def view_template
-    render Components::LegalPage.new(title: t(".title"), user: @user) do
-      intro_section
-      example_section
-      process_section
-      cost_section
+    render Components::PublicShell.new(user: @user) do
+      hero
+      steps
+      example
+      cost
     end
   end
 
   private
 
-  def intro_section
-    paragraph(t(".intro_1"))
-    paragraph(t(".intro_2"))
+  def hero
+    section(class: "mx-auto max-w-3xl px-6 pb-14 pt-20") do
+      eyebrow(t(".eyebrow"))
+      h1(class: "mb-5 font-display text-4xl font-bold leading-tight tracking-tight") { t(".headline") }
+      p(class: "mb-8 text-lg leading-relaxed text-text-secondary") { t(".lede") }
+      contact_actions
+    end
   end
 
-  def example_section
-    heading(t(".example_h"))
-    paragraph(t(".example_p"))
+  def contact_actions
+    div(class: "flex flex-wrap gap-3") do
+      render Components::Button.new(
+        href: "mailto:#{SupportContact::EMAIL}",
+        label: t(".write"),
+        icon: "envelope-simple",
+        size: :xl
+      )
+      render Components::Button.new(
+        href: SupportContact::SERVER_URL,
+        label: t(".ask_in_server"),
+        icon: "discord-logo",
+        variant: :secondary,
+        size: :xl,
+        target: "_blank",
+        rel: "noopener"
+      )
+    end
   end
 
-  def process_section
-    heading(t(".process_h"))
-    bullets(t(".process_ask"), t(".process_scope"), t(".process_ship"))
+  def steps
+    section(class: "mx-auto max-w-3xl px-6 pb-14") do
+      eyebrow(t(".steps_eyebrow"))
+      div(class: "flex flex-col gap-4 sm:flex-row") do
+        STEPS.each_with_index { |key, index| step_card(key, index) }
+      end
+    end
   end
 
-  def cost_section
-    heading(t(".cost_h"))
-    paragraph(t(".cost_p"))
+  def step_card(key, index)
+    render Components::Card.new(class: "flex-1") do
+      p(class: "mb-3 font-mono text-xs text-accent-2-text") { (index + 1).to_s.rjust(2, "0") }
+      p(class: "font-display text-sm font-semibold") { t(".steps.#{key}.title") }
+      p(class: "mt-1 text-sm leading-relaxed text-text-secondary") { t(".steps.#{key}.body") }
+    end
+  end
+
+  def example
+    section(class: "mx-auto max-w-3xl px-6 pb-14") do
+      eyebrow(t(".example_eyebrow"))
+      render Components::Card.new(padding: :lg) do
+        div(class: "flex items-start gap-4") do
+          render Components::PluginTile.new(icon: plugin_icon(:twilight_struggle))
+          div do
+            p(class: "font-display text-sm font-semibold") { t("components.plugin_row.plugin.twilight_struggle.name") }
+            p(class: "mt-1 text-sm leading-relaxed text-text-secondary") { t(".example_body") }
+          end
+        end
+      end
+    end
+  end
+
+  def cost
+    section(class: "mx-auto max-w-3xl px-6 pb-24") do
+      eyebrow(t(".cost_eyebrow"))
+      render Components::Callout.new(variant: :neutral) do
+        p(class: "leading-relaxed text-text-secondary") { t(".cost_body") }
+      end
+    end
+  end
+
+  def eyebrow(text)
+    p(class: "mb-5 text-[11px] font-semibold uppercase tracking-widest text-eyebrow") { text }
   end
 end

--- a/app/views/bespoke_plugins.rb
+++ b/app/views/bespoke_plugins.rb
@@ -3,7 +3,7 @@
 class Views::BespokePlugins < Views::Base
   include Components::PluginNav
 
-  STEPS = %i[ask fit ship].freeze
+  STEPS = %i[talk build run].freeze
 
   def initialize(user:)
     @user = user
@@ -73,7 +73,12 @@ class Views::BespokePlugins < Views::Base
         div(class: "flex items-start gap-4") do
           render Components::PluginTile.new(icon: plugin_icon(:twilight_struggle))
           div do
-            p(class: "font-display text-sm font-semibold") { t("components.plugin_row.plugin.twilight_struggle.name") }
+            a(
+              href: t(".example_url"),
+              target: "_blank",
+              rel: "noopener",
+              class: "font-display text-sm font-semibold underline decoration-border-strong underline-offset-4 transition-colors hover:decoration-accent"
+            ) { t("components.plugin_row.plugin.twilight_struggle.name") }
             p(class: "mt-1 text-sm leading-relaxed text-text-secondary") { t(".example_body") }
           end
         end

--- a/app/views/imprint.rb
+++ b/app/views/imprint.rb
@@ -36,7 +36,7 @@ class Views::Imprint < Views::Base
     heading(t(".contact_h"))
     p(class: "mb-4 leading-relaxed text-text-secondary") do
       plain t(".contact_email_pre")
-      a(href: "mailto:#{Components::LegalPage::CONTACT_EMAIL}", class: link_classes) { Components::LegalPage::CONTACT_EMAIL }
+      a(href: "mailto:#{SupportContact::EMAIL}", class: link_classes) { SupportContact::EMAIL }
     end
     p(class: "leading-relaxed text-text-secondary") { t(".contact_phone") }
     p(class: "mb-4 text-sm text-text-muted") { t(".contact_phone_note") }

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -632,28 +632,37 @@ en:
           subtitle: Global settings for shrkbot's owner.
           title: Owner settings
     bespoke_plugins:
-      cost_h: What it costs
-      cost_p: shrkbot is free and stays free. Work done for one server is where that
-        stops. If it's a real chunk of work, we agree a small fee before anything
-        gets written, so you know the number up front. Small additions usually cost
-        nothing.
-      example_h: An example
-      example_p: The Twilight Struggle plugin pulls tournament matches and results
-        from an external ladder site and posts them into the channels each participating
-        server picks. That's the size of thing we mean.
-      intro_1: Every plugin shrkbot ships is built for every server that turns it
-        on. Some things only ever make sense for one server.
-      intro_2: If your community runs on something no bot covers, we can build it
-        into shrkbot and switch it on for you alone. It stays off every other server's
-        dashboard and out of the public plugin list.
-      process_ask: Tell us what should happen. A rough idea is enough to start; we'll
-        ask the questions that pin it down.
-      process_h: How it goes
-      process_scope: We tell you honestly whether it fits. Discord's API has hard
-        limits, and some ideas belong in a bot of your own rather than in shrkbot.
-      process_ship: It gets built with tests, enabled for your server, and maintained
-        like the rest of shrkbot.
-      title: Bespoke plugins
+      ask_in_server: Ask in the support server
+      cost_body: shrkbot is free and stays free. Work done for one server is where
+        that stops. If your idea is a real chunk of work, I'll name a small fee before
+        anything gets written, so you know the number up front. Small additions usually
+        cost nothing.
+      cost_eyebrow: What it costs
+      example_body: Pulls tournament matches and results from an external ladder site
+        and posts them into the channels each participating server picks. That's the
+        size of thing I mean.
+      example_eyebrow: One that already exists
+      eyebrow: Bespoke plugins
+      headline: Some things only make sense for one server.
+      lede: Every plugin shrkbot ships is built for everyone who turns it on. If your
+        community runs on something no bot covers, I can build it into shrkbot and
+        switch it on for you alone. It stays off every other server's dashboard and
+        out of the public plugin list.
+      steps:
+        ask:
+          body: A rough idea is enough to start. I'll ask the questions that pin it
+            down.
+          title: Say what should happen
+        fit:
+          body: Discord's API has hard limits, and some ideas belong in a bot of your
+            own rather than in shrkbot.
+          title: I tell you if it fits
+        ship:
+          body: Built with tests, switched on for your server, and maintained like
+            the rest of shrkbot.
+          title: It ships and stays shipped
+      steps_eyebrow: How it goes
+      write: Write me
     home:
       add_to_server: Sign in to add shrkbot to your servers
       lede: 'shrkbot provides tools where Discord doesn''t, and gets out of your way

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -632,37 +632,39 @@ en:
           subtitle: Global settings for shrkbot's owner.
           title: Owner settings
     bespoke_plugins:
-      ask_in_server: Ask in the support server
-      cost_body: shrkbot is free and stays free. Work done for one server is where
-        that stops. If your idea is a real chunk of work, I'll name a small fee before
-        anything gets written, so you know the number up front. Small additions usually
-        cost nothing.
+      ask_in_server: Ask me on Discord
+      cost_body: I offer shrkbot for free and for everyone, but I might charge a little
+        fee for custom work that's only for you. Smaller things, and features everyone
+        would get, are usually free, and I'll do my best to keep prices affordable.
       cost_eyebrow: What it costs
-      example_body: Pulls tournament matches and results from an external ladder site
-        and posts them into the channels each participating server picks. That's the
-        size of thing I mean.
+      example_body: Game results posted on twilight-struggle.com get posted straight
+        to Discord, in whichever servers, channels, and message formats each server
+        picks.
       example_eyebrow: One that already exists
+      example_url: https://twilight-struggle.com
       eyebrow: Bespoke plugins
-      headline: Some things only make sense for one server.
-      lede: Every plugin shrkbot ships is built for everyone who turns it on. If your
-        community runs on something no bot covers, I can build it into shrkbot and
-        switch it on for you alone. It stays off every other server's dashboard and
-        out of the public plugin list.
+      headline: shrkbot can do it all, even if it's only for you
+      lede: If you're enjoying the general usefulness of shrkbot but have an idea
+        that needs custom work - or you plain don't want another bot in your ecosystem
+        - I can build a bespoke plugin just for you. No other server will ever see
+        it exists, but for you it lives right alongside the functionality you know
+        and love.
       steps:
-        ask:
-          body: A rough idea is enough to start. I'll ask the questions that pin it
-            down.
-          title: Say what should happen
-        fit:
-          body: Discord's API has hard limits, and some ideas belong in a bot of your
-            own rather than in shrkbot.
-          title: I tell you if it fits
-        ship:
-          body: Built with tests, switched on for your server, and maintained like
-            the rest of shrkbot.
-          title: It ships and stays shipped
-      steps_eyebrow: How it goes
-      write: Write me
+        build:
+          body: It gets built and tested like everything else in shrkbot, and switched
+            on for your server alone.
+          title: I build it
+        run:
+          body: Keeping your feature running is free, barring external API costs.
+            If you want more functionality down the line, we can talk about it again
+            :)
+          title: I ship and maintain it
+        talk:
+          body: Let me know what your general idea is, and we'll figure out together
+            if and how shrkbot can work for you.
+          title: Talk to me!
+      steps_eyebrow: How it works
+      write: Email me
     home:
       add_to_server: Sign in to add shrkbot to your servers
       lede: 'shrkbot provides tools where Discord doesn''t, and gets out of your way

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -40,6 +40,8 @@ en:
       plugins_on:
         one: "%{count} plugin on"
         other: "%{count} plugins on"
+    bespoke_plugins_link:
+      label: Bespoke Plugins
     channel_card:
       none: No channels have synced yet. shrkbot needs to be in the server first.
       placeholder: Choose a channel
@@ -629,6 +631,29 @@ en:
         show:
           subtitle: Global settings for shrkbot's owner.
           title: Owner settings
+    bespoke_plugins:
+      cost_h: What it costs
+      cost_p: shrkbot is free and stays free. Work done for one server is where that
+        stops. If it's a real chunk of work, we agree a small fee before anything
+        gets written, so you know the number up front. Small additions usually cost
+        nothing.
+      example_h: An example
+      example_p: The Twilight Struggle plugin pulls tournament matches and results
+        from an external ladder site and posts them into the channels each participating
+        server picks. That's the size of thing we mean.
+      intro_1: Every plugin shrkbot ships is built for every server that turns it
+        on. Some things only ever make sense for one server.
+      intro_2: If your community runs on something no bot covers, we can build it
+        into shrkbot and switch it on for you alone. It stays off every other server's
+        dashboard and out of the public plugin list.
+      process_ask: Tell us what should happen. A rough idea is enough to start; we'll
+        ask the questions that pin it down.
+      process_h: How it goes
+      process_scope: We tell you honestly whether it fits. Discord's API has hard
+        limits, and some ideas belong in a bot of your own rather than in shrkbot.
+      process_ship: It gets built with tests, enabled for your server, and maintained
+        like the rest of shrkbot.
+      title: Bespoke plugins
     home:
       add_to_server: Sign in to add shrkbot to your servers
       lede: 'shrkbot provides tools where Discord doesn''t, and gets out of your way

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -643,7 +643,7 @@ en:
       example_eyebrow: One that already exists
       example_url: https://twilight-struggle.com
       eyebrow: Bespoke plugins
-      headline: shrkbot can do it all, even if it's only for you
+      headline: can do it all, even if it's only for you
       lede: If you're enjoying the general usefulness of shrkbot but have an idea
         that needs custom work - or you plain don't want another bot in your ecosystem
         - I can build a bespoke plugin just for you. No other server will ever see

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,8 @@ Rails.application.routes.draw do
   resource :terms_of_service, only: :show, path: "terms"
   resource :imprint, only: :show
 
+  resource :bespoke_plugins, only: :show, path: "bespoke-plugins"
+
   resources :notifications, only: [:index, :show, :update]
   namespace :notifications do
     resource :read, only: :create

--- a/spec/requests/bespoke_plugins_spec.rb
+++ b/spec/requests/bespoke_plugins_spec.rb
@@ -14,8 +14,14 @@ RSpec.describe "Bespoke plugins page", type: :request do
   it "leads with the bespoke-plugin pitch" do
     bespoke_plugins
 
-    expect(response.body).to include("even if it")
+    expect(response.body).to include("can do it all, even if it")
     expect(response.body).to include("only for you")
+  end
+
+  it "sets the headline's brand mark in wordmark colours" do
+    bespoke_plugins
+
+    expect(response.body).to include('<span class="text-accent">shrk</span><span class="text-accent-2-text">bot</span> can do it all')
   end
 
   it "says custom work may carry a fee" do

--- a/spec/requests/bespoke_plugins_spec.rb
+++ b/spec/requests/bespoke_plugins_spec.rb
@@ -14,13 +14,14 @@ RSpec.describe "Bespoke plugins page", type: :request do
   it "leads with the bespoke-plugin pitch" do
     bespoke_plugins
 
-    expect(response.body).to include("Some things only make sense for one server.")
+    expect(response.body).to include("even if it")
+    expect(response.body).to include("only for you")
   end
 
-  it "names the fee up front" do
+  it "says custom work may carry a fee" do
     bespoke_plugins
 
-    expect(response.body).to include("name a small fee before anything gets written")
+    expect(response.body).to include("might charge a little fee for custom work")
   end
 
   it "offers both contact routes" do

--- a/spec/requests/bespoke_plugins_spec.rb
+++ b/spec/requests/bespoke_plugins_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Bespoke plugins page", type: :request do
+  subject(:bespoke_plugins) { get bespoke_plugins_path }
+
+  it "responds ok while signed out" do
+    bespoke_plugins
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "includes the page title" do
+    bespoke_plugins
+
+    expect(response.body).to include("Bespoke plugins")
+  end
+
+  it "names the fee up front" do
+    bespoke_plugins
+
+    expect(response.body).to include("we agree a small fee before anything gets written")
+  end
+
+  it "links the page from the public top bar" do
+    get root_path
+
+    expect(response.body).to include('href="/bespoke-plugins"')
+  end
+end

--- a/spec/requests/bespoke_plugins_spec.rb
+++ b/spec/requests/bespoke_plugins_spec.rb
@@ -11,16 +11,23 @@ RSpec.describe "Bespoke plugins page", type: :request do
     expect(response).to have_http_status(:ok)
   end
 
-  it "includes the page title" do
+  it "leads with the bespoke-plugin pitch" do
     bespoke_plugins
 
-    expect(response.body).to include("Bespoke plugins")
+    expect(response.body).to include("Some things only make sense for one server.")
   end
 
   it "names the fee up front" do
     bespoke_plugins
 
-    expect(response.body).to include("we agree a small fee before anything gets written")
+    expect(response.body).to include("name a small fee before anything gets written")
+  end
+
+  it "offers both contact routes" do
+    bespoke_plugins
+
+    expect(response.body).to include("mailto:info@shrkbot.com")
+    expect(response.body).to include("https://discord.gg/3gwFMTY")
   end
 
   it "links the page from the public top bar" do


### PR DESCRIPTION
Advertises bespoke plugin work now that the first one (Twilight Struggle) is live.

- New public page at `/bespoke-plugins`: eyebrow / headline / lede + two contact actions (mail, support server), a three-step "how it goes" sequence, the Twilight Struggle plugin as the one example, and a neutral callout on cost.
- Linked from both top bars via `Components::BespokePluginsLink` — the public shell for signed-out visitors, the app shell for dashboard users (who never see the public shell, since `/` redirects them to `/servers`). The footer was considered and rejected as too easy to miss for something being offered.
- Copy is first person: the offer comes from one person, not a team. It states plainly that shrkbot stays free and that a bespoke plugin may carry a small fee agreed up front.
- Contact details move out of `Components::LegalPage` into `SupportContact` now that a second page needs them.

Gates: rspec (2782), standardrb, active_record_doctor, undercover, i18n-tasks missing + check-normalized — all green.