### PR TITLE
Share one token chip between the two config forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project follows [Semantic Versioning](https://semver.org).
 - The Twilight Struggle results API takes an optional rating before and after the game for each player. Twelve new template tokens render them: `{usa_rating_before}`, `{usa_rating_after}` and `{usa_rating_change}`, plus the same three for `ussr`, `winning` and `losing`. The change token is the difference between the two ratings, always signed, such as `+12`. A rating we did not receive renders empty, as `{winning_method}` does. No shipped template uses the new tokens, so put them in your own template to see them. shrkbot never stores a rating, exactly as it never stores a player's name or flag.
 
 ### Changed
+- The welcome message placeholders copy on click, the same as the Twilight Struggle template tokens. Click `{user}`, `{username}`, `{displayname}` or `{membercount}` under the message boxes to copy it.
 - The Twilight Struggle template tokens are grouped by what each one describes: the game, the USA player, the USSR player, the winner and the loser. Click a token to copy it.
 - The Twilight Struggle results API no longer requires `winning_method` on a game. A site that does not record how a game ended can leave it out, and `{winning_method}` then renders empty, as `{turn}` already did without a `winning_turn`. Templates keep the punctuation around the token, so `in {turn} ({winning_method})` reads `in Turn 7 ()` for a game sent without one.
 

--- a/app/components/copyable_tokens.rb
+++ b/app/components/copyable_tokens.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Components::CopyableTokens < Components::Base
+  def view_template(&block)
+    div(
+      data: {
+        controller: "clipboard",
+        clipboard_copied_label_value: t(".copied"),
+        clipboard_failed_label_value: t(".copy_failed")
+      }
+    ) do
+      yield
+      announcer
+    end
+  end
+
+  private
+
+  def announcer
+    span(class: "sr-only", role: "status", data: {clipboard_target: "announcer"})
+  end
+end

--- a/app/components/token_chip.rb
+++ b/app/components/token_chip.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Components::TokenChip < Components::Base
+  CHIP = "cursor-pointer rounded bg-surface-sunken px-1.5 py-0.5 font-mono text-xs text-accent-soft-fg " \
+    "transition-colors hover:bg-accent-soft focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]"
+
+  def initialize(token:, description:)
+    @token = "{#{token}}"
+    @description = description
+  end
+
+  def view_template
+    render Components::Tooltip.new(text: @description) do
+      button(
+        type: "button",
+        class: CHIP,
+        data: {action: "clipboard#copy", clipboard_text_param: @token}
+      ) { @token }
+    end
+  end
+end

--- a/app/components/twilight_struggle/token_help_card.rb
+++ b/app/components/twilight_struggle/token_help_card.rb
@@ -9,52 +9,30 @@ class Components::TwilightStruggle::TokenHelpCard < Components::Base
     loser: %w[losing_player losing_name losing_flag losing_side losing_rating_before losing_rating_after losing_rating_change]
   }.freeze
 
-  CHIP = "cursor-pointer rounded bg-surface-sunken px-1.5 py-0.5 font-mono text-xs text-accent-soft-fg " \
-    "transition-colors hover:bg-accent-soft focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]"
-
   GROUP_LABEL = "w-20 flex-none text-[11px] font-semibold uppercase tracking-widest text-eyebrow"
 
   def view_template
     render Components::Card.new do
       p(class: "text-sm font-semibold") { t(".label") }
       p(class: "mb-3 mt-0.5 text-sm text-text-secondary") { t(".help") }
-      div(
-        data: {
-          controller: "clipboard",
-          clipboard_copied_label_value: t(".copied"),
-          clipboard_failed_label_value: t(".copy_failed")
-        }
-      ) do
+      render Components::CopyableTokens.new do
         dl(class: "flex flex-col gap-2.5") do
           GROUPS.each { |group, tokens| token_row(group, tokens) }
         end
-        announcer
       end
     end
   end
 
   private
 
