### PR TITLE
Let servers skip leave messages for kicks and bans

### DIFF
--- a/.active_record_doctor.rb
+++ b/.active_record_doctor.rb
@@ -62,6 +62,7 @@ ActiveRecordDoctor.configure do
       "Reminders::Reminder.deliver_via_dm",
       "ServerConfiguration.force_dm_reminders",
       "ServerRole.managed",
-      "Moderation::Phash.global_scam"
+      "Moderation::Phash.global_scam",
+      "Welcomes::Settings.suppress_removal_messages"
     ]
 end

--- a/app/components/toggle_card.rb
+++ b/app/components/toggle_card.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Components::ToggleCard < Components::Base
-  def initialize(name:, checked:, label:, help:)
+  def initialize(name:, checked:, label:, help: nil)
     @name = name
     @checked = checked
     @label = label
@@ -12,7 +12,7 @@ class Components::ToggleCard < Components::Base
     render Components::Card.new(class: "flex items-center gap-4") do
       div(class: "flex-1") do
         p(class: "text-sm font-semibold") { @label }
-        p(class: "mt-0.5 text-sm text-text-secondary") { @help }
+        p(class: "mt-0.5 text-sm text-text-secondary") { @help } if @help
       end
       render Components::Toggle.new(name: @name, checked: @checked, label: @label)
     end

--- a/app/components/toggle_card.rb
+++ b/app/components/toggle_card.rb
@@ -9,12 +9,8 @@ class Components::ToggleCard < Components::Base
   end
 
   def view_template
-    render Components::Card.new(class: "flex items-center gap-4") do
-      div(class: "flex-1") do
-        p(class: "text-sm font-semibold") { @label }
-        p(class: "mt-0.5 text-sm text-text-secondary") { @help } if @help
-      end
-      render Components::Toggle.new(name: @name, checked: @checked, label: @label)
+    render Components::Card.new do
+      render Components::ToggleRow.new(name: @name, checked: @checked, label: @label, help: @help)
     end
   end
 end

--- a/app/components/toggle_row.rb
+++ b/app/components/toggle_row.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class Components::ToggleRow < Components::Base
+  def initialize(name:, checked:, label:, help: nil)
+    @name = name
+    @checked = checked
+    @label = label
+    @help = help
+  end
+
+  def view_template
+    div(class: "flex items-center gap-4") do
+      div(class: "flex-1") do
+        p(class: "text-sm font-semibold") { @label }
+        p(class: "mt-0.5 text-sm text-text-secondary") { @help } if @help
+      end
+      render Components::Toggle.new(name: @name, checked: @checked, label: @label)
+    end
+  end
+end

--- a/app/components/welcomes/config_form.rb
+++ b/app/components/welcomes/config_form.rb
@@ -5,7 +5,6 @@ class Components::Welcomes::ConfigForm < Components::Base
     "text-sm text-text-primary placeholder:text-text-secondary focus:border-accent focus:outline-none " \
     "focus:ring-3 focus:ring-[var(--focus-ring)]"
   PLACEHOLDERS = %w[user username displayname membercount].freeze
-  COLUMNS = "grid gap-5 sm:grid-cols-2"
 
   def initialize(server_configuration:, enable_error: nil)
     @config = server_configuration
@@ -18,7 +17,6 @@ class Components::Welcomes::ConfigForm < Components::Base
       enable_error_callout
       channel_card
       message_cards
-      toggles
       placeholder_help
       preview
     end
@@ -44,20 +42,17 @@ class Components::Welcomes::ConfigForm < Components::Base
   end
 
   def message_cards
-    div(class: COLUMNS) do
-      message_card(:join_message, @settings.join_message)
-      message_card(:leave_message, @settings.leave_message)
+    div(class: "grid gap-5 sm:grid-cols-2") do
+      message_card(:join_message, @settings.join_message) do
+        ping_toggle
+      end
+      message_card(:leave_message, @settings.leave_message) do
+        suppress_removal_toggle
+      end
     end
   end
 
-  def toggles
-    div(class: COLUMNS) do
-      ping_toggle
-      suppress_removal_toggle
-    end
-  end
-
-  def message_card(name, value)
+  def message_card(name, value, &toggle)
     render Components::Card.new do
       label(class: "block text-sm font-semibold") { t(".#{name}.label") }
       p(class: "mb-2 mt-0.5 text-sm text-text-secondary") { t(".#{name}.help") }
