### PR TITLE
Stop requiring winning_method on a reported game

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ refactors, tooling, and CI changes are omitted; see the git history for those.
 
 This project follows [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+
+### Changed
+- The Twilight Struggle results API no longer requires `winning_method` on a game. A site that does not record how a game ended can leave it out, and `{winning_method}` then renders empty, as `{turn}` already did without a `winning_turn`. Templates keep the punctuation around the token, so `in {turn} ({winning_method})` reads `in Turn 7 ()` for a game sent without one.
+
 ## [3.7.0] - 2026-07-27
 
 ### Added

--- a/config/api/twilight-struggle/v1/docs/games.md
+++ b/config/api/twilight-struggle/v1/docs/games.md
@@ -66,12 +66,17 @@ bare links so Discord builds its own embed.
 Templates are written with `{token}` placeholders. Unknown tokens are left alone,
 so a stray brace renders literally rather than breaking the message.
 
+A token whose field you did not send renders empty. It does not fail. The
+punctuation around the token stays, so the default templates, which end in
+`in {turn} ({winning_method})`, read `in  ()` for a game sent with neither
+field. Send both fields, or write a template that matches what you send.
+
 | Token | Renders |
 | --- | --- |
 | `{tournament_name}` | the tournament's name |
 | `{game_id}` | the `game_code` you sent |
-| `{turn}` | `Turn 7`, or `Final Scoring` at turn 11 |
-| `{winning_method}` | the `winning_method` you sent |
+| `{turn}` | `Turn 7`, or `Final Scoring` at turn 11; empty without a `winning_turn` |
+| `{winning_method}` | the `winning_method` you sent; empty without one |
 | `{winning_player}` / `{losing_player}` | name and flag; empty on a tie |
 | `{winning_side}` / `{losing_side}` | `USA` or `USSR`; empty on a tie |
 | `{usa_player}` / `{ussr_player}` | name and flag for that side |

--- a/config/api/twilight-struggle/v1/games.yaml
+++ b/config/api/twilight-struggle/v1/games.yaml
@@ -61,7 +61,7 @@ components:
   schemas:
     GameInput:
       type: object
-      required: [usa, ussr, winning_side, winning_method, reported_at]
+      required: [usa, ussr, winning_side, reported_at]
       properties:
         tournament_external_id:
           type: string
@@ -96,7 +96,11 @@ components:
         winning_method:
           type: string
           maxLength: 60
-          description: Free text, rendered as sent.
+          description: >-
+            Free text, rendered as sent. Omit it if you do not record one. Then
+            `{winning_method}` renders empty, as `{turn}` does without a
+            `winning_turn`. Check the punctuation around the token in your
+            templates.
           example: "defcon"
         usa:
           $ref: "#/components/schemas/PlayerInput"

--- a/spec/models/twilight_struggle/message_spec.rb
+++ b/spec/models/twilight_struggle/message_spec.rb
@@ -157,6 +157,37 @@ RSpec.describe TwilightStruggle::Message do
       end
     end
 
+    context "winning method token" do
+      let(:template) { "{winning_method}" }
+
+      context "when sent" do
+        let(:report) { TwilightStruggle::GameReport.new(usa:, ussr:, winning_side: "usa", winning_method: "Wargames") }
+
+        it "renders it as sent" do
+          expect(content).to eq("Wargames")
+        end
+      end
+
+      context "when nil" do
+        let(:report) { TwilightStruggle::GameReport.new(usa:, ussr:, winning_side: "usa", winning_method: nil) }
+
+        it "renders empty" do
+          expect(content).to eq("")
+        end
+      end
+
+      context "when nil in the default win template" do
+        let(:template) { "{tournament_name}: {game_id} - {winning_player} ({winning_side}) has defeated {losing_player} in {turn} ({winning_method})" }
+        let(:report) do
+          TwilightStruggle::GameReport.new(usa:, ussr:, winning_side: "usa", winning_turn: 7, game_code: "G372")
+        end
+
+        it "leaves the parentheses the template author wrote" do
+          expect(content).to eq("OTSL 2026 - Season 8: G372 - M B 🇵🇱 (USA) has defeated L S 🇦🇷 in Turn 7 ()")
+        end
+      end
+    end
+
     context "on a tie" do
       let(:template) { "[{winning_player}][{losing_player}][{winning_side}][{losing_side}]" }
       let(:report) { TwilightStruggle::GameReport.new(usa:, ussr:, winning_side: "tie") }

--- a/spec/requests/api/twilight_struggle/v1/games_spec.rb
+++ b/spec/requests/api/twilight_struggle/v1/games_spec.rb
@@ -164,6 +164,18 @@ RSpec.describe "Api::TwilightStruggle::V1::Games", type: :request do
       end
     end
 
+    context "without a winning_method" do
+      let(:params) do
+        {game: valid_result_attributes.except(:winning_method).merge(tournament_external_id: tournament.external_id)}
+      end
+
+      it "returns 201" do
+        put_game
+
+        expect(response).to have_http_status(:created)
+      end
+    end
+
     context "with an invalid winning_side" do
       let(:params) { {game: valid_result_attributes.merge(tournament_external_id: tournament.external_id, winning_side: "nope")} }
 


### PR DESCRIPTION
## Problem

twilight-struggle.com stores `end_mode` in a nullable column. The v1 games schema listed
`winning_method` as required. A game reported without a method could not be sent at all: the
committee middleware rejected the body with a `422` before the controller ran.

## Change

Remove `winning_method` from the `required` list in `config/api/twilight-struggle/v1/games.yaml`.

No Ruby changes. `GameReport` has defaulted `winning_method` to `nil` since it was written, and
`TemplateText.render` already calls `to_s` on each token value. `winning_turn` was already optional
and already rendered empty. This makes the two fields behave the same way.

An omitted token renders empty. The template keeps its own punctuation, so the default win template
gives:

```
OTSL 2026 - Season 8: G372 - M B 🇵🇱 (USA) has defeated L S 🇦🇷 in Turn 7 ()
```

The API docs and the field description now state this, because the caller chooses the template and
must know what an omitted field does to it.

## Tests

Four examples added:

- `winning_method` renders as sent
- `winning_method` renders empty when `nil`
- the default win template keeps its parentheses when the method is `nil`
- `PUT /games/{external_id}` without `winning_method` returns `201`

```
$ bundle exec rspec
2787 examples, 0 failures
```

## Gates

Run in the dev container from a Windows host checkout. Two gates failed for environment reasons,
not for this change. Both are recorded in `PAPERCUTS.md`.

| Gate | Result |
| --- | --- |
| `rspec` | 2787 examples, 0 failures |
| `active_record_doctor` | exit 0, after `db:migrate` fixed a stale dev database |
| `standardrb` | 176 offences, all `Layout/EndOfLine` |
| `undercover --compare origin/main` | exit 1, 5 nodes, none in this diff |

`standardrb`: the host has `core.autocrlf=true` and the repo has no `.gitattributes`, so every file
on disk is CRLF while the index stays LF. The offence count is repo-wide and predates this branch.
Committed content is unaffected:

```
$ git diff --stat origin/main HEAD
 5 files changed, 61 insertions(+), 4 deletions(-)
```

`undercover`: this branch changes YAML, Markdown and two spec files. It contains no application
Ruby, so a changed-line coverage gate has nothing to measure. The five nodes it named are in
`app/components/plugin_nav.rb`, `app/components/twilight_struggle/tournament_row.rb` and
`app/controllers/servers/plugins_controller.rb`, none of which this branch touches.
