### PR TITLE
Stop owner error DMs from storming, and size the bot's DB pool for bursts

### DIFF
--- a/app/bot/error_throttle.rb
+++ b/app/bot/error_throttle.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Bot
+  class ErrorThrottle
+    WINDOW = 5.minutes
+
+    INSTANCE_MUTEX = Mutex.new
+
+    def self.instance
+      INSTANCE_MUTEX.synchronize { @instance ||= new }
+    end
+
+    def initialize
+      @mutex = Mutex.new
+      @windows = {}
+    end
+
+    def admit(key, at: Time.current)
+      @mutex.synchronize do
+        if throttled?(key, at)
+          @windows[key][:suppressed] += 1
+          nil
+        else
+          open_window(key, at)
+        end
+      end
+    end
+
+    private
+
+    def throttled?(key, at)
+      window = @windows[key]
+      !window.nil? && window[:until] > at
+    end
+
+    def open_window(key, at)
+      suppressed = @windows.dig(key, :suppressed) || 0
+      @windows[key] = {until: at + WINDOW, suppressed: 0}
+      suppressed
+    end
+  end
+end

--- a/app/bot/owner_notifier.rb
+++ b/app/bot/owner_notifier.rb
@@ -7,7 +7,12 @@ module Bot
     module_function
 
     def report(bot:, error:, source:)
-      deliver(bot, format_message(error, source)) if BotSetting.owner_error_dms?
+      return unless BotSetting.owner_error_dms?
+
+      suppressed = ErrorThrottle.instance.admit([error.class.name, source])
+      return if suppressed.nil?
+
+      deliver(bot, format_message(error, source, suppressed))
     end
 
     def notify(bot:, message:)
@@ -23,16 +28,22 @@ module Bot
       Rails.logger.error("[OwnerNotifier] could not DM owner: #{e.class}: #{e.message}")
     end
 
-    def format_message(error, source)
+    def format_message(error, source, suppressed = 0)
       backtrace = Array(error.backtrace).first(8).join("\n")
       msg = <<~MSG