@@ -69,7 +64,12 @@ class Components::Welcomes::ConfigForm < Components::Base
         data: {welcome_preview_target: camel(name), action: "input->welcome-preview#render"}
       ) { value }
       info_line(name)
+      toggle_section(&toggle)
     end
+  end
+
+  def toggle_section(&toggle)
+    div(class: "mt-4 border-t border-border-subtle pt-4", &toggle)
   end
 
   def info_line(name)
@@ -84,7 +84,7 @@ class Components::Welcomes::ConfigForm < Components::Base
   end
 
   def ping_toggle
-    render Components::ToggleCard.new(
+    render Components::ToggleRow.new(
       name: "welcomes[ping_on_join]",
       checked: @settings.ping_on_join,
       label: t(".ping_on_join.label"),
@@ -93,7 +93,7 @@ class Components::Welcomes::ConfigForm < Components::Base
   end
 
   def suppress_removal_toggle
-    render Components::ToggleCard.new(
+    render Components::ToggleRow.new(
       name: "welcomes[suppress_removal_messages]",
       checked: @settings.suppress_removal_messages,
       label: t(".suppress_removal_messages.label")

--- a/app/components/welcomes/config_form.rb
+++ b/app/components/welcomes/config_form.rb
@@ -5,6 +5,7 @@ class Components::Welcomes::ConfigForm < Components::Base
     "text-sm text-text-primary placeholder:text-text-secondary focus:border-accent focus:outline-none " \
     "focus:ring-3 focus:ring-[var(--focus-ring)]"
   PLACEHOLDERS = %w[user username displayname membercount].freeze
+  COLUMNS = "grid gap-5 sm:grid-cols-2"
 
   def initialize(server_configuration:, enable_error: nil)
     @config = server_configuration
@@ -17,8 +18,7 @@ class Components::Welcomes::ConfigForm < Components::Base
       enable_error_callout
       channel_card
       message_cards
-      ping_toggle
-      suppress_removal_toggle
+      toggles
       placeholder_help
       preview
     end
@@ -44,9 +44,16 @@ class Components::Welcomes::ConfigForm < Components::Base
   end
 
   def message_cards
-    div(class: "grid gap-5 sm:grid-cols-2") do
+    div(class: COLUMNS) do
       message_card(:join_message, @settings.join_message)
       message_card(:leave_message, @settings.leave_message)
+    end
+  end
+
+  def toggles
+    div(class: COLUMNS) do
+      ping_toggle
+      suppress_removal_toggle
     end
   end
 
@@ -89,8 +96,7 @@ class Components::Welcomes::ConfigForm < Components::Base
     render Components::ToggleCard.new(
       name: "welcomes[suppress_removal_messages]",
       checked: @settings.suppress_removal_messages,
-      label: t(".suppress_removal_messages.label"),
-      help: t(".suppress_removal_messages.help")
+      label: t(".suppress_removal_messages.label")
     )
   end
 

--- a/app/components/welcomes/config_form.rb
+++ b/app/components/welcomes/config_form.rb
@@ -18,6 +18,7 @@ class Components::Welcomes::ConfigForm < Components::Base
       channel_card
       message_cards
       ping_toggle
+      suppress_removal_toggle
       placeholder_help
       preview
     end
@@ -81,6 +82,15 @@ class Components::Welcomes::ConfigForm < Components::Base
       checked: @settings.ping_on_join,
       label: t(".ping_on_join.label"),
       help: t(".ping_on_join.help")
+    )
+  end
+
+  def suppress_removal_toggle
+    render Components::ToggleCard.new(
+      name: "welcomes[suppress_removal_messages]",
+      checked: @settings.suppress_removal_messages,
+      label: t(".suppress_removal_messages.label"),
+      help: t(".suppress_removal_messages.help")
     )
   end
 

--- a/app/controllers/servers/welcomes_controller.rb
+++ b/app/controllers/servers/welcomes_controller.rb
@@ -22,6 +22,7 @@ class Servers::WelcomesController < ApplicationController
       join_message: welcomes_params[:join_message],
       leave_message: welcomes_params[:leave_message],
       ping_on_join: welcomes_params.fetch(:ping_on_join, "1"),
+      suppress_removal_messages: welcomes_params.fetch(:suppress_removal_messages, "0"),
       enabled: welcomes_params[:enabled]
     )
     respond_with_configuration(result)
@@ -30,6 +31,6 @@ class Servers::WelcomesController < ApplicationController
   private
 
   def welcomes_params
-    params.expect(welcomes: [:channel_id, :join_message, :leave_message, :ping_on_join, :enabled])
+    params.expect(welcomes: [:channel_id, :join_message, :leave_message, :ping_on_join, :suppress_removal_messages, :enabled])
   end
 end

--- a/app/operations/welcomes/configure.rb
+++ b/app/operations/welcomes/configure.rb
@@ -5,11 +5,23 @@ module Ops
     class Configure < ApplicationOperation
       include Ops::PluginConfiguration
 
-      receives :server_configuration, :channel_id, :join_message, :leave_message, :ping_on_join, :enabled
+      receives :server_configuration,
+        :channel_id,
+        :join_message,
+        :leave_message,
+        :ping_on_join,
+        :suppress_removal_messages,
+        :enabled
 
       def call
         settings = server_configuration.welcome_settings
-        settings.assign_attributes(channel_id:, join_message:, leave_message:, ping_on_join:)
+        settings.assign_attributes(
+          channel_id:,
+          join_message:,
+          leave_message:,
+          ping_on_join:,
+          suppress_removal_messages:
+        )
         activation = staged_activation
 
         return failure(messages(settings, activation), value: activation) unless settings.valid? && activation.valid?

--- a/app/plugins/welcomes/events/member_banned.rb
+++ b/app/plugins/welcomes/events/member_banned.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Welcomes
+  class MemberBanned < RemovalRecord
+    on :audit_log_entry, action: :member_ban_add
+  end
+end

--- a/app/plugins/welcomes/events/member_kicked.rb
+++ b/app/plugins/welcomes/events/member_kicked.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Welcomes
+  class MemberKicked < RemovalRecord
+    on :audit_log_entry, action: :member_kick
+  end
+end

--- a/app/plugins/welcomes/events/member_leave.rb
+++ b/app/plugins/welcomes/events/member_leave.rb
@@ -11,10 +11,23 @@ module Welcomes
       return unless setting&.channel_id.present?
       return if setting.leave_message.blank?
 
-      event.bot.send_message(setting.channel_id, content(setting.leave_message), false, nil, nil, {parse: []})
+      message = content(setting.leave_message)
+      return post(setting.channel_id, message) unless setting.suppress_removal_messages
+
+      GracePeriod.after do
+        post(setting.channel_id, message) unless removed_by_staff?
+      end
     end
 
     private
+
+    def post(channel_id, message)
+      event.bot.send_message(channel_id, message, false, nil, nil, {parse: []})
+    end
+
+    def removed_by_staff?
+      PendingRemovals.instance.forget(guild_id: event.server.id, user_id: event.user.id)
+    end
 
     def content(template)
       Message.render(

--- a/app/plugins/welcomes/events/removal_record.rb
+++ b/app/plugins/welcomes/events/removal_record.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Welcomes
+  class RemovalRecord < Bot::BaseEvent
+    def handle
+      target = event.entry.target
+      return unless target
+
+      PendingRemovals.instance.remember(guild_id: event.server.id, user_id: target.id)
+    end
+  end
+end

--- a/app/plugins/welcomes/expiring_member_set.rb
+++ b/app/plugins/welcomes/expiring_member_set.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Welcomes
+  class ExpiringMemberSet
+    INSTANCE_MUTEX = Mutex.new
+
+    class << self
+      def retention(value = nil)
+        @retention = value if value
+        @retention
+      end
+
+      def instance
+        INSTANCE_MUTEX.synchronize { @instance ||= new }
+      end
+    end
+
+    def initialize
+      @mutex = Mutex.new
+      @expiries = {}
+    end
+
+    def remember(guild_id:, user_id:, at: Time.current)
+      @mutex.synchronize do
+        sweep(at)
+        @expiries[key(guild_id, user_id)] = at + self.class.retention
+      end
+      nil
+    end
+
+    def forget(guild_id:, user_id:, at: Time.current)
+      @mutex.synchronize do
+        sweep(at)
+        !@expiries.delete(key(guild_id, user_id)).nil?
+      end
+    end
+
+    private
+
+    def key(guild_id, user_id)
+      [guild_id, user_id]
+    end
+
+    def sweep(at)
+      @expiries.delete_if { |_key, expiry| expiry <= at }
+    end
+  end
+end

--- a/app/plugins/welcomes/grace_period.rb
+++ b/app/plugins/welcomes/grace_period.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Welcomes
+  class GracePeriod
+    DURATION = 3
+
+    def self.after(&block)
+      Thread.new do
+        sleep(DURATION)
+        block.call
+      rescue => e
+        Rails.logger.error("[#{name}] #{e.class}: #{e.message}")
+      end
+    end
+  end
+end

--- a/app/plugins/welcomes/pending_joins.rb
+++ b/app/plugins/welcomes/pending_joins.rb
@@ -1,43 +1,7 @@
 # frozen_string_literal: true
 
 module Welcomes
-  class PendingJoins
-    RETENTION = 24.hours
-
-    INSTANCE_MUTEX = Mutex.new
-
-    def self.instance
-      INSTANCE_MUTEX.synchronize { @instance ||= new }
-    end
-
-    def initialize
-      @mutex = Mutex.new
-      @expiries = {}
-    end
-
-    def remember(guild_id:, user_id:, at: Time.current)
-      @mutex.synchronize do
-        sweep(at)
-        @expiries[key(guild_id, user_id)] = at + RETENTION
-      end
-      nil
-    end
-
-    def forget(guild_id:, user_id:, at: Time.current)
-      @mutex.synchronize do
-        sweep(at)
-        !@expiries.delete(key(guild_id, user_id)).nil?
-      end
-    end
-
-    private
-
-    def key(guild_id, user_id)
-      [guild_id, user_id]
-    end
-
-    def sweep(at)
-      @expiries.delete_if { |_key, expiry| expiry <= at }
-    end
+  class PendingJoins < ExpiringMemberSet
+    retention 24.hours
   end
 end

--- a/app/plugins/welcomes/pending_removals.rb
+++ b/app/plugins/welcomes/pending_removals.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Welcomes
+  class PendingRemovals < ExpiringMemberSet
+    retention 30.seconds
+  end
+end

--- a/config/locales/legal.en.yml
+++ b/config/locales/legal.en.yml
@@ -97,7 +97,11 @@ en:
         screening, a short-lived in-memory note that a member has joined but not yet
         finished onboarding - the server ID and their Discord ID, nothing else. It
         exists so the welcome can wait until they finish, which is what makes the
-        greeting name them correctly. It is never written to disk.'
+        greeting name them correctly. It is never written to disk. When a member is
+        kicked or banned, we also make a short-lived in-memory note of the server
+        ID and their Discord ID, so that a server which has turned off leave messages
+        for removals can tell a kick from a voluntary leave. This is never written
+        to disk either.'
       deletion_account: Delete your dashboard account and your reminders with the
         "Delete my account" button on your account page.
       deletion_contact: Or contact us (see below) and we'll take care of it.
@@ -188,7 +192,9 @@ en:
         tournament - and are deleted with the tournament.'
       retention_welcomes: 'Pending-join notes: discarded the moment the welcome is
         sent or the member leaves, after 24 hours either way, and on every restart.
-        They live in memory only and are never written down.'
+        They live in memory only and are never written down. Kick and ban notes are
+        discarded as soon as the leave message is decided, after 30 seconds either
+        way, and on every restart.'
       rights_h: Your rights
       rights_p: Under the GDPR you have the right to access, correct, delete, restrict
         or object to our use of your personal data, and the right to data portability.
@@ -206,7 +212,7 @@ en:
         and our hosting provider Hetzner (Helsinki, Finland, within the EEA), where
         the Service and its database run. We may disclose data where required by law.'
       title: Privacy policy
-      updated: 'Last updated: July 27th, 2026'
+      updated: 'Last updated: August 4th, 2026'
     terms_of_service:
       admin_h: Your responsibilities as a server admin
       admin_p: If you add shrkbot to a server or configure it, you're responsible

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -558,6 +558,10 @@ en:
           empty: This message is off.
           label: Live preview
           timestamp: Today
+        suppress_removal_messages:
+          help: Members who were kicked or banned get no leave message. Delays every
+            leave message by a few seconds while shrkbot works out which it was.
+          label: Skip leave messages for kicks and bans
   meta:
     default_description: A mechanical assistant for your Discord server. With teeth
       when needed.

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -543,8 +543,7 @@ en:
           placeholder: "{user} has left the server."
         ping_on_join:
           help: Off delivers silently - the mention badge still shows, but no sound
-            or push. The mention itself stays real, because stripping it risks rendering
-            as "@unknown-user".
+            or push.
           label: Ping on join
         placeholders:
           displayname: Expands to the member's nickname on this server, or their display
@@ -559,8 +558,6 @@ en:
           label: Live preview
           timestamp: Today
         suppress_removal_messages:
-          help: Members who were kicked or banned get no leave message. Delays every
-            leave message by a few seconds while shrkbot works out which it was.
           label: Skip leave messages for kicks and bans
   meta:
     default_description: A mechanical assistant for your Discord server. With teeth

--- a/db/migrate/20260804225206_add_suppress_removal_messages_to_welcome_settings.rb
+++ b/db/migrate/20260804225206_add_suppress_removal_messages_to_welcome_settings.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSuppressRemovalMessagesToWelcomeSettings < ActiveRecord::Migration[8.1]
+  def change
+    add_column :welcome_settings, :suppress_removal_messages, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_27_144813) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_04_225206) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -500,6 +500,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_27_144813) do
     t.text "leave_message"
     t.boolean "ping_on_join", default: true, null: false
     t.string "server_configuration_id", null: false
