### PR TITLE
Lift bespoke plugins to the top of the server dashboard

### DIFF
--- a/app/components/plugin_row.rb
+++ b/app/components/plugin_row.rb
@@ -9,18 +9,13 @@ class Components::PluginRow < Components::Base
     disabled: :neutral
   }.freeze
 
-  def initialize(server_id:, key:, enabled:, configured:, locked: false, manageable: true, toggleable: true)
+  def initialize(server_id:, row:)
     @server_id = server_id
-    @key = key
-    @enabled = enabled
-    @configured = configured
-    @locked = locked
-    @manageable = manageable
-    @toggleable = toggleable
+    @row = row
   end
 
   def view_template
-    render Components::Card.new(enabled: @enabled, id: "plugin-#{@key}", class: "flex min-h-[108px] flex-wrap items-center gap-x-4 gap-y-3") do
+    render Components::Card.new(enabled: @row.enabled, id: "plugin-#{@row.key}", class: "flex min-h-[108px] flex-wrap items-center gap-x-4 gap-y-3") do
       identity
       div(class: "ml-auto flex flex-none items-center gap-3") do
         configure_link
@@ -33,32 +28,33 @@ class Components::PluginRow < Components::Base
 
   def identity
     div(class: "flex min-w-0 flex-[1_1_320px] items-center gap-4") do
-      render Components::PluginTile.new(icon: plugin_icon(@key), enabled: @enabled)
+      render Components::PluginTile.new(icon: plugin_icon(@row.key), enabled: @row.enabled)
       div(class: "min-w-0 flex-1") do
         div(class: "flex flex-wrap items-center gap-2") do
           span(class: "font-display font-semibold") { name }
           status_badge
+          bespoke_badge if @row.bespoke
         end
-        p(class: "mt-0.5 text-sm leading-[1.5] text-pretty text-text-secondary") { t(".plugin.#{@key}.description") }
+        p(class: "mt-0.5 text-sm leading-[1.5] text-pretty text-text-secondary") { t(".plugin.#{@row.key}.description") }
       end
     end
   end
 
   def toggle
-    if !@manageable
-      locked_toggle(checked: @enabled, tooltip: t(".not_manageable"))
-    elsif @locked
-      locked_toggle(checked: true, tooltip: t(".plugin.#{@key}.locked"))
-    elsif !@toggleable
-      locked_toggle(checked: @enabled, tooltip: t(".admin_only"))
+    if !@row.manageable
+      locked_toggle(checked: @row.enabled, tooltip: t(".not_manageable"))
+    elsif @row.locked
+      locked_toggle(checked: true, tooltip: t(".plugin.#{@row.key}.locked"))
+    elsif !@row.toggleable
+      locked_toggle(checked: @row.enabled, tooltip: t(".admin_only"))
     elsif blocked_until_setup?
       locked_toggle(checked: false, tooltip: t(".needs_setup_hint"))
     else
       render Components::Toggle.new(
         name: :enabled,
-        checked: @enabled,
+        checked: @row.enabled,
         label: t(".toggle", plugin: name),
-        url: server_plugin_path(@server_id, @key),
+        url: server_plugin_path(@server_id, @row.key),
         submit_on_change: true
       )
     end
@@ -71,28 +67,35 @@ class Components::PluginRow < Components::Base
   end
 
   def blocked_until_setup?
-    !@configured && !@enabled
+    !@row.configured && !@row.enabled
   end
 
   def name
-    t(".plugin.#{@key}.name")
+    t(".plugin.#{@row.key}.name")
   end
 
   def status_badge
-    if @locked
+    if @row.locked
       render Components::Badge.new(variant: :copper) { t(".status.global") }
     else
       render Components::Badge.new(variant: STATUS_VARIANTS.fetch(status), dot: true) { t(".status.#{status}") }
     end
   end
 
+  def bespoke_badge
+    render Components::Badge.new(variant: :copper) do
+      render Components::Icon.new("puzzle-piece", weight: :fill, class: "size-3.5")
+      plain t(".bespoke")
+    end
+  end
+
   def status
-    return :needs_setup unless @configured
-    @enabled ? :enabled : :disabled
+    return :needs_setup unless @row.configured
+    @row.enabled ? :enabled : :disabled
   end
 
   def configure_link
-    return configure_button if @manageable
+    return configure_button if @row.manageable
 
     render Components::Tooltip.new(text: t(".not_manageable")) do
       configure_button
@@ -102,15 +105,15 @@ class Components::PluginRow < Components::Base
   def configure_button
     render Components::Button.new(
       variant: :secondary,
-      href: @manageable ? configure_href : nil,
+      href: @row.manageable ? configure_href : nil,
       label: t(".configure"),
       trailing_icon: "arrow-right",
-      disabled: !@manageable,
+      disabled: !@row.manageable,
       class: "flex-none"
     )
   end
 
   def configure_href