-  def announcer
-    span(class: "sr-only", role: "status", data: {clipboard_target: "announcer"})
-  end
-
   def token_row(group, tokens)
     div(class: "flex flex-col gap-1.5 sm:flex-row sm:items-baseline sm:gap-3") do
       dt(class: GROUP_LABEL) { t(".groups.#{group}") }
       dd(class: "flex flex-wrap gap-1.5") do
-        tokens.each { |token| chip(token) }
+        tokens.each do |token|
+          render Components::TokenChip.new(token:, description: t(".tokens.#{token}"))
+        end
       end
-    end
-  end
-
-  def chip(token)
-    render Components::Tooltip.new(text: t(".tokens.#{token}")) do
-      button(
-        type: "button",
-        class: CHIP,
-        data: {action: "clipboard#copy", clipboard_text_param: "{#{token}}"}
-      ) { "{#{token}}" }
     end
   end
 end

--- a/app/components/welcomes/config_form.rb
+++ b/app/components/welcomes/config_form.rb
@@ -102,21 +102,13 @@ class Components::Welcomes::ConfigForm < Components::Base
 
   def placeholder_help
     render Components::Callout.new(variant: :neutral) do
-      span(class: "font-semibold") { t(".placeholders.intro") }
-      PLACEHOLDERS.each do |name|
-        whitespace
-        placeholder_chip("{#{name}}", t(".placeholders.#{name}"))
+      render Components::CopyableTokens.new do
+        span(class: "font-semibold") { t(".placeholders.intro") }
+        PLACEHOLDERS.each do |name|
+          whitespace
+          render Components::TokenChip.new(token: name, description: t(".placeholders.#{name}"))
+        end
       end
-    end
-  end
-
-  def placeholder_chip(token, description)
-    render Components::Tooltip.new(text: description) do
-      code(
-        tabindex: "0",
-        class: "cursor-help rounded bg-surface-sunken px-1.5 py-0.5 font-mono text-xs text-accent-soft-fg " \
-          "focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]"
-      ) { token }
     end
   end
 

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -60,6 +60,9 @@ en:
       message: We only set technical cookies to make the site work. No tracking, analytics,
         or anything else from a third party. We will remember that you've seen this,
         though - with a cookie, of course. :)
+    copyable_tokens:
+      copied: Copied!
+      copy_failed: Copy failed
     legal_links:
       imprint: Imprint
       privacy: Privacy policy
@@ -491,8 +494,6 @@ en:
           help: Used when one player won.
           label: Decided game
       token_help_card:
-        copied: Copied!
-        copy_failed: Copy failed
         groups:
           game: Game
           loser: Loser
@@ -574,7 +575,7 @@ en:
         placeholders:
           displayname: Expands to the member's nickname on this server, or their display
             name if they have none.
-          intro: 'Placeholders:'
+          intro: 'Placeholders (click one to copy):'
           membercount: Expands to the server's current member count.
           user: Expands to a mention of the member on join, and to their plain @handle
             on leave.

--- a/spec/components/copyable_tokens_spec.rb
+++ b/spec/components/copyable_tokens_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::CopyableTokens do
+  subject(:html) { described_class.new.render_in(view_context) { "chips" } }
+
+  let(:view_context) { ApplicationController.new.view_context }
+
+  it "mounts the clipboard controller and yields the block" do
+    expect(html).to include('data-controller="clipboard"').and include("chips")
+  end
+
+  it "hands the confirmation labels to the controller" do
+    expect(html).to include('data-clipboard-copied-label-value="Copied!"')
+    expect(html).to include('data-clipboard-failed-label-value="Copy failed"')
+  end
+
+  it "carries a live region so the copy is announced to screen readers" do
+    expect(html).to include('role="status"').and include('data-clipboard-target="announcer"')
+  end
+end