+    t.boolean "suppress_removal_messages", default: false, null: false
     t.datetime "updated_at", null: false
     t.index ["server_configuration_id"], name: "index_welcome_settings_on_server_configuration_id", unique: true
   end

--- a/docs/running/deployment.md
+++ b/docs/running/deployment.md
@@ -38,10 +38,12 @@ a permission and you lose the feature that needs it, and shrkbot does not work
 around that.
 
 - **View Audit Log** — required for moderation action logging (timeout, kick,
-  ban). shrkbot receives these actions as audit-log entries pushed over the
+  ban) and for the Welcomes toggle that skips leave messages for kicks and bans.
+  shrkbot receives these actions as audit-log entries pushed over the
   gateway, and Discord only sends those to bots that hold this permission.
   Without it, moderation logging goes silent rather than degrading to an
-  entry with an unknown moderator.
+  entry with an unknown moderator, and every removal is announced as if it
+  were voluntary.
 - **Mention @everyone, @here and All Roles** — staff-role pings on flag/notify posts
 - **Manage Messages** — spam purge and scam image removal
 - **Moderate Members** — the timeout punishment

--- a/spec/components/toggle_row_spec.rb
+++ b/spec/components/toggle_row_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::ToggleRow do
+  subject(:html) do
+    described_class.new(name: "welcomes[ping_on_join]", checked: true, label: "Ping on join", help:).call
+  end
+
+  let(:help) { "Ping new members." }
+
+  it "renders a checked toggle wired to the given field name" do
+    expect(html).to include('name="welcomes[ping_on_join]"')
+    expect(html).to include('type="checkbox"').and include("checked")
+  end
+
+  it "renders the label and the help text" do
+    expect(html).to include("Ping on join").and include("Ping new members.")
+  end
+
+  context "without help text" do
+    let(:help) { nil }
+
+    it "renders the label without an empty help paragraph" do
+      expect(html).to include("Ping on join")
+      expect(html).not_to include("text-text-secondary")
+    end
+  end
+end