-    plugin_config_path(@server_id, @key) || "#"
+    plugin_config_path(@server_id, @row.key) || "#"
   end
 end

--- a/app/presenters/plugin_status.rb
+++ b/app/presenters/plugin_status.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class PluginStatus
-  Row = Data.define(:key, :enabled, :configured, :locked, :manageable, :toggleable) do
-    def initialize(key:, enabled:, configured:, locked: false, manageable: true, toggleable: true)
+  Row = Data.define(:key, :enabled, :configured, :locked, :manageable, :toggleable, :bespoke) do
+    def initialize(key:, enabled:, configured:, locked: false, manageable: true, toggleable: true, bespoke: false)
       super
     end
   end
@@ -16,7 +16,8 @@ class PluginStatus
         enabled: activations[definition.key]&.enabled? || false,
         configured: definition.prerequisites_met?(server_configuration, enabled_keys:),
         manageable: access.manage?(definition.key),
-        toggleable: access.toggle?(definition.key)
+        toggleable: access.toggle?(definition.key),
+        bespoke: definition.bespoke
       )
     end
     display_order(catalog_rows + global_rows(access))
@@ -24,12 +25,14 @@ class PluginStatus
 
   def self.row(server_configuration, plugin, access:)
     activation = server_configuration.plugin_activations.find_by(plugin:)
+    definition = PluginCatalog.find(plugin.key)
     Row.new(
       key: plugin.key,
       enabled: activation&.enabled? || false,
-      configured: PluginCatalog.find(plugin.key).prerequisites_met?(server_configuration, enabled_keys: server_configuration.enabled_plugin_keys),
+      configured: definition.prerequisites_met?(server_configuration, enabled_keys: server_configuration.enabled_plugin_keys),
       manageable: access.manage?(plugin.key),
-      toggleable: access.toggle?(plugin.key)
+      toggleable: access.toggle?(plugin.key),
+      bespoke: definition.bespoke
     )
   end
 
@@ -41,7 +44,7 @@ class PluginStatus
   private_class_method :global_rows
 
   def self.display_order(rows)
-    rows.sort_by { |row| [row.manageable ? 0 : 1, plugin_name(row.key)] }
+    rows.sort_by { |row| [row.bespoke ? 0 : 1, row.manageable ? 0 : 1, plugin_name(row.key)] }
   end
   private_class_method :display_order
 

--- a/app/views/servers/plugins/update.turbo_stream.erb
+++ b/app/views/servers/plugins/update.turbo_stream.erb
@@ -1,2 +1,2 @@
-<%= turbo_stream.replace "plugin-#{@plugin.key}", html: render(Components::PluginRow.new(server_id: params[:server_id], key: @row.key, enabled: @row.enabled, configured: @row.configured, toggleable: @row.toggleable)) %>
+<%= turbo_stream.replace "plugin-#{@plugin.key}", html: render(Components::PluginRow.new(server_id: params[:server_id], row: @row)) %>
 <%= turbo_stream.append "toasts", html: render(Components::Toast.new(**@toast)) %>

--- a/app/views/servers/show.rb
+++ b/app/views/servers/show.rb
@@ -58,12 +58,21 @@ class Views::Servers::Show < Views::Base
   def plugins_section
     p(class: "mb-3 text-[11px] font-semibold uppercase tracking-widest text-eyebrow") { t(".plugins") }
     div(class: "flex flex-col gap-6") do
-      plugin_groups.each { |group| plugin_group(group) }
+      plugin_sections.each_with_index do |rows, index|
+        hr(class: "border-border-subtle") if index.positive?
+        plugin_section(rows)
+      end
     end
   end
 
-  def plugin_groups
-    visible_plugins.partition(&:manageable).reject(&:empty?)
+  def plugin_sections
+    visible_plugins.partition(&:bespoke).reject(&:empty?)
+  end
+
+  def plugin_section(rows)
+    div(class: "flex flex-col gap-6") do
+      rows.partition(&:manageable).reject(&:empty?).each { |group| plugin_group(group) }
+    end
   end
 
   def visible_plugins
@@ -73,7 +82,7 @@ class Views::Servers::Show < Views::Base
   def plugin_group(rows)
     div(class: "flex flex-col gap-3") do
       rows.each do |row|
-        render Components::PluginRow.new(server_id: @server.id, key: row.key, enabled: row.enabled, configured: row.configured, locked: row.locked, manageable: row.manageable, toggleable: row.toggleable)
+        render Components::PluginRow.new(server_id: @server.id, row:)
       end
     end
   end

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -351,6 +351,7 @@ en:
       recommended_default: 'Recommended default: %{value}'
     plugin_row:
       admin_only: Only a server admin can switch this plugin on or off.