-        ⚠️ **shrkbot error** (#{source})
+        ⚠️ **shrkbot error** (#{source})#{suppressed_note(suppressed)}
         **#{error.class}**: #{error.message}
         ```
         #{backtrace}
         ```
       MSG
       Discord::Truncate.call(msg, MAX_LENGTH)
+    end
+
+    def suppressed_note(count)
+      return "" if count.zero?
+
+      " — plus #{count} more in the previous #{ErrorThrottle::WINDOW.inspect}"
     end
   end
 end

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -14,6 +14,9 @@ servers:
       - <%= ENV["DEPLOY_HOST"] %>
     cmd: bin/bot
     proxy: false
+    env:
+      clear:
+        RAILS_MAX_THREADS: "15"
   jobs:
     hosts:
       - <%= ENV["DEPLOY_HOST"] %>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,6 +19,15 @@ discordrb dispatches each handler on its own thread, so any DB work in the bot
 process must check out and return its own connection from the AR pool — see
 `Bot::WithConnection`, mixed into `Bot::BaseCommand` and `Bot::BaseEvent`.
 
+That dispatch is unbounded — discordrb spawns a bare thread per handler with no
+queue or cap — so a single gateway burst (a role reorder fans out one
+`GUILD_ROLE_UPDATE` per moved role) can put far more threads in flight than the
+web process ever sees. The bot therefore runs a larger AR pool than Puma needs:
+`RAILS_MAX_THREADS` is set per-role in `config/deploy.yml`, not globally. A pool
+too small for a burst surfaces as `ActiveRecord::ConnectionTimeoutError` storms
+rather than slow requests, because handlers hold their connection across
+Discord REST calls that block on discordrb's rate limiter.
+
 ## Primary keys
 
 Internal records use prefixed-UUID string PKs (`srv_<uuid>`, `plg_<uuid>`, …),

--- a/spec/bot/error_throttle_spec.rb
+++ b/spec/bot/error_throttle_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Bot::ErrorThrottle do
+  let(:throttle) { described_class.new }
+  let(:key) { ["ActiveRecord::ConnectionTimeoutError", "event Bot::RoleSync"] }
+  let(:now) { Time.current }
+
+  describe "#admit" do
+    subject(:admit) { throttle.admit(key, at: now) }
+
+    context "with an unseen key" do
+      it "admits the report with nothing suppressed" do
+        expect(admit).to eq(0)
+      end
+    end
+
+    context "with a second report inside the window" do
+      before { throttle.admit(key, at: now) }
+
+      it "throttles it" do
+        expect(throttle.admit(key, at: now + 1.second)).to be_nil
+      end
+    end
+
+    context "with a different key inside the window" do
+      before { throttle.admit(key, at: now) }
+
+      it "admits it, since throttling is per error class and source" do
+        expect(throttle.admit(["JSON::ParserError", "event Bot::RoleSync"], at: now)).to eq(0)
+      end
+    end
+
+    context "with a storm followed by the window elapsing" do
+      before do
+        throttle.admit(key, at: now)
+        5.times { |i| throttle.admit(key, at: now + i.seconds) }
+      end
+
+      it "admits the next report and hands back how many were suppressed" do
+        expect(throttle.admit(key, at: now + described_class::WINDOW + 1.second)).to eq(5)
+      end
+    end
+
+    context "with a quiet window after a storm" do
+      before do
+        throttle.admit(key, at: now)
+        3.times { throttle.admit(key, at: now) }
+        throttle.admit(key, at: now + described_class::WINDOW + 1.second)
+      end
+
+      it "resets the suppressed count once it has been reported" do
+        expect(throttle.admit(key, at: now + (described_class::WINDOW * 2) + 2.seconds)).to eq(0)
+      end
+    end
+  end
+
+  describe ".instance" do
+    subject(:instance) { described_class.instance }
+
+    it "is memoised so throttling state is shared process-wide" do
+      expect(instance).to be(described_class.instance)
+    end
+  end
+end

--- a/spec/bot/owner_notifier_spec.rb
+++ b/spec/bot/owner_notifier_spec.rb
@@ -6,11 +6,18 @@ RSpec.describe Bot::OwnerNotifier do
   let(:pm_channel) { double("pm_channel", send_message: nil) }
   let(:bot) { double("bot", pm_channel:) }
   let(:error) { RuntimeError.new("boom").tap { |e| e.set_backtrace(["a.rb:1", "b.rb:2"]) } }
+  let(:throttle) { Bot::ErrorThrottle.new }
+
+  before do
+    allow(Bot::ErrorThrottle).to receive(:instance).and_return(throttle)
+  end
 
   describe ".report" do
     subject(:report) { described_class.report(bot:, error:, source:) }
 
     let(:source) { "command /ping" }
+    let(:dms_enabled) { true }
+    let(:owner_id) { "4242" }
 
     before do
       allow(BotSetting).to receive(:owner_error_dms?).and_return(dms_enabled)
@@ -18,9 +25,6 @@ RSpec.describe Bot::OwnerNotifier do
     end
 
     context "when the toggle is on and an owner is configured" do
-      let(:dms_enabled) { true }
-      let(:owner_id) { "4242" }
-
       it "DMs the owner the formatted error" do
         expect(bot).to receive(:pm_channel).with(4242).and_return(pm_channel)
         expect(pm_channel).to receive(:send_message).with(a_string_including("RuntimeError", "boom", "command /ping"))
@@ -28,9 +32,35 @@ RSpec.describe Bot::OwnerNotifier do
       end
     end
 
+    context "when the same error repeats inside the throttle window" do
+      before { described_class.report(bot:, error:, source:) }
+
+      it "DMs the owner once instead of once per occurrence" do
+        expect(pm_channel).not_to receive(:send_message)
+        10.times { described_class.report(bot:, error:, source:) }
+      end
+    end
+
+    context "when the throttle admits a report after suppressing others" do
+      before { allow(throttle).to receive(:admit).and_return(3) }
+
+      it "tells the owner how many occurrences were suppressed" do
+        expect(pm_channel).to receive(:send_message).with(a_string_including("plus 3 more"))
+        report
+      end
+    end
+
+    context "when a different error hits the same source" do
+      before { described_class.report(bot:, error: RuntimeError.new("first"), source:) }
+
+      it "is not throttled, since it is a distinct failure" do
+        expect(pm_channel).to receive(:send_message).with(a_string_including("ArgumentError"))
+        described_class.report(bot:, error: ArgumentError.new("second"), source:)
+      end
+    end
+
     context "when the toggle is off" do
       let(:dms_enabled) { false }
-      let(:owner_id) { "4242" }
 
       it "does nothing" do
         expect(bot).not_to receive(:pm_channel)
@@ -39,7 +69,6 @@ RSpec.describe Bot::OwnerNotifier do
     end
 
     context "when no owner is configured" do
-      let(:dms_enabled) { true }
       let(:owner_id) { nil }
 
       it "does nothing" do
@@ -49,9 +78,6 @@ RSpec.describe Bot::OwnerNotifier do
     end
 
     context "when the DM fails" do
-      let(:dms_enabled) { true }
-      let(:owner_id) { "4242" }
-
       before do
         allow(bot).to receive(:pm_channel).and_raise(StandardError, "discord down")
       end


### PR DESCRIPTION
Fixes the `ActiveRecord::ConnectionTimeoutError` DM storms — a couple of minutes of one-DM-every-few-seconds that stop on their own.

## What was happening

discordrb's `call_event` spawns a **bare `Thread.new` per handler, per event** — no queue, no cap, no backpressure. The bot process ran the default AR pool of 5 (`RAILS_MAX_THREADS` was never set for it, in compose or in `deploy.yml`).

A role reorder in the Discord UI fires one `GUILD_ROLE_UPDATE` **per role whose position changed** — 60 roles, 60 events, 60 threads, 5 connections. Everything past the first five hits the 5s checkout timeout and reports. Because owner DMs are themselves rate-limited by Discord, a burst that happens in seconds trickles out over ~2 minutes, then stops as the queue drains. The self-healing was the tell: nothing leaking, just a thundering herd draining.

Made worse by `Bot::BaseEvent#call` wrapping the whole handler in `with_connection` — so a connection stays checked out across Discord REST calls that block on discordrb's rate-limiter mutex.

## Changes

**Pool sizing** — `RAILS_MAX_THREADS: "15"` on the `bot` role in `config/deploy.yml`. The bot's concurrency is set by inbound gateway traffic, not by a configured thread count, so it needs a bigger pool than Puma, not the same one. 15 keeps plenty of Postgres headroom (default `max_connections` is 100) while absorbing 3× the current burst ceiling.

**`Bot::ErrorThrottle`** — per-`(error class, source)` window. First occurrence DMs immediately; repeats inside 5 minutes are counted rather than sent; the next admitted report carries `— plus N more in the previous 5 minutes`, so a storm still reads as a storm instead of being silently swallowed. In-memory + mutex, mirroring `Welcomes::PendingJoins`. `OwnerNotifier.notify` (deliberate operational notices, e.g. a deleted log channel) stays unthrottled.

This also covers the unrelated one-off `JSON::ParserError` on `Welcomes::MemberJoin` — Discord's edge returned an HTML error page and discordrb `JSON.parse`d it unconditionally at `api.rb:117`, masking the real HTTP status. Nothing to fix on our side; the throttle just means a recurrence can't spam.

**`docs/architecture.md`** — records why the bot's pool is sized separately, since the failure mode (timeout storms, not slow requests) isn't obvious.

## Not in scope

`RoleSync` still runs a **full-guild** resync per role event — 60 events × 60 roles ≈ 3600 UPDATEs for one reorder. That's the actual root cause of the herd and it gets its own PR.

`docker-compose.yml` needs the same `RAILS_MAX_THREADS: 15` on the `bot` service for dev parity — the file is mounted read-only in my sandbox, so that one line is yours to apply.

## Gates

`rspec` (2792 examples, 0 failures) · `standardrb` · `active_record_doctor` · `undercover --compare origin/main` — all green. No locale changes.