--- a/spec/components/welcomes/config_form_spec.rb
+++ b/spec/components/welcomes/config_form_spec.rb
@@ -25,4 +25,8 @@ RSpec.describe Components::Welcomes::ConfigForm do
   it "renders the ping-on-join toggle" do
     expect(html).to include('name="welcomes[ping_on_join]"')
   end
+
+  it "renders the suppress-removal-messages toggle" do
+    expect(html).to include('name="welcomes[suppress_removal_messages]"')
+  end
 end

--- a/spec/components/welcomes/config_form_spec.rb
+++ b/spec/components/welcomes/config_form_spec.rb
@@ -22,11 +22,18 @@ RSpec.describe Components::Welcomes::ConfigForm do
     expect(html).to include("No channels have synced yet")
   end
 
-  it "renders the ping-on-join toggle" do
-    expect(html).to include('name="welcomes[ping_on_join]"')
+  it "nests the ping-on-join toggle in the join message card" do
+    expect(card_containing("welcomes[join_message]")).to include('name="welcomes[ping_on_join]"')
   end
 
-  it "renders the suppress-removal-messages toggle" do
-    expect(html).to include('name="welcomes[suppress_removal_messages]"')
+  it "nests the suppress-removal-messages toggle in the leave message card" do
+    expect(card_containing("welcomes[leave_message]")).to include('name="welcomes[suppress_removal_messages]"')
+  end
+
+  def card_containing(field)
+    Nokogiri::HTML.fragment(html)
+      .css("div.rounded-card")
+      .find { |card| card.css("[name]").any? { |node| node["name"] == field } }
+      .to_html
   end
 end

