### PR TITLE
Outline every badge variant, not only copper

### DIFF
--- a/app/assets/tailwind/theme.css
+++ b/app/assets/tailwind/theme.css
@@ -38,10 +38,13 @@
 
   --color-success: var(--success);
   --color-success-soft: var(--success-soft);
+  --color-success-soft-bd: var(--success-soft-bd);
   --color-warning: var(--warning);
   --color-warning-soft: var(--warning-soft);
+  --color-warning-soft-bd: var(--warning-soft-bd);
   --color-danger: var(--danger);
   --color-danger-soft: var(--danger-soft);
+  --color-danger-soft-bd: var(--danger-soft-bd);
 
   --color-surface-page: var(--surface-page);
   --color-surface-card: var(--surface-card);

--- a/app/assets/tailwind/tokens.css
+++ b/app/assets/tailwind/tokens.css
@@ -42,6 +42,9 @@
   --warning-soft: #f8efdc;
   --danger: #e0533d;
   --danger-soft: #f8e7e2;
+  --success-soft-bd: color-mix(in srgb, var(--success) 34%, transparent);
+  --warning-soft-bd: color-mix(in srgb, var(--warning) 34%, transparent);
+  --danger-soft-bd: color-mix(in srgb, var(--danger) 34%, transparent);
 
   --text-primary: var(--ink-900);
   --text-secondary: var(--ink-600);

--- a/app/assets/tailwind/tokens.css
+++ b/app/assets/tailwind/tokens.css
@@ -141,6 +141,9 @@
   --success-soft: rgba(47, 175, 107, 0.14);
   --warning-soft: rgba(232, 161, 58, 0.14);
   --danger-soft: rgba(224, 83, 61, 0.14);
+  --success-soft-bd: color-mix(in srgb, var(--success) 22%, transparent);
+  --warning-soft-bd: color-mix(in srgb, var(--warning) 22%, transparent);
+  --danger-soft-bd: color-mix(in srgb, var(--danger) 22%, transparent);
 
   --focus-ring: color-mix(in srgb, #46817a 42%, transparent);
 

--- a/app/components/badge.rb
+++ b/app/components/badge.rb
@@ -2,12 +2,12 @@
 
 class Components::Badge < Components::Base
   VARIANTS = {
-    success: {tone: "bg-success-soft text-success", dot: "bg-success"},
-    warning: {tone: "bg-warning-soft text-warning", dot: "bg-warning"},
-    danger: {tone: "bg-danger-soft text-danger", dot: "bg-danger"},
-    neutral: {tone: "bg-surface-sunken text-text-secondary", dot: "bg-text-muted"},
-    brand: {tone: "bg-accent-soft text-accent-soft-fg", dot: "bg-accent"},
-    copper: {tone: "border border-accent-2-soft-bd bg-accent-2-soft text-accent-2-text", dot: "bg-accent-2"}
+    success: {tone: "border-success-soft-bd bg-success-soft text-success", dot: "bg-success"},
+    warning: {tone: "border-warning-soft-bd bg-warning-soft text-warning", dot: "bg-warning"},
+    danger: {tone: "border-danger-soft-bd bg-danger-soft text-danger", dot: "bg-danger"},
+    neutral: {tone: "border-border-default bg-surface-sunken text-text-secondary", dot: "bg-text-muted"},
+    brand: {tone: "border-accent-soft-bd bg-accent-soft text-accent-soft-fg", dot: "bg-accent"},
+    copper: {tone: "border-accent-2-soft-bd bg-accent-2-soft text-accent-2-text", dot: "bg-accent-2"}
   }.freeze
 
   SHAPES = {pill: "rounded-full", chip: "rounded-chip"}.freeze
@@ -31,7 +31,7 @@ class Components::Badge < Components::Base
 
   def css
     [
-      "inline-flex items-center gap-1.5 px-2 py-0.5 text-xs font-semibold",
+      "inline-flex items-center gap-1.5 border px-2 py-0.5 text-xs font-semibold",
       SHAPES.fetch(@shape),
       @variant[:tone],
       @extra

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -195,7 +195,9 @@ duplicated class strings:
   `lift:` adds the hover-raise, `dashed:` is the placeholder/add affordance.
 - **`Components::Badge`** — status pill or tag. `variant:` (`:success`/`:warning`/
   `:danger`/`:neutral`/`:brand`/`:copper`), `dot:`, `shape:` (`:pill`/`:chip`).
-  Copper is for wayfinding/personality, never status.
+  Copper is for wayfinding/personality, never status. Every variant is a soft fill
+  inside a 1px border of the same hue (`*-soft-bd`), so badges of different tones
+  sit next to each other as one family; a new variant supplies a border colour too.
 - **`Components::PluginTile`** — the chamfered identity tile (icon on teal when
   `enabled:`, muted sand otherwise). `size:` (`:sm`/`:md`/`:lg`).
 - **`Components::Callout`** — tinted bordered notice. `variant:` (`:info`/

--- a/spec/components/badge_spec.rb
+++ b/spec/components/badge_spec.rb
@@ -36,9 +36,14 @@ RSpec.describe Components::Badge do
   context "copper variant" do
     let(:options) { {variant: :copper} }
 
-    it "uses the copper wayfinding tone with a border for contrast on cream surfaces" do
+    it "uses the copper wayfinding tone" do
       expect(html).to include("bg-accent-2-soft").and include("text-accent-2-text")
-      expect(html).to include("border-accent-2-soft-bd")
     end
+  end
+
+  it "outlines every variant so the faint fills keep their edge on cream surfaces" do
+    outlines = described_class::VARIANTS.each_key.map { |variant| described_class.new(variant:).call { "Enabled" } }
+
+    expect(outlines).to all(match(/class="[^"]*\bborder\b[^"]*\sborder-[a-z0-9-]+/))
   end
 end


### PR DESCRIPTION
The copper badge was the only variant with a border. The border is not decoration: `--accent-2-soft` is `#fbf1ea` against a `#fdfbf7` card, so without it the badge has no edge. The status badges are flat. On a bespoke plugin row the two sit side by side and read as different components.

Every variant now carries a 1px border in its own hue. `neutral` uses `border-border-default`, `brand` and `copper` reuse the `accent-*-soft-bd` tokens they already had, and success/warning/danger get new tokens:

```css
--success-soft-bd: color-mix(in srgb, var(--success) 34%, transparent);
```

Dark mode drops the three to 22%. Copper's dark text (`#e8a06d`) is a lighter tint than its fill hue (`copper-500`), so its border sits about a tenth of the way up the ramp from fill to text. Success and warning use one colour for both fill and text, so 34% lands twice as far up there and reads as washed-out text. At 22% they sit where copper sits.

The alternative was to flatten the copper badge instead. That needs a stronger `--accent-2-soft`, and the darkest fill that still holds text contrast (`copper-100` `#f5dcca` under `accent-2-text` `#a44f23`) measures 4.18:1, under the 4.5:1 that 12px bold text needs. Deepening the fill therefore also means darkening `--accent-2-text`, which changes the bespoke plugins page. Borders cost nothing and touch nothing else.

Gates:

```
2903 examples, 0 failures
standardrb          clean
active_record_doctor clean
undercover --compare origin/main  ✅ No coverage is missing in latest changes
```

`rails tailwindcss:build` emits the three new utilities, for example `.border-success-soft-bd{border-color:var(--success-soft-bd)}`.

Worth a look in both themes: every badge grows by 2px, so the status pills on the dashboard and the plugin pages are slightly larger than before.
