### PR TITLE
Accept optional player ratings on reported games

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ This project follows [Semantic Versioning](https://semver.org).
 - The Twilight Struggle template tokens are grouped by what each one describes: the game, the USA player, the USSR player, the winner and the loser. Click a token to copy it.
 - The Twilight Struggle results API no longer requires `winning_method` on a game. A site that does not record how a game ended can leave it out, and `{winning_method}` then renders empty, as `{turn}` already did without a `winning_turn`. Templates keep the punctuation around the token, so `in {turn} ({winning_method})` reads `in Turn 7 ()` for a game sent without one.
 
+### Fixed
+- A tooltip no longer stays on screen after you click what it belongs to. Clicking a template token, a welcome placeholder or a reset button left its tooltip up until you clicked elsewhere, where it could sit on top of the next tooltip you hovered.
+
 ## [3.7.0] - 2026-07-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project follows [Semantic Versioning](https://semver.org).
 - The Twilight Struggle results API takes an optional rating before and after the game for each player. Twelve new template tokens render them: `{usa_rating_before}`, `{usa_rating_after}` and `{usa_rating_change}`, plus the same three for `ussr`, `winning` and `losing`. The change token is the difference between the two ratings, always signed, such as `+12`. A rating we did not receive renders empty, as `{winning_method}` does. No shipped template uses the new tokens, so put them in your own template to see them. shrkbot never stores a rating, exactly as it never stores a player's name or flag.
 
 ### Changed
+- The Twilight Struggle template tokens are grouped by what each one describes: the game, the USA player, the USSR player, the winner and the loser. Click a token to copy it.
 - The Twilight Struggle results API no longer requires `winning_method` on a game. A site that does not record how a game ended can leave it out, and `{winning_method}` then renders empty, as `{turn}` already did without a `winning_turn`. Templates keep the punctuation around the token, so `in {turn} ({winning_method})` reads `in Turn 7 ()` for a game sent without one.
 
 ## [3.7.0] - 2026-07-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project follows [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Added
+- The Twilight Struggle results API takes an optional rating before and after the game for each player. Twelve new template tokens render them: `{usa_rating_before}`, `{usa_rating_after}` and `{usa_rating_change}`, plus the same three for `ussr`, `winning` and `losing`. The change token is the difference between the two ratings, always signed, such as `+12`. A rating we did not receive renders empty, as `{winning_method}` does. No shipped template uses the new tokens, so put them in your own template to see them. shrkbot never stores a rating, exactly as it never stores a player's name or flag.
+
 ### Changed
 - The Twilight Struggle results API no longer requires `winning_method` on a game. A site that does not record how a game ended can leave it out, and `{winning_method}` then renders empty, as `{turn}` already did without a `winning_turn`. Templates keep the punctuation around the token, so `in {turn} ({winning_method})` reads `in Turn 7 ()` for a game sent without one.
 

--- a/app/components/tooltip.rb
+++ b/app/components/tooltip.rb
@@ -14,7 +14,8 @@ class Components::Tooltip < Components::Base
   BUBBLE = "pointer-events-none absolute z-20 w-max rounded-md " \
     "border border-border-default bg-surface-card px-3 py-2 text-xs font-medium leading-snug text-text-secondary shadow-lg " \
     "invisible opacity-0 transition-opacity motion-safe:duration-[120ms] " \
-    "group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100"
+    "group-hover:visible group-hover:opacity-100 " \
+    "group-has-[:focus-visible]:visible group-has-[:focus-visible]:opacity-100"
 
   def initialize(text:, placement: :up, align: :right, width: "max-w-64")
     @text = text

--- a/app/components/twilight_struggle/token_help_card.rb
+++ b/app/components/twilight_struggle/token_help_card.rb
@@ -1,35 +1,59 @@
 # frozen_string_literal: true
 
 class Components::TwilightStruggle::TokenHelpCard < Components::Base
-  TOKENS = %w[
-    tournament_name game_id turn winning_method
-    winning_player losing_player winning_side losing_side
-    usa_player ussr_player usa_name ussr_name winning_name losing_name
-    usa_flag ussr_flag winning_flag losing_flag videos
-    usa_rating_before usa_rating_after usa_rating_change
-    ussr_rating_before ussr_rating_after ussr_rating_change
-    winning_rating_before winning_rating_after winning_rating_change
-    losing_rating_before losing_rating_after losing_rating_change
-  ].freeze
+  GROUPS = {
+    game: %w[tournament_name game_id turn winning_method videos],
+    usa: %w[usa_player usa_name usa_flag usa_rating_before usa_rating_after usa_rating_change],
+    ussr: %w[ussr_player ussr_name ussr_flag ussr_rating_before ussr_rating_after ussr_rating_change],
+    winner: %w[winning_player winning_name winning_flag winning_side winning_rating_before winning_rating_after winning_rating_change],
+    loser: %w[losing_player losing_name losing_flag losing_side losing_rating_before losing_rating_after losing_rating_change]
+  }.freeze
+
+  CHIP = "cursor-pointer rounded bg-surface-sunken px-1.5 py-0.5 font-mono text-xs text-accent-soft-fg " \
+    "transition-colors hover:bg-accent-soft focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]"
+
+  GROUP_LABEL = "w-20 flex-none text-[11px] font-semibold uppercase tracking-widest text-eyebrow"
 
   def view_template
     render Components::Card.new do
       p(class: "text-sm font-semibold") { t(".label") }
       p(class: "mb-3 mt-0.5 text-sm text-text-secondary") { t(".help") }
-      div(class: "flex flex-wrap gap-1.5") do
-        TOKENS.each { |token| chip(token) }
+      div(
+        data: {
+          controller: "clipboard",
+          clipboard_copied_label_value: t(".copied"),
+          clipboard_failed_label_value: t(".copy_failed")
+        }
+      ) do
+        dl(class: "flex flex-col gap-2.5") do
+          GROUPS.each { |group, tokens| token_row(group, tokens) }
+        end
+        announcer
       end
     end
   end
 
   private
 
+  def announcer
+    span(class: "sr-only", role: "status", data: {clipboard_target: "announcer"})
+  end
+
+  def token_row(group, tokens)
+    div(class: "flex flex-col gap-1.5 sm:flex-row sm:items-baseline sm:gap-3") do
+      dt(class: GROUP_LABEL) { t(".groups.#{group}") }
+      dd(class: "flex flex-wrap gap-1.5") do
+        tokens.each { |token| chip(token) }
+      end
+    end
+  end
+
   def chip(token)
     render Components::Tooltip.new(text: t(".tokens.#{token}")) do
-      code(
-        tabindex: "0",
-        class: "cursor-help rounded bg-surface-sunken px-1.5 py-0.5 font-mono text-xs text-accent-soft-fg " \
-          "focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]"
+      button(
+        type: "button",
+        class: CHIP,
+        data: {action: "clipboard#copy", clipboard_text_param: "{#{token}}"}
       ) { "{#{token}}" }
     end
   end

--- a/app/components/twilight_struggle/token_help_card.rb
+++ b/app/components/twilight_struggle/token_help_card.rb
@@ -6,6 +6,10 @@ class Components::TwilightStruggle::TokenHelpCard < Components::Base
     winning_player losing_player winning_side losing_side
     usa_player ussr_player usa_name ussr_name winning_name losing_name
     usa_flag ussr_flag winning_flag losing_flag videos
+    usa_rating_before usa_rating_after usa_rating_change
+    ussr_rating_before ussr_rating_after ussr_rating_change
+    winning_rating_before winning_rating_after winning_rating_change
+    losing_rating_before losing_rating_after losing_rating_change
   ].freeze
 
   def view_template

--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -1,0 +1,38 @@
+import { Controller } from "@hotwired/stimulus"
+
+const FLASH_MS = 1200
+
+export default class extends Controller {
+  static targets = ["announcer"]
+  static values = { copiedLabel: String, failedLabel: String }
+
+  copy({ params: { text }, currentTarget }) {
+    const bubble = currentTarget.parentElement.querySelector("[role=tooltip]")
+    const written = navigator.clipboard?.writeText(text) ?? Promise.reject()
+
+    written.then(
+      () => this.flash(bubble, this.copiedLabelValue),
+      () => this.flash(bubble, this.failedLabelValue)
+    )
+  }
+
+  flash(bubble, label) {
+    if (!bubble) return
+
+    this.restore?.()
+    const original = bubble.textContent
+    bubble.textContent = label
+    this.announce(label)
+    this.restore = () => {
+      clearTimeout(this.timer)
+      bubble.textContent = original
+      this.announce("")
+      this.restore = null
+    }
+    this.timer = setTimeout(() => this.restore?.(), FLASH_MS)
+  }
+
+  announce(label) {
+    if (this.hasAnnouncerTarget) this.announcerTarget.textContent = label
+  }
+}

--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -22,14 +22,26 @@ export default class extends Controller {
     this.restore?.()
     const original = bubble.textContent
     bubble.textContent = label
+    this.pin(bubble)
     this.announce(label)
     this.restore = () => {
       clearTimeout(this.timer)
       bubble.textContent = original
+      this.unpin(bubble)
       this.announce("")
       this.restore = null
     }
     this.timer = setTimeout(() => this.restore?.(), FLASH_MS)
+  }
+
+  pin(bubble) {
+    bubble.style.visibility = "visible"
+    bubble.style.opacity = "1"
+  }
+
+  unpin(bubble) {
+    bubble.style.visibility = ""
+    bubble.style.opacity = ""
   }
 
   announce(label) {

--- a/app/javascript/controllers/twilight_struggle_preview_controller.js
+++ b/app/javascript/controllers/twilight_struggle_preview_controller.js
@@ -5,8 +5,8 @@ const GAMES = {
   win: {
     tournament: "OTSL 2026 - Season 8",
     code: "G372",
-    usa: { name: "Michał Bąk", flag: "🇵🇱", handle: "michal" },
-    ussr: { name: "Lucas Sosa", flag: "🇦🇷" },
+    usa: { name: "Michał Bąk", flag: "🇵🇱", handle: "michal", rating: { before: 1502, after: 1522 } },
+    ussr: { name: "Lucas Sosa", flag: "🇦🇷", rating: { before: 1498, after: 1478 } },
     winner: "usa",
     turn: "Turn 7",
     method: "VP Track (+20)",
@@ -15,8 +15,8 @@ const GAMES = {
   tie: {
     tournament: "RATS Cup 2026",
     code: "C204",
-    usa: { name: "Marc Naudi", flag: "🇦🇩", handle: "marc" },
-    ussr: { name: "Ji-woo Han", flag: "🇰🇷" },
+    usa: { name: "Marc Naudi", flag: "🇦🇩", handle: "marc", rating: { before: 1503.5, after: 1505.75 } },
+    ussr: { name: "Ji-woo Han", flag: "🇰🇷", rating: { before: 1496.5, after: 1494.25 } },
     winner: null,
     turn: "Turn 10",
     method: "Wargames",
@@ -25,8 +25,8 @@ const GAMES = {
   video: {
     tournament: "OTSL 2026 - Season 8",
     code: "S378",
-    usa: { name: "Tomasz Borowski", flag: "🇵🇱", handle: "tomasz" },
-    ussr: { name: "Astrid Lindqvist", flag: "🇸🇪" },
+    usa: { name: "Tomasz Borowski", flag: "🇵🇱", handle: "tomasz", rating: { before: 1450, after: 1465 } },
+    ussr: { name: "Astrid Lindqvist", flag: "🇸🇪", rating: { before: 1550, after: 1535 } },
     winner: null,
     turn: "Turn 4",
     method: "DEFCON",
@@ -106,6 +106,18 @@ export default class extends Controller {
       usa_flag: game.usa.flag,
       ussr_flag: game.ussr.flag,
       videos: game.videos,
+      usa_rating_before: this.ratingText(game.usa, "before"),
+      usa_rating_after: this.ratingText(game.usa, "after"),
+      usa_rating_change: this.ratingChange(game.usa),
+      ussr_rating_before: this.ratingText(game.ussr, "before"),
+      ussr_rating_after: this.ratingText(game.ussr, "after"),
+      ussr_rating_change: this.ratingChange(game.ussr),
+      winning_rating_before: this.ratingText(winner, "before"),
+      winning_rating_after: this.ratingText(winner, "after"),
+      winning_rating_change: this.ratingChange(winner),
+      losing_rating_before: this.ratingText(loser, "before"),
+      losing_rating_after: this.ratingText(loser, "after"),
+      losing_rating_change: this.ratingChange(loser),
     }
   }
 
@@ -115,6 +127,21 @@ export default class extends Controller {
 
   name(person) {
     return this.tagged(person, [person?.name])
+  }
+
+  ratingText(person, field) {
+    const value = person?.rating?.[field]
+    return value == null ? "" : String(value)
+  }
+
+  ratingChange(person) {
+    const before = person?.rating?.before
+    const after = person?.rating?.after
+    if (before == null || after == null) return ""
+
+    const diff = Math.round((after - before) * 100) / 100
+
+    return `${diff >= 0 ? "+" : ""}${diff}`
   }
 
   tagged(person, parts) {

--- a/app/javascript/controllers/twilight_struggle_preview_controller.js
+++ b/app/javascript/controllers/twilight_struggle_preview_controller.js
@@ -15,8 +15,8 @@ const GAMES = {
   tie: {
     tournament: "RATS Cup 2026",
     code: "C204",
-    usa: { name: "Marc Naudi", flag: "🇦🇩", handle: "marc", rating: { before: 1503.5, after: 1505.75 } },
-    ussr: { name: "Ji-woo Han", flag: "🇰🇷", rating: { before: 1496.5, after: 1494.25 } },
+    usa: { name: "Marc Naudi", flag: "🇦🇩", handle: "marc", rating: { before: 1503, after: 1506 } },
+    ussr: { name: "Ji-woo Han", flag: "🇰🇷", rating: { before: 1497, after: 1494 } },
     winner: null,
     turn: "Turn 10",
     method: "Wargames",

--- a/app/models/twilight_struggle/message.rb
+++ b/app/models/twilight_struggle/message.rb
@@ -39,7 +39,28 @@ module TwilightStruggle
         winning_flag: flag_of(@report.winner),
         losing_flag: flag_of(@report.loser),
         videos: @report.video_urls.join(" ")
+      }.merge(rating_tokens)
+    end
+
+    def rating_tokens
+      rated_sides.flat_map { |side, player| rating_pairs(side, PlayerRating.new(player)) }.to_h
+    end
+
+    def rated_sides
+      {
+        usa: @report.usa,
+        ussr: @report.ussr,
+        winning: @report.winner,
+        losing: @report.loser
       }
+    end
+
+    def rating_pairs(side, rating)
+      [
+        [:"#{side}_rating_before", rating.before],
+        [:"#{side}_rating_after", rating.after],
+        [:"#{side}_rating_change", rating.change]
+      ]
     end
 
     def render_player(player)

--- a/app/models/twilight_struggle/player.rb
+++ b/app/models/twilight_struggle/player.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module TwilightStruggle
-  Player = Data.define(:name, :flag, :discord_id) do
-    def initialize(name:, flag: nil, discord_id: nil)
+  Player = Data.define(:name, :flag, :discord_id, :rating_before, :rating_after) do
+    def initialize(name:, flag: nil, discord_id: nil, rating_before: nil, rating_after: nil)
       super
     end
 
@@ -11,7 +11,9 @@ module TwilightStruggle
       new(
         name: payload[:name],
         flag: payload[:flag],
-        discord_id: payload[:discord_id]
+        discord_id: payload[:discord_id],
+        rating_before: payload[:rating_before],
+        rating_after: payload[:rating_after]
       )
     end
 

--- a/app/models/twilight_struggle/player_rating.rb
+++ b/app/models/twilight_struggle/player_rating.rb
@@ -15,7 +15,8 @@ module TwilightStruggle
     end
 
     def change
-      return "" if @player&.rating_before.nil? || @player&.rating_after.nil?
+      return "" if @player.nil?
+      return "" if @player.rating_before.nil? || @player.rating_after.nil?
 
       signed(@player.rating_after - @player.rating_before)
     end

--- a/app/models/twilight_struggle/player_rating.rb
+++ b/app/models/twilight_struggle/player_rating.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module TwilightStruggle
+  class PlayerRating
+    def initialize(player)
+      @player = player
+    end
+
+    def before
+      decimal(@player&.rating_before)
+    end
+
+    def after
+      decimal(@player&.rating_after)
+    end
+
+    def change
+      return "" if @player&.rating_before.nil? || @player&.rating_after.nil?
+
+      signed(@player.rating_after - @player.rating_before)
+    end
+
+    private
+
+    def decimal(value)
+      return "" if value.nil?
+
+      whole?(value) ? value.to_i.to_s : value.to_s
+    end
+
+    def signed(value)
+      rounded = value.round(2)
+
+      "#{"+" if rounded >= 0}#{decimal(rounded)}"
+    end
+
+    def whole?(value)
+      (value % 1).zero?
+    end
+  end
+end

--- a/config/api/twilight-struggle/v1/docs/games.md
+++ b/config/api/twilight-struggle/v1/docs/games.md
@@ -7,12 +7,13 @@ tournament, so it cannot identify a game on its own.
 grouped under shrkbot's internal "Friendly games" tournament instead of being
 rejected.
 
-**Everything except the identifiers is render-only.** Player names, flags, the
-winning side/method/turn, and the video URLs are used once to build the Discord
-message and are then discarded — shrkbot does not store them. Only the game's own
-id, its tournament link, and (once posted) the Discord channel/message id of each
-subscribing server's posted result are kept — one pair per server. See the
-[privacy policy](https://shrkbot.com/privacy) for the full data inventory.
+**Everything except the identifiers is render-only.** Player names, flags and
+ratings, the winning side/method/turn, and the video URLs are used once to build
+the Discord message and are then discarded — shrkbot does not store them. Only
+the game's own id, its tournament link, and (once posted) the Discord
+channel/message id of each subscribing server's posted result are kept — one pair
+per server. See the [privacy policy](https://shrkbot.com/privacy) for the full
+data inventory.
 
 ## Posting results to Discord
 
@@ -83,6 +84,9 @@ field. Send both fields, or write a template that matches what you send.
 | `{usa_name}` / `{ussr_name}` / `{winning_name}` / `{losing_name}` | name, no flag |
 | `{usa_flag}` / `{ussr_flag}` / `{winning_flag}` / `{losing_flag}` | flag only |
 | `{videos}` | the video URLs, space separated |
+| `{usa_rating_before}` / `{ussr_rating_before}` / `{winning_rating_before}` / `{losing_rating_before}` | the player's rating before the game; empty without one. The `winning_`/`losing_` tokens are also empty on a tie |
+| `{usa_rating_after}` / `{ussr_rating_after}` / `{winning_rating_after}` / `{losing_rating_after}` | the player's rating after the game; empty without one. The `winning_`/`losing_` tokens are also empty on a tie |
+| `{usa_rating_change}` / `{ussr_rating_change}` / `{winning_rating_change}` / `{losing_rating_change}` | the rating change, signed, such as `+12` or `-8`; empty unless both ratings were sent. The `winning_`/`losing_` tokens are also empty on a tie |
 
 A tournament can be set to show Discord tags. Then every token that carries a
 player's name also carries their tag in brackets after it — `Alice 🇺🇸 (@alice)` —

--- a/config/api/twilight-struggle/v1/games.yaml
+++ b/config/api/twilight-struggle/v1/games.yaml
@@ -138,6 +138,24 @@ components:
             safe integer range. Tournaments set to show Discord tags render it
             alongside the player's name. We never store it.
           example: "123456789012345678"
+        rating_before:
+          type: number
+          minimum: -100000
+          maximum: 100000
+          description: >-
+            The player's rating before this game. Optional. Fractional and
+            negative values are accepted, so send the rating your system holds
+            without rounding it. We never store it.
+          example: 1512
+        rating_after:
+          type: number
+          minimum: -100000
+          maximum: 100000
+          description: >-
+            The player's rating after this game. Optional. `{usa_rating_change}`
+            and its siblings need both ratings; a player sent with only one of
+            them renders an empty change. We never store it.
+          example: 1524
     GameUpsertResponse:
       type: object
       properties:

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -491,8 +491,16 @@ en:
           help: Used when one player won.
           label: Decided game
       token_help_card:
+        copied: Copied
+        copy_failed: Copy failed
+        groups:
+          game: Game
+          loser: Loser
+          usa: USA
+          ussr: USSR
+          winner: Winner
         help: Anything in braces is replaced when the message is built. A token we
-          do not know is left exactly as you typed it.
+          do not know is left exactly as you typed it. Click a token to copy it.
         label: Tokens
         tokens:
           game_id: The game's code on twilight-struggle.com, such as G372.

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -499,21 +499,39 @@ en:
           losing_flag: The losing player's flag. Empty on a tie.
           losing_name: The losing player's name, without their flag. Empty on a tie.
           losing_player: The losing player's name and flag. Empty on a tie.
+          losing_rating_after: The losing player's rating after the game. Empty on
+            a tie.
+          losing_rating_before: The losing player's rating before the game. Empty
+            on a tie.
+          losing_rating_change: The losing player's rating change, signed, such as
+            -12. Empty on a tie.
           losing_side: USA or USSR, whichever lost. Empty on a tie.
           tournament_name: The tournament's name.
           turn: The turn the game ended on, such as Turn 7. Turn 11 reads Final Scoring.
           usa_flag: The USA player's flag.
           usa_name: The USA player's name, without their flag.
           usa_player: The USA player's name and flag.
+          usa_rating_after: The USA player's rating after the game.
+          usa_rating_before: The USA player's rating before the game.
+          usa_rating_change: The USA player's rating change, signed, such as +12.
           ussr_flag: The USSR player's flag.
           ussr_name: The USSR player's name, without their flag.
           ussr_player: The USSR player's name and flag.
+          ussr_rating_after: The USSR player's rating after the game.
+          ussr_rating_before: The USSR player's rating before the game.
+          ussr_rating_change: The USSR player's rating change, signed, such as +12.
           videos: The video links, separated by spaces. Discord builds the embed.
           winning_flag: The winning player's flag. Empty on a tie.
           winning_method: How the game ended, such as VP Track (+20).
           winning_name: The winning player's name, without their flag. Empty on a
             tie.
           winning_player: The winning player's name and flag. Empty on a tie.
+          winning_rating_after: The winning player's rating after the game. Empty
+            on a tie.
+          winning_rating_before: The winning player's rating before the game. Empty
+            on a tie.
+          winning_rating_change: The winning player's rating change, signed, such
+            as +12. Empty on a tie.
           winning_side: USA or USSR, whichever won. Empty on a tie.
       tournament_row:
         archived: Archived

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -491,7 +491,7 @@ en:
           help: Used when one player won.
           label: Decided game
       token_help_card:
-        copied: Copied
+        copied: Copied!
         copy_failed: Copy failed
         groups:
           game: Game

--- a/spec/components/tooltip_spec.rb
+++ b/spec/components/tooltip_spec.rb
@@ -49,6 +49,14 @@ RSpec.describe Components::Tooltip do
     end
   end
 
+  context "with the default trigger" do
+    it "reveals the bubble on hover and on keyboard focus, but leaves it hidden after a mouse click" do
+      expect(html).to include("group-hover:visible")
+      expect(html).to include("group-has-[:focus-visible]:visible")
+      expect(html).not_to include("group-focus-within")
+    end
+  end
+
   context "with an unknown alignment" do
     let(:align) { :center }
 

--- a/spec/components/twilight_struggle/token_help_card_spec.rb
+++ b/spec/components/twilight_struggle/token_help_card_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Components::TwilightStruggle::TokenHelpCard do
   end
 
   it "hands the copy confirmation labels to the controller" do
-    expect(html).to include('data-clipboard-copied-label-value="Copied"')
+    expect(html).to include('data-clipboard-copied-label-value="Copied!"')
   end
 
   it "carries a live region so the copy is announced to screen readers" do

--- a/spec/components/twilight_struggle/token_help_card_spec.rb
+++ b/spec/components/twilight_struggle/token_help_card_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::TwilightStruggle::TokenHelpCard do
+  subject(:html) { described_class.new.render_in(view_context) }
+
+  let(:view_context) { ApplicationController.new.view_context }
+
+  it "renders every token in GROUPS as a copy button" do
+    described_class::GROUPS.values.flatten.each do |token|
+      expect(html).to include(%(data-clipboard-text-param="{#{token}}"))
+    end
+  end
+
+  it "labels each group" do
+    expect(html).to include("Game").and include("USA").and include("USSR").and include("Winner").and include("Loser")
+  end
+
+  it "makes the chips buttons rather than focusable code elements" do
+    expect(html).to include('type="button"')
+    expect(html).not_to include('tabindex="0"')
+  end
+
+  it "hands the copy confirmation labels to the controller" do
+    expect(html).to include('data-clipboard-copied-label-value="Copied"')
+  end
+
+  it "carries a live region so the copy is announced to screen readers" do
+    expect(html).to include('role="status"').and include('data-clipboard-target="announcer"')
+  end
+end

--- a/spec/models/twilight_struggle/game_report_spec.rb
+++ b/spec/models/twilight_struggle/game_report_spec.rb
@@ -48,6 +48,24 @@ RSpec.describe TwilightStruggle::GameReport do
         expect(report.video_urls).to eq([])
       end
     end
+
+    context "with ratings on the players" do
+      let(:payload) do
+        {
+          usa: {name: "Alice", rating_before: 1500, rating_after: 1512},
+          ussr: {name: "Bob", rating_before: 1500, rating_after: 1488},
+          winning_side: "usa"
+        }
+      end
+
+      it "carries the ratings through onto usa" do
+        expect(report.usa).to have_attributes(rating_before: 1500, rating_after: 1512)
+      end
+
+      it "carries the ratings through onto ussr" do
+        expect(report.ussr).to have_attributes(rating_before: 1500, rating_after: 1488)
+      end
+    end
   end
 
   describe "#tie?" do

--- a/spec/models/twilight_struggle/message_spec.rb
+++ b/spec/models/twilight_struggle/message_spec.rb
@@ -197,6 +197,43 @@ RSpec.describe TwilightStruggle::Message do
       end
     end
 
+    context "rating tokens" do
+      let(:template) { "{usa_rating_before}/{usa_rating_after}/{usa_rating_change}" }
+      let(:usa) { TwilightStruggle::Player.new(name: "M B", flag: "🇵🇱", discord_id: "111", rating_before: 1500, rating_after: 1512) }
+
+      it "renders all three usa rating tokens" do
+        expect(content).to eq("1500/1512/+12")
+      end
+
+      context "winning/losing rating tokens on a decided game" do
+        let(:template) { "{winning_rating_before}/{winning_rating_after}/{winning_rating_change}|{losing_rating_before}/{losing_rating_after}/{losing_rating_change}" }
+        let(:ussr) { TwilightStruggle::Player.new(name: "L S", flag: "🇦🇷", discord_id: "222", rating_before: 1600, rating_after: 1588) }
+
+        it "picks the winning player's ratings for winning_ and the loser's for losing_" do
+          expect(content).to eq("1500/1512/+12|1600/1588/-12")
+        end
+      end
+
+      context "on a tie" do
+        let(:template) { "[{winning_rating_before}][{losing_rating_before}]|{usa_rating_before}/{ussr_rating_before}" }
+        let(:ussr) { TwilightStruggle::Player.new(name: "L S", flag: "🇦🇷", discord_id: "222", rating_before: 1600, rating_after: 1588) }
+        let(:report) { TwilightStruggle::GameReport.new(usa:, ussr:, winning_side: "tie") }
+
+        it "renders the winning_/losing_ rating tokens empty while usa_/ussr_ still render" do
+          expect(content).to eq("[][]|1500/1600")
+        end
+      end
+
+      context "when a player is sent without ratings" do
+        let(:template) { "({usa_rating_before}/{usa_rating_after}/{usa_rating_change})" }
+        let(:usa) { TwilightStruggle::Player.new(name: "M B", flag: "🇵🇱", discord_id: "111") }
+
+        it "renders all three tokens empty and leaves the parentheses the template author wrote" do
+          expect(content).to eq("(//)")
+        end
+      end
+    end
+
     context "videos token" do
       let(:template) { "{videos}" }
 

--- a/spec/models/twilight_struggle/player_rating_spec.rb
+++ b/spec/models/twilight_struggle/player_rating_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TwilightStruggle::PlayerRating do
+  subject(:rating) { described_class.new(player) }
+
+  describe "#before" do
+    subject { rating.before }
+
+    context "with a whole-number integer rating" do
+      let(:player) { TwilightStruggle::Player.new(name: "Alice", rating_before: 1512) }
+
+      it { is_expected.to eq("1512") }
+    end
+
+    context "with a whole-number float rating" do
+      let(:player) { TwilightStruggle::Player.new(name: "Alice", rating_before: 1512.0) }
+
+      it { is_expected.to eq("1512") }
+    end
+
+    context "with a fractional rating" do
+      let(:player) { TwilightStruggle::Player.new(name: "Alice", rating_before: 1512.5) }
+
+      it { is_expected.to eq("1512.5") }
+    end
+
+    context "with a negative rating" do
+      let(:player) { TwilightStruggle::Player.new(name: "Alice", rating_before: -12) }
+
+      it { is_expected.to eq("-12") }
+    end
+
+    context "with a nil player" do
+      let(:player) { nil }
+
+      it { is_expected.to eq("") }
+    end
+
+    context "without a rating_before" do
+      let(:player) { TwilightStruggle::Player.new(name: "Alice") }
+
+      it { is_expected.to eq("") }
+    end
+  end
+
+  describe "#after" do
+    subject { rating.after }
+
+    context "with a whole-number integer rating" do
+      let(:player) { TwilightStruggle::Player.new(name: "Alice", rating_after: 1524) }
+
+      it { is_expected.to eq("1524") }
+    end
+
+    context "with a whole-number float rating" do
+      let(:player) { TwilightStruggle::Player.new(name: "Alice", rating_after: 1524.0) }
+
+      it { is_expected.to eq("1524") }
+    end
+
+    context "with a fractional rating" do
+      let(:player) { TwilightStruggle::Player.new(name: "Alice", rating_after: 1524.5) }
+
+      it { is_expected.to eq("1524.5") }
+    end
+
+    context "with a negative rating" do
+      let(:player) { TwilightStruggle::Player.new(name: "Alice", rating_after: -12) }
+
+      it { is_expected.to eq("-12") }
+    end
+
+    context "with a nil player" do
+      let(:player) { nil }
+
+      it { is_expected.to eq("") }
+    end
+
+    context "without a rating_after" do
+      let(:player) { TwilightStruggle::Player.new(name: "Alice") }
+
+      it { is_expected.to eq("") }
+    end
+  end
+
+  describe "#change" do
+    subject { rating.change }
+
+    context "with a nil player" do
+      let(:player) { nil }
+
+      it { is_expected.to eq("") }
+    end
+
+    context "without a rating_before" do
+      let(:player) { TwilightStruggle::Player.new(name: "Alice", rating_after: 1512) }
+
+      it { is_expected.to eq("") }
+    end
+
+    context "without a rating_after" do
+      let(:player) { TwilightStruggle::Player.new(name: "Alice", rating_before: 1500) }
+
+      it { is_expected.to eq("") }
+    end
+
+    context "on a rise" do
+      let(:player) { TwilightStruggle::Player.new(name: "Alice", rating_before: 1500, rating_after: 1512) }
+
+      it { is_expected.to eq("+12") }
+    end
+
+    context "on a fall" do
+      let(:player) { TwilightStruggle::Player.new(name: "Alice", rating_before: 1500, rating_after: 1488) }
+
+      it { is_expected.to eq("-12") }
+    end
+
+    context "with no change" do
+      let(:player) { TwilightStruggle::Player.new(name: "Alice", rating_before: 1500, rating_after: 1500) }
+
+      it { is_expected.to eq("+0") }
+    end
+
+    context "with float subtraction noise" do
+      let(:player) { TwilightStruggle::Player.new(name: "Alice", rating_before: 1200.2, rating_after: 1234.7) }
+
+      it { is_expected.to eq("+34.5") }
+    end
+
+    context "with negative ratings on both ends" do
+      let(:player) { TwilightStruggle::Player.new(name: "Alice", rating_before: -20, rating_after: -8) }
+
+      it { is_expected.to eq("+12") }
+    end
+  end
+end

--- a/spec/models/twilight_struggle/player_spec.rb
+++ b/spec/models/twilight_struggle/player_spec.rb
@@ -7,18 +7,18 @@ RSpec.describe TwilightStruggle::Player do
     subject(:player) { described_class.from_payload(payload) }
 
     context "with string keys" do
-      let(:payload) { {"name" => "Alice", "flag" => "🇺🇸", "discord_id" => "123"} }
+      let(:payload) { {"name" => "Alice", "flag" => "🇺🇸", "discord_id" => "123", "rating_before" => 1500, "rating_after" => 1512} }
 
       it "builds a Player" do
-        expect(player).to eq(described_class.new(name: "Alice", flag: "🇺🇸", discord_id: "123"))
+        expect(player).to eq(described_class.new(name: "Alice", flag: "🇺🇸", discord_id: "123", rating_before: 1500, rating_after: 1512))
       end
     end
 
     context "with symbol keys" do
-      let(:payload) { {name: "Bob", flag: "🇷🇺", discord_id: "456"} }
+      let(:payload) { {name: "Bob", flag: "🇷🇺", discord_id: "456", rating_before: 1500, rating_after: 1488} }
 
       it "builds a Player" do
-        expect(player).to eq(described_class.new(name: "Bob", flag: "🇷🇺", discord_id: "456"))
+        expect(player).to eq(described_class.new(name: "Bob", flag: "🇷🇺", discord_id: "456", rating_before: 1500, rating_after: 1488))
       end
     end
 
@@ -27,6 +27,11 @@ RSpec.describe TwilightStruggle::Player do
 
       it "defaults flag and discord_id to nil" do
         expect(player).to eq(described_class.new(name: "Carol"))
+      end
+
+      it "defaults rating_before and rating_after to nil" do
+        expect(player.rating_before).to be_nil
+        expect(player.rating_after).to be_nil
       end
     end
   end

--- a/spec/requests/api/twilight_struggle/v1/games_spec.rb
+++ b/spec/requests/api/twilight_struggle/v1/games_spec.rb
@@ -230,6 +230,92 @@ RSpec.describe "Api::TwilightStruggle::V1::Games", type: :request do
       end
     end
 
+    context "with ratings on the players" do
+      let(:params) do
+        {
+          game: valid_result_attributes.merge(
+            tournament_external_id: tournament.external_id,
+            usa: {name: "Alice", flag: "🇺🇸", rating_before: 1500, rating_after: 1512},
+            ussr: {name: "Bob", flag: "🇷🇺", rating_before: 1600, rating_after: 1588}
+          )
+        }
+      end
+
+      it "returns 201" do
+        put_game
+
+        expect(response).to have_http_status(:created)
+      end
+    end
+
+    context "with a fractional rating" do
+      let(:params) do
+        {
+          game: valid_result_attributes.merge(
+            tournament_external_id: tournament.external_id,
+            usa: {name: "Alice", flag: "🇺🇸", rating_before: 1500.5, rating_after: 1512.5}
+          )
+        }
+      end
+
+      it "returns 201" do
+        put_game
+
+        expect(response).to have_http_status(:created)
+      end
+    end
+
+    context "with a negative rating" do
+      let(:params) do
+        {
+          game: valid_result_attributes.merge(
+            tournament_external_id: tournament.external_id,
+            usa: {name: "Alice", flag: "🇺🇸", rating_before: -50, rating_after: -20}
+          )
+        }
+      end
+
+      it "returns 201" do
+        put_game
+
+        expect(response).to have_http_status(:created)
+      end
+    end
+
+    context "with a rating above the maximum" do
+      let(:params) do
+        {
+          game: valid_result_attributes.merge(
+            tournament_external_id: tournament.external_id,
+            usa: {name: "Alice", flag: "🇺🇸", rating_before: 1000000}
+          )
+        }
+      end
+
+      it "returns 422" do
+        put_game
+
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+
+    context "with a rating sent as a string" do
+      let(:params) do
+        {
+          game: valid_result_attributes.merge(
+            tournament_external_id: tournament.external_id,
+            usa: {name: "Alice", flag: "🇺🇸", rating_before: "1512"}
+          )
+        }
+      end
+
+      it "returns 422" do
+        put_game
+
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+
     context "with a successful upsert and a server subscribed to the tournament" do
       let(:server_configuration) { create(:server_configuration) }
       let!(:destination) { create(:twilight_struggle_destination, tournament:, server_configuration:) }


### PR DESCRIPTION
Adds `rating_before` and `rating_after` to `PlayerInput` on `PUT /games/{external_id}`. Both fields are optional. Both pass through to the Discord message and are never stored, like every other report field. `twilight_struggle_games` persists only `external_id` and `tournament_id`.

twilight-struggle.com computes each player's rating change when a result is reported, so both numbers are in hand at the point where the site's game sync will call this endpoint.

## Tokens

Twelve new tokens, three per side, on the existing `<side>_<attribute>` scheme: `{usa_rating_before}`, `{usa_rating_after}` and `{usa_rating_change}`, plus the same three for `ussr_`, `winning_` and `losing_`.

`_change` is `after - before`, rounded to 2 decimals and always signed (`+12`, `-8`, `+0`). A rating we did not receive renders empty, as `{winning_method}` does. `_change` needs both ratings. The `winning_`/`losing_` tokens are empty on a tie, like `{winning_player}`.

The punctuation around an empty token stays. That is the template author's problem:

```
template "({usa_rating_before}/{usa_rating_after}/{usa_rating_change})"
unrated player renders "(//)"
```

No shipped template gains a rating token. The token help card and the live preview list all twelve.

## Validation

`type: number`, `minimum: -100000`, `maximum: 100000`, in `games.yaml`. Committee enforces it against the OpenAPI document, so the controller needs no hand-written validation.

Negative and fractional values are accepted. Rating systems produce fractional values, and a system without a floor can go below zero. Rejecting either would enforce taste. The bounds only stop a stray timestamp or an overflowed float. twilight-struggle.com itself sends integers, from `game_results.usa_previous_rating` and `ratings_history.rating`.

## Token help card

The twelve new tokens took the card to 31, listed in one wrapped row. The card now has five labelled rows, keyed on the prefix each token already carries: game, USA, USSR, winner, loser. Reading one row teaches the naming of the other four. `{winning_method}` sits under game, because it describes how the game ended, not who won.

Each chip is a `<button type="button">` that copies its token to the clipboard. The confirmation reuses the tooltip already anchored to that chip. Its text becomes "Copied!" and the controller pins the bubble open for 1.2 seconds, so the confirmation survives the pointer leaving the chip. The bubble then returns to the token's description and to hover-only reveal. An `sr-only` `role="status"` element in the same card carries the same text for screen readers, matching `Components::Toast`. `navigator.clipboard` is undefined outside a secure context, so a dashboard self-hosted on `http://192.168.x.x` reads "Copy failed" instead of going quiet.

The chip was a `<code tabindex="0">`. The button gives it keyboard activation, which the code element never had.

`Components::Tooltip` revealed its bubble on `group-focus-within`. A mouse click focuses the trigger, so every tooltip in the dashboard stayed on screen after a click until focus moved elsewhere, where it could overlap the next tooltip the user hovered. Copying a token made it obvious; the reset button and the Welcomes placeholder chips had it too. The bubble now reveals on `group-has-[:focus-visible]`, which keeps the keyboard path and drops the mouse-click one that hover already covers. Blurring the trigger after a copy would have fixed the symptom and thrown away a keyboard user's place in the tab order.

The tie preview sent fractional sample ratings (`1503.5` to `1505.75`) and now sends whole numbers. Fractional ratings stay supported, and `PlayerRating` still has a spec for each of them.

## Specs

`PlayerRating` renders every case: whole integer, whole float (`1512.0` renders `1512`), fractional, negative, nil player, one rating missing, rise, fall, no change, and float subtraction noise (`1200.2` to `1234.7` renders `+34.5`). `Message` covers the four sides and the tie. The request spec covers the contract: ratings accepted, fractional accepted, negative accepted, `1000000` rejected, `"1512"` rejected. `TokenHelpCard` asserts a copy button for every token in `GROUPS`, the five group labels, the absence of the old `tabindex="0"`, and the live region. `Tooltip` asserts the bubble reveals on hover and on `:focus-visible`, and no longer on `:focus-within`.

## Gates

Run in the dev container against this branch, after the last commit.

```
$ bundle exec rspec
2889 examples, 0 failures

$ bundle exec standardrb
(no output, exit 0)

$ bundle exec rake active_record_doctor
(no output)

$ bundle exec undercover --compare origin/main
undercover: ✅ No coverage is missing in latest changes

$ bundle exec i18n-tasks missing
✓ Perfect! No translations are missing.

$ bundle exec i18n-tasks check-normalized
✓ Good job! All data is normalized
```