--- a/spec/operations/welcomes/configure_spec.rb
+++ b/spec/operations/welcomes/configure_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Ops::Welcomes::Configure do
       join_message: "hi {user}",
       leave_message: "bye",
       ping_on_join: false,
+      suppress_removal_messages: true,
       enabled:
     )
   end
@@ -27,6 +28,7 @@ RSpec.describe Ops::Welcomes::Configure do
       expect(config.welcome_settings.join_message).to eq("hi {user}")
       expect(config.plugin_activations.find_by(plugin:).enabled).to be(true)
       expect(config.welcome_settings.ping_on_join).to be(false)
+      expect(config.welcome_settings.suppress_removal_messages).to be(true)
     end
   end
 

--- a/spec/plugins/welcomes/events/member_banned_spec.rb
+++ b/spec/plugins/welcomes/events/member_banned_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Welcomes::MemberBanned do
+  subject(:handle) { described_class.new(event).handle }
+
+  include_context "audit log entry event"
+
+  let(:ledger) { Welcomes::PendingRemovals.new }
+
+  before do
+    allow(Welcomes::PendingRemovals).to receive(:instance).and_return(ledger)
+  end
+
+  it "registers on the ban audit action" do
+    expect(described_class.discord_events).to eq([:audit_log_entry])
+    expect(described_class.event_attributes).to eq(action: :member_ban_add)
+  end
+
+  it "records the target in the ledger" do
+    handle
+
+    expect(ledger.forget(guild_id:, user_id: target.id)).to be(true)
+  end
+
+  context "when the entry has no target" do
+    let(:target) { nil }
+
+    it "records nothing" do
+      handle
+
+      expect(ledger.forget(guild_id:, user_id: 222)).to be(false)
+    end
+  end
+end