+      bespoke: Bespoke
       configure: Configure
       needs_setup_hint: Complete setup before enabling this plugin.
       not_manageable: You can't configure this plugin on this server.

--- a/spec/components/plugin_row_spec.rb
+++ b/spec/components/plugin_row_spec.rb
@@ -6,11 +6,13 @@ RSpec.describe Components::PluginRow do
   include_context "component view context"
 
   subject(:html) do
-    described_class.new(server_id: 900_000_001, key: :roles, enabled: true, configured: true, manageable:, toggleable:).render_in(view_context)
+    described_class.new(server_id: 900_000_001, row:).render_in(view_context)
   end
 
+  let(:row) { PluginStatus::Row.new(key: :roles, enabled: true, configured: true, manageable:, toggleable:, bespoke:) }
   let(:manageable) { true }
   let(:toggleable) { true }
+  let(:bespoke) { false }
 
   context "when the user may configure the plugin" do
     it "links to the configuration page" do
@@ -47,5 +49,17 @@ RSpec.describe Components::PluginRow do
       expect(html).to include("disabled")
       expect(html).to include(CGI.escapeHTML(I18n.t("components.plugin_row.admin_only")))
     end
+  end
+
+  context "when the plugin is bespoke" do
+    let(:bespoke) { true }
+
+    it "marks it with a badge" do
+      expect(html).to include(I18n.t("components.plugin_row.bespoke"))
+    end
+  end
+
+  it "leaves the badge off a plugin every server can have" do
+    expect(html).not_to include(I18n.t("components.plugin_row.bespoke"))
   end
 end

--- a/spec/presenters/plugin_status_spec.rb
+++ b/spec/presenters/plugin_status_spec.rb
@@ -22,6 +22,14 @@ RSpec.describe PluginStatus do
       it "includes it" do
         expect(rows.map(&:key)).to include(:bespoke_thing)
       end
+
+      it "flags it as bespoke" do
+        expect(rows.select(&:bespoke).map(&:key)).to eq([:bespoke_thing])
+      end
+
+      it "lists it before every plugin any server can have" do
+        expect(rows.first.key).to eq(:bespoke_thing)
+      end
     end
 
     context "when the policy denies the user management of the server" do

--- a/spec/requests/server_dashboard_spec.rb
+++ b/spec/requests/server_dashboard_spec.rb
@@ -43,6 +43,11 @@ RSpec.describe "Server dashboard", type: :request do
         expect(response.body).to include("Roles").and include("Welcomes").and include("Logging")
       end
 
+      it "skips the separator when the server has no bespoke plugin" do
+        get_dashboard
+        expect(response.body).not_to include("<hr")
+      end
+
       it "lists moderation but not its sub-plugins on the dashboard" do
         create(:plugin, key: "moderation", name: "Server Shield")
         create(:plugin, key: "spam_protection", name: "Cross-Channel Spam Guard")
@@ -128,6 +133,15 @@ RSpec.describe "Server dashboard", type: :request do
           expect(manageable_index).not_to be_nil
           expect(unmanageable_index).not_to be_nil
           expect(unmanageable_index).to be > manageable_index
+        end
+
+        it "separates the bespoke plugin from the rest and badges it" do
+          get_dashboard
+          expect(response.body).to include(I18n.t("components.plugin_row.bespoke"))
+          expect(response.body.index("<hr")).to be_between(
+            response.body.index("plugin-twilight_struggle"),
+            response.body.index("plugin-roles")
+          )
         end
       end
 


### PR DESCRIPTION
Bespoke plugins are granted per server, but on the dashboard they sorted alphabetically among the plugins every server has. Nothing set them apart.

Granted bespoke plugins now render in their own section above a separator line. The section and the line only appear when the server has one. Sorting stays alphabetical inside each section, and unmanageable plugins still come last within a section. Each bespoke row carries a copper puzzle-piece badge, the same identity the bespoke plugins page already uses.

`Components::PluginRow` took the seven fields of `PluginStatus::Row` one by one, and the badge needed an eighth. It takes the row itself now. That also fixes a latent bug in the toggle re-render: `app/views/servers/plugins/update.turbo_stream.erb` passed four of the fields, so `locked` and `manageable` fell back to their defaults instead of the real row state.

Gates:

```
2902 examples, 0 failures
standardrb          clean
active_record_doctor clean
i18n-tasks missing / check-normalized  clean
undercover --compare origin/main  ✅ No coverage is missing in latest changes
```

Not checked in a browser from here.

Convention review flagged `PluginStatus::Row` at seven keyword params and proposed grouping `locked`/`manageable`/`toggleable` into a sub-value. I rejected it: `Row` is a flat `Data` record, not a class with mixed responsibilities, and the nesting would cost every reader an extra hop for no gain.
