### PR TITLE
Normalize line endings to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+* text=auto eol=lf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.woff binary
+*.woff2 binary
+*.zip binary


### PR DESCRIPTION
## Problem

The repository sets no line-ending attributes. On Windows `core.autocrlf` defaults to `true`, so a
clone converts the whole tree to CRLF. `standardrb` then reports `Layout/EndOfLine` on every file
and the gate cannot be used:

```
$ bundle exec standardrb
176 offences, all Layout/EndOfLine
```

This has cost two sessions. It is also a risk for the container: `bin/docker-entrypoint`, `bin/bot`
and `bin/jobs` must be LF to run.

## Evidence that no content changes

Every blob in the repository is already LF. With the new file in place, a full renormalize stages
nothing else:

```
$ git add .gitattributes && git add --renormalize .
$ git status --short
A  .gitattributes
```

The fix is a checkout rule, not a content change.

## Change

Add `.gitattributes`: `* text=auto eol=lf`, plus explicit `binary` for `*.png`, `*.jpg`, `*.jpeg`,
`*.gif`, `*.ico`, `*.woff`, `*.woff2` and `*.zip`. The binary list is explicit rather than left to
content detection, because 45 of those files contain `\r` bytes.

## Result

```
$ bundle exec standardrb
$ echo $?
0
```

## After you merge

Attributes apply at checkout, so files already on disk keep their CRLF. Each existing clone needs
one refresh. Commit or stash local work first, because this rewrites every tracked file:

```
git rm --cached -r -q .
git reset --hard HEAD
```

A rebase across this commit has the same effect on the files it replays: they are checked out
before `.gitattributes` exists in the tree. Run the refresh again if `standardrb` reports
`Layout/EndOfLine` after a rebase.

## Gates

| Gate | Result |
| --- | --- |
| `standardrb` | exit 0 (was 176 offences) |
| `rspec` | 2787 examples, 0 failures |
| `active_record_doctor` | exit 0 |
| `undercover --compare origin/main` | no coverage missing |