--- a/spec/plugins/welcomes/events/member_kicked_spec.rb
+++ b/spec/plugins/welcomes/events/member_kicked_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Welcomes::MemberKicked do
+  subject(:handle) { described_class.new(event).handle }
+
+  include_context "audit log entry event"
+
+  let(:ledger) { Welcomes::PendingRemovals.new }
+
+  before do
+    allow(Welcomes::PendingRemovals).to receive(:instance).and_return(ledger)
+  end
+
+  it "registers on the kick audit action" do
+    expect(described_class.discord_events).to eq([:audit_log_entry])
+    expect(described_class.event_attributes).to eq(action: :member_kick)
+  end
+
+  it "records the target in the ledger" do
+    handle
+
+    expect(ledger.forget(guild_id:, user_id: target.id)).to be(true)
+  end
+
+  context "when the entry has no target" do
+    let(:target) { nil }
+
+    it "records nothing" do
+      handle
+
+      expect(ledger.forget(guild_id:, user_id: 222)).to be(false)
+    end
+  end
+end

--- a/spec/plugins/welcomes/events/member_leave_spec.rb
+++ b/spec/plugins/welcomes/events/member_leave_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Welcomes::MemberLeave do
   end
 
   context "with an active setting and a leave message" do
-    let(:setting) { double("settings", channel_id: 555, leave_message: "{user} left. {membercount} remain.") }
+    let(:setting) { double("settings", channel_id: 555, leave_message: "{user} left. {membercount} remain.", suppress_removal_messages: false) }
 
     it "posts the rendered message with the @handle and suppresses all mentions" do
       expect(bot).to receive(:send_message).with(555, "@ghost left. 9 remain.", false, nil, nil, {parse: []})
@@ -26,7 +26,7 @@ RSpec.describe Welcomes::MemberLeave do
   end
 
   context "with the name placeholders in the leave message" do
-    let(:setting) { double("settings", channel_id: 555, leave_message: "{displayname} ({username}) left.") }
+    let(:setting) { double("settings", channel_id: 555, leave_message: "{displayname} ({username}) left.", suppress_removal_messages: false) }
 
     it "renders the display name and username" do
       expect(bot).to receive(:send_message).with(555, "Ghost (ghost) left.", false, nil, nil, {parse: []})
@@ -35,10 +35,46 @@ RSpec.describe Welcomes::MemberLeave do
   end
 
   context "when the leave message is blank" do
-    let(:setting) { double("settings", channel_id: 555, leave_message: "") }
+    let(:setting) { double("settings", channel_id: 555, leave_message: "", suppress_removal_messages: false) }
 
     it "does nothing" do
       expect(bot).not_to receive(:send_message)