--- a/spec/components/token_chip_spec.rb
+++ b/spec/components/token_chip_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::TokenChip do
+  subject(:html) { described_class.new(token: "user", description: "Expands to a mention.").call }
+
+  it "braces the bare token name for the label" do
+    expect(html).to include(">{user}<")
+  end
+
+  it "copies the braced token" do
+    expect(html).to include('data-clipboard-text-param="{user}"').and include('data-action="clipboard#copy"')
+  end
+
+  it "renders a button rather than a focusable code element" do
+    expect(html).to include('type="button"')
+    expect(html).not_to include('tabindex="0"')
+  end
+
+  it "describes the token in a tooltip" do
+    expect(html).to include('role="tooltip"').and include("Expands to a mention.")
+  end
+end

--- a/spec/components/twilight_struggle/token_help_card_spec.rb
+++ b/spec/components/twilight_struggle/token_help_card_spec.rb
@@ -16,17 +16,4 @@ RSpec.describe Components::TwilightStruggle::TokenHelpCard do
   it "labels each group" do
     expect(html).to include("Game").and include("USA").and include("USSR").and include("Winner").and include("Loser")
   end
-
-  it "makes the chips buttons rather than focusable code elements" do
-    expect(html).to include('type="button"')
-    expect(html).not_to include('tabindex="0"')
-  end
-
-  it "hands the copy confirmation labels to the controller" do
-    expect(html).to include('data-clipboard-copied-label-value="Copied!"')
-  end
-
-  it "carries a live region so the copy is announced to screen readers" do
-    expect(html).to include('role="status"').and include('data-clipboard-target="announcer"')
-  end
 end

--- a/spec/components/welcomes/config_form_spec.rb
+++ b/spec/components/welcomes/config_form_spec.rb
@@ -30,6 +30,20 @@ RSpec.describe Components::Welcomes::ConfigForm do
     expect(card_containing("welcomes[leave_message]")).to include('name="welcomes[suppress_removal_messages]"')
   end
 
+  it "renders every placeholder as a copy button" do
+    described_class::PLACEHOLDERS.each do |name|
+      expect(html).to include(%(data-clipboard-text-param="{#{name}}"))
+    end
+  end
+
+  it "mounts the placeholder run on the clipboard controller with an announcer" do
+    expect(html).to include('data-controller="clipboard"').and include('data-clipboard-target="announcer"')
+  end
+
+  it "reads the intro with the copy hint" do
+    expect(html).to include("Placeholders (click one to copy):")
+  end
+
   def card_containing(field)
     Nokogiri::HTML.fragment(html)
       .css("div.rounded-card")


### PR DESCRIPTION
Two components rendered the same token chip with different code. This PR extracts the chip and gives the second call site the copy-on-click that #240 gave the first.

## The two new components

`Components::TokenChip` owns the tooltip, the `<button type="button">` and the chip classes. It takes the bare token name and braces it once, for both the label and the copy payload. The welcome form passed an already-braced `"{#{name}}"` before, so that call site now passes `name`.

`Components::CopyableTokens` owns the `clipboard` controller, its two labels and the `sr-only role="status"` announcer. It yields, so each caller keeps its own layout: the `dl` of five groups for Twilight Struggle, one inline run inside the callout for welcomes.

## What changes for a user

The welcome placeholders copy on click. They were `<code tabindex="0">` chips with a tooltip and no copy. The intro reads `Placeholders (click one to copy):`.

`copied` and `copy_failed` moved from `components.twilight_struggle.token_help_card` to `components.copyable_tokens`, so both callers read one copy of the strings. `app/javascript/controllers/clipboard_controller.js` needs no change.

## Left out on purpose

The four welcome placeholders stay one inline run. The Twilight Struggle card groups its tokens because it has 31.

## Gates

```
$ bundle exec rspec
2896 examples, 0 failures

$ bundle exec standardrb
(no offenses)

$ bundle exec rake active_record_doctor
(no output)

$ bundle exec i18n-tasks missing
✓ Well done! No translations are missing.

$ bundle exec i18n-tasks check-normalized
✓ Perfect! All data is normalized

$ bundle exec undercover --compare origin/main
✅ No coverage is missing in latest changes
```