+      handle
+    end
+  end
+
+  context "when suppress_removal_messages is enabled" do
+    let(:setting) { double("settings", channel_id: 555, leave_message: "{user} left. {membercount} remain.", suppress_removal_messages: true) }
+    let(:pending_removals) { Welcomes::PendingRemovals.new }
+
+    before do
+      allow(Welcomes::PendingRemovals).to receive(:instance).and_return(pending_removals)
+      allow(Welcomes::GracePeriod).to receive(:after) { |&block| block.call }
+    end
+
+    context "when the removal was a kick or ban" do
+      before { pending_removals.remember(guild_id: 123, user_id: 7) }
+
+      it "sends no leave message" do
+        expect(bot).not_to receive(:send_message)
+        handle
+      end
+    end
+
+    context "when the member left voluntarily" do
+      it "still posts the leave message" do
+        expect(bot).to receive(:send_message).with(555, "@ghost left. 9 remain.", false, nil, nil, {parse: []})
+        handle
+      end
+    end
+  end
+
+  context "when suppress_removal_messages is disabled" do
+    let(:setting) { double("settings", channel_id: 555, leave_message: "{user} left. {membercount} remain.", suppress_removal_messages: false) }
+
+    it "posts immediately without going through the grace period" do
+      expect(Welcomes::GracePeriod).not_to receive(:after)
+      expect(bot).to receive(:send_message).with(555, "@ghost left. 9 remain.", false, nil, nil, {parse: []})
       handle
     end
   end

--- a/spec/plugins/welcomes/grace_period_spec.rb
+++ b/spec/plugins/welcomes/grace_period_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Welcomes::GracePeriod do
+  subject(:after) { described_class.after(&block) }
+
+  before { allow(described_class).to receive(:sleep) }
+
+  context "with a block that succeeds" do
+    let(:ran) { [] }
+    let(:block) { -> { ran << true } }
+
+    it "runs the block" do
+      after.join
+
+      expect(ran).to eq([true])
+    end
+  end
+
+  context "with a block that raises" do
+    let(:block) { -> { raise "boom" } }
+
+    before { allow(Rails.logger).to receive(:error) }
+
+    it "logs the error instead of raising out" do
+      after.join
+
+      expect(Rails.logger).to have_received(:error).with(/GracePeriod.*boom/)
+    end
+  end
+end

--- a/spec/plugins/welcomes/pending_joins_spec.rb
+++ b/spec/plugins/welcomes/pending_joins_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Welcomes::PendingJoins do
     end
 
     context "just before the retention window closes" do
-      let(:at) { now + described_class::RETENTION - 1.second }
+      let(:at) { now + described_class.retention - 1.second }
 
       it "still reports the pending join" do
         expect(forget).to be(true)
@@ -38,7 +38,7 @@ RSpec.describe Welcomes::PendingJoins do
     end
 
     context "once the retention window has closed" do
-      let(:at) { now + described_class::RETENTION }
+      let(:at) { now + described_class.retention }
 
       it "has dropped the join" do
         expect(forget).to be(false)

--- a/spec/plugins/welcomes/pending_removals_spec.rb
+++ b/spec/plugins/welcomes/pending_removals_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Welcomes::PendingRemovals do
+  subject(:forget) { store.forget(guild_id: 1, user_id: 7, at:) }
+
+  let(:store) { described_class.new }
+  let(:now) { Time.utc(2026, 7, 23, 12, 0, 0) }
+  let(:at) { now }
+
+  it "retains for 30 seconds" do
+    expect(described_class.retention).to eq(30.seconds)
+  end
+
+  context "when a removal is pending" do
+    before { store.remember(guild_id: 1, user_id: 7, at: now) }
+
+    it "reports the pending removal" do
+      expect(forget).to be(true)
+    end
+
+    it "reports it only once" do
+      forget
+
+      expect(store.forget(guild_id: 1, user_id: 7, at:)).to be(false)
+    end
+
+    context "once the retention window has closed" do
+      let(:at) { now + described_class.retention }
+
+      it "has dropped the removal" do
+        expect(forget).to be(false)
+      end
+    end
+  end
+
+  context "when no removal is pending" do
+    it "reports nothing to do" do
+      expect(forget).to be(false)
+    end
+  end
+end

--- a/spec/requests/welcomes_config_spec.rb
+++ b/spec/requests/welcomes_config_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe "Welcomes config", type: :request do
 
         it "saves the settings and enables the plugin in one request" do
           patch server_welcomes_path(guild.id),
-            params: {welcomes: {channel_id: 111, join_message: "hi {user}", leave_message: "", ping_on_join: "0", enabled: "1"}},
+            params: {welcomes: {channel_id: 111, join_message: "hi {user}", leave_message: "", ping_on_join: "0", suppress_removal_messages: "1", enabled: "1"}},
             **turbo
           expect(response.media_type).to eq("text/vnd.turbo-stream.html")
           expect(config.welcome_settings.reload.channel_id).to eq(111)
@@ -100,6 +100,7 @@ RSpec.describe "Welcomes config", type: :request do
           expect(response.body).to include("saved")
           expect(response.body).to include('target="plugin-sidebar"')
           expect(config.welcome_settings.reload.ping_on_join).to be(false)
+          expect(config.welcome_settings.reload.suppress_removal_messages).to be(true)
         end
 
         it "re-renders the form with an inline error when enabling without a channel" do


### PR DESCRIPTION
Answers a standing want: a server that announces "{user} has left" for someone staff just removed reads as the bot siding with them. This adds an opt-in Welcomes toggle that announces only voluntary departures.

Checked first that this didn't already exist — it didn't. `Welcomes::MemberLeave` fired on every removal with no reason awareness; only the moderation plugin knew about kicks and bans.

## How it tells them apart

`GUILD_MEMBER_REMOVE` carries no reason. Only the audit-log entry says a removal was a kick or a ban, and the two gateway events have **no ordering guarantee**. So:

- `Welcomes::MemberKicked` / `MemberBanned` (audit-log entry events) record `(guild_id, user_id)` into `Welcomes::PendingRemovals`, a 30-second in-memory ledger
- `Welcomes::MemberLeave` reads its settings, renders the message, then waits ~3s and consumes from the ledger — a hit suppresses the post

Polling the audit-log REST endpoint on leave is deliberately not an option: 6e064c0 removed exactly that, because Discord writes the entry asynchronously and the poll routinely ran before it existed.

The wait runs on its own thread via `Welcomes::GracePeriod`, **not** inline in `handle`. `Bot::BaseEvent#call` wraps the handler in `connection_pool.with_connection`, and the pool is `RAILS_MAX_THREADS` (default 5) — sleeping inline would exhaust it and stall the bot on exactly the mass-kick case this toggle is for. Everything the deferred block needs (channel ID, rendered string) is captured before it's built; the block touches no DB.

`Welcomes::RemovalRecord` deliberately does no DB read — it doesn't check whether the plugin or the toggle is on. A 30-second in-memory note is cheaper than a query on every kick and ban across every guild, and the toggle is read on the leave side anyway.

## Permissions

Needs **View Audit Log**, same as moderation logging. That's covered where it already belongs — the *Invite permissions* section in `docs/running/deployment.md`, which states the policy: the default invite grants Administrator, and a server that deliberately narrows the grant loses the feature and shrkbot doesn't work around it. The bullet there now names this toggle alongside moderation logging. The website copy doesn't re-explain it.

**Prunes aren't covered.** Discord's prune audit entry is a bulk count with no per-user target, so there's nothing to key on.

## Default

Off. Existing servers keep announcing every departure until an admin opts in — no silent behaviour change, and no surprise delay appearing on servers nobody touched. The setting's help text does mention the few-second delay, since that's a real user-visible effect of switching it on.

## Boyscouting

`PendingJoins` and the new `PendingRemovals` are the same TTL-swept set at different retentions, so both now sit on an extracted `Welcomes::ExpiringMemberSet` (rule of two). `PendingJoins`' public behaviour is unchanged.

## Privacy

`legal.en.yml` covers the new in-memory kick/ban note (what, why, 30s retention) and the privacy policy's "Last updated" date is bumped in the same commit. Nothing is persisted beyond the settings column, which rides the existing `dependent: :delete` cascade.

## Note on the tooling config

`active_record_doctor`'s `missing_presence_validation` flagged the new boolean despite `ignore_columns_with_default`. Its check is `column.default || column.default_function`, so a boolean defaulting to `false` is falsy and never gets ignored. Fixed at the config level (`ignore_attributes`, alongside the other boolean columns already listed), not with a bogus presence validation.

## Gates

`rspec` (2848 examples, 0 failures), `standardrb`, `active_record_doctor`, `undercover --compare origin/main`, `i18n-tasks missing` + `check-normalized` — all green locally.