### PR TITLE
Name and mention the offender in moderation log entries

### DIFF
--- a/app/bot/discord/components.rb
+++ b/app/bot/discord/components.rb
@@ -81,17 +81,21 @@ module Bot
         end
 
         message = channel.send_message(subject, false, nil, attachments, allowed_mentions, nil, nil, 0)
-        convert_to_v2(channel.id, message.id, rendered)
+        convert_to_v2(channel.id, message.id, rendered, mention_users(allowed_mentions))
         message
       end
 
-      def convert_to_v2(channel_id, message_id, rendered)
+      def mention_users(allowed_mentions)
+        {parse: [], users: Array(allowed_mentions && allowed_mentions[:users])}
+      end
+
+      def convert_to_v2(channel_id, message_id, rendered, allowed_mentions = {parse: []})
         Discordrb::API::Channel.edit_message(
           Bot::Config.rest_token,
           channel_id,
           message_id,
           nil,
-          {parse: []},
+          allowed_mentions,
           nil,
           rendered[:components],
           rendered[:flags]

--- a/app/plugins/moderation/commands/report_scam.rb
+++ b/app/plugins/moderation/commands/report_scam.rb
@@ -52,12 +52,13 @@ module Moderation
         title: I18n.t("moderation.image_scanning.report.log.title"),
         body: I18n.t(
           "moderation.image_scanning.report.log.body",
-          reporter: "<@#{event.user.id}>",
-          author: "<@#{message.author.id}>",
+          reporter: UserLabel.for(event.user),
+          author: UserLabel.for(message.author),
           channel: "<##{event.channel.id}>"
         ),
         meta: I18n.t("moderation.image_scanning.report.log.meta.#{meta_key}"),
-        image: log_image
+        image: log_image,
+        allowed_mentions: {parse: [], users: [message.author.id]}
       )
     end
 

--- a/app/plugins/moderation/events/member_action_log.rb
+++ b/app/plugins/moderation/events/member_action_log.rb
@@ -12,6 +12,7 @@ module Moderation
       Bot::ActivityLog.post(
         server_configuration,
         bot: event.bot,
+        allowed_mentions: {parse: [], users: [target.id]},
         **activity_entry
       )
     end

--- a/app/plugins/moderation/events/spam_guard.rb
+++ b/app/plugins/moderation/events/spam_guard.rb
@@ -107,7 +107,7 @@ module Moderation
       channels = entries.map(&:channel_id).uniq
       body = StaffPing.prefix(staff_role_id, ping:) + I18n.t(
         "moderation.spam_protection.notification.body",
-        author: "<@#{event.author.id}>",
+        author: UserLabel.for(event.author),
         count: channels.size,
         window: settings.window_seconds,
         channels: channels.map { |id| "<##{id}>" }.join(", ")
@@ -127,7 +127,7 @@ module Moderation
         body:,
         meta: I18n.t("moderation.spam_protection.notification.meta.#{settings.action}"),
         subject: StaffPing.prefix(staff_role_id, ping:) + title,
-        allowed_mentions: {parse: [], roles: StaffPing.allowed_roles(staff_role_id, ping:)}
+        allowed_mentions: {parse: [], users: [event.author.id], roles: StaffPing.allowed_roles(staff_role_id, ping:)}
       )
     end
 
@@ -143,10 +143,11 @@ module Moderation
         title: I18n.t("moderation.spam_protection.notification.followup.title"),
         body: I18n.t(
           "moderation.spam_protection.notification.followup.body",
-          author: "<@#{event.author.id}>",
+          author: UserLabel.for(event.author),
           channel: "<##{entry.channel_id}>"
         ),
-        meta: I18n.t("moderation.spam_protection.notification.followup.meta")
+        meta: I18n.t("moderation.spam_protection.notification.followup.meta"),
+        allowed_mentions: {parse: [], users: [event.author.id]}
       )
     end
 

--- a/app/plugins/moderation/image_scanning/verdict_executor.rb
+++ b/app/plugins/moderation/image_scanning/verdict_executor.rb
@@ -78,7 +78,7 @@ module Moderation
           title:,
           body: StaffPing.prefix(staff_role_id, ping:) + I18n.t(
             "moderation.image_scanning.flag.body",
-            author: "<@#{context.member.id}>",
+            author: UserLabel.for(context.member),
             channel: "<##{context.channel_id}>",
             jump_url:
           ) + "\n" + risk_line(state) + "\n" + reason_lines + "\n" + PunishmentNote.line(punishment.action, timeout_until: punishment.timeout_until),
@@ -86,7 +86,7 @@ module Moderation
           image:,
           components: message_components(punishment.action),
           subject: StaffPing.prefix(staff_role_id, ping:) + title,
-          allowed_mentions: {parse: [], roles: StaffPing.allowed_roles(staff_role_id, ping:)}
+          allowed_mentions: {parse: [], users: [context.member.id], roles: StaffPing.allowed_roles(staff_role_id, ping:)}
         )
       end
 

--- a/app/plugins/moderation/member_log/activity_entry.rb
+++ b/app/plugins/moderation/member_log/activity_entry.rb
@@ -32,7 +32,7 @@ module Moderation
       end
 
       def action_line
-        interpolations = {target: user_label(target), moderator: moderator_label, locale: :en, raise: true}
+        interpolations = {target: UserLabel.for(target), moderator: moderator_label, locale: :en, raise: true}
         interpolations[:until] = "<t:#{timeout_until.to_i}:f>" if timeout_until
         I18n.t("activity_log.moderation.#{event_key}", **interpolations)
       end
@@ -40,11 +40,7 @@ module Moderation
       def moderator_label
         return I18n.t("activity_log.moderation.unknown_moderator", locale: :en, raise: true) unless moderator
 
-        user_label(moderator)
-      end
-
-      def user_label(user)
-        "#{user.mention} (#{user.username})"
+        UserLabel.for(moderator)
       end
 
       def reason_line

--- a/app/plugins/moderation/user_label.rb
+++ b/app/plugins/moderation/user_label.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Moderation
+  module UserLabel
+    module_function
+
+    def for(user)
+      "#{user.mention} (#{user.username})"
+    end
+  end
+end

--- a/config/locales/legal.en.yml
+++ b/config/locales/legal.en.yml
@@ -134,7 +134,8 @@ en:
         review it - it is delivered as an ordinary Discord message and is therefore
         stored by Discord in that channel, not retained by shrkbot. A short record
         that an action occurred (without the message content) may also appear in the
-        dashboard.
+        dashboard. The entry names the member involved by mention and username; the
+        username is rendered into the message and not stored by shrkbot.
       messages_p_4: The bot also receives member join and leave events to deliver
         welcome messages; the username shown there is rendered into the message and
         not stored.
@@ -212,7 +213,7 @@ en:
         and our hosting provider Hetzner (Helsinki, Finland, within the EEA), where
         the Service and its database run. We may disclose data where required by law.'
       title: Privacy policy
-      updated: 'Last updated: August 4th, 2026'
+      updated: 'Last updated: August 12th, 2026'
     terms_of_service:
       admin_h: Your responsibilities as a server admin
       admin_p: If you add shrkbot to a server or configure it, you're responsible

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ work actually touches.
 
 - [bot/commands-and-events.md](bot/commands-and-events.md) — `Bot::BaseCommand`/`BaseEvent` and their class macros, native Discord permission bits via `default_member_permissions` (and why the bot doesn't re-check them), guild vs global registration, and the 3-second interaction ack window.
 - [bot/guild-sync.md](bot/guild-sync.md) — syncing a guild's channels, roles and overwrites into Postgres so the web app never needs the bot token; live and startup channel-delete handling; and the two triggers that onboard a server exactly once.
-- [bot/message-rendering.md](bot/message-rendering.md) — `Bot::Discord::Components`, the shared Components V2 primitives every sender goes through, and the subject-first plain-to-V2 conversion that keeps push-notification previews readable.
+- [bot/message-rendering.md](bot/message-rendering.md) — `Bot::Discord::Components`, the shared Components V2 primitives every sender goes through, the subject-first plain-to-V2 conversion that keeps push-notification previews readable, and the mention rules that come with it (why a suppressed mention renders `@unknown-user`, and how the allow-list is split across the two calls so nobody gets pinged twice).
 - [bot/sharding-and-leadership.md](bot/sharding-and-leadership.md) — static sharding inside one process, the Redis leader lock that keeps exactly one bot connected across a Kamal deploy (and the two load-bearing orderings), and the `Bot <token>` REST header.
 - [bot/notifications.md](bot/notifications.md) — notification records written by bot-side ops when a Discord event invalidates plugin config, and how the web side reads them scoped to the servers you administer.
 

--- a/docs/bot/message-rendering.md
+++ b/docs/bot/message-rendering.md
@@ -22,3 +22,33 @@ create with that preview), then `convert_to_v2` edits the message into the conta
 (explicit null content + the `COMPONENTS_V2` flag — Discord only allows this conversion
 plain→V2, never back). A failed conversion is logged and leaves the readable plain
 message standing; `DeliverJob` shares `convert_to_v2` after its REST `create_message`.
+
+## Mentioning a user
+
+A Discord client resolves `<@id>` against a lazily-filled local member store, and the
+user objects in a message payload's `mentions` array are one of the two things that
+fill it. `allowed_mentions` decides that array, so a mention posted under
+`{parse: []}` renders as `@unknown-user` for every viewer whose client never met the
+user — permanently, for a member who was banned before that client ever saw them. A
+message that names a user therefore does two things: it allows that user in
+`allowed_mentions`, and it prints the name next to the mention
+(`Moderation::UserLabel.for` renders `mention (username)`) so the entry still reads
+after a rename or a deleted account. Whether the allowed mention also fires a real
+ping is the caller's decision to make and to defend: the moderation log allows the
+offender because a private log channel delivers no notification to them, while
+`Welcomes::JoinAnnouncement` allows the joiner and sets `SUPPRESS_NOTIFICATIONS`
+(`1 << 12`) instead, so the mention resolves without a sound.
+
+The subject-first flow makes this two API calls, and **a mention allowed on both of
+them can ping twice**. `send_to` therefore splits the allow-list: the plain create
+gets the caller's `allowed_mentions` verbatim, and `convert_to_v2` receives only its
+`users:` entries. Roles are dropped there because a ping-bearing subject already
+mentioned the staff or game role in its own text. User mentions survive into the edit
+because they live in the container body, which the create never contained, so the
+edit is the first call that can put them in the `mentions` array. When adding a
+mention to any message, work out which of the two calls carries it and allow it on
+that call alone. Senders that skip the subject (an activity-log entry with no staff
+ping, a role message) take the plain `send_message` branch, where the allow-list
+applies once, and the three direct `convert_to_v2` callers (`Lfg::PingReply`, the LFG
+join refresh, `DeliverJob`) ping from their own create and keep the suppressed default
+on the edit.

--- a/spec/bot/discord/components_spec.rb
+++ b/spec/bot/discord/components_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe Bot::Discord::Components do
           20,
           30,
           nil,
-          {parse: []},
+          {parse: [], users: []},
           nil,
           rendered[:components],
           rendered[:flags]
@@ -185,6 +185,31 @@ RSpec.describe Bot::Discord::Components do
 
       it "returns the sent message" do
         expect(send_to).to eq(message)
+      end
+
+      context "with allowed user mentions" do
+        subject(:send_to) do
+          described_class.send_to(
+            channel,
+            rendered,
+            subject: "reminder: hello",
+            allowed_mentions: {parse: [], users: [77], roles: [88]}
+          )
+        end
+
+        it "carries the users into the conversion so the mention resolves, without re-pinging roles" do
+          expect(Discordrb::API::Channel).to receive(:edit_message).with(
+            "Bot tok",
+            20,
+            30,
+            nil,
+            {parse: [], users: [77]},
+            nil,
+            rendered[:components],
+            rendered[:flags]
+          )
+          send_to
+        end
       end
 
       context "when the conversion fails" do

--- a/spec/plugins/moderation/commands/report_scam_spec.rb
+++ b/spec/plugins/moderation/commands/report_scam_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe Moderation::ReportScam do
   let(:attachments) { [image_attachment] }
   let(:content) { nil }
   let(:embeds) { [] }
-  let(:message_author) { double("author", id: author_id) }
+  let(:message_author) { double("author", id: author_id, mention: "<@#{author_id}>", username: "offender") }
   let(:target) { double("message", attachments:, content:, embeds:, author: message_author, delete: nil) }
   let(:server) { double("server", id: guild_id) }
-  let(:user) { double("user", id: 555) }
+  let(:user) { double("user", id: 555, mention: "<@555>", username: "reporter") }
   let(:channel) { double("channel", id: channel_id) }
   let(:bot) { double("bot") }
   let(:event) do
@@ -135,10 +135,11 @@ RSpec.describe Moderation::ReportScam do
         expect(kwargs[:title]).to eq(I18n.t("moderation.image_scanning.report.log.title"))
         expect(kwargs[:meta]).to eq(I18n.t("moderation.image_scanning.report.log.meta.removed"))
         body = kwargs[:body]
-        expect(body).to include("<@#{user.id}>")
-        expect(body).to include("<@#{author_id}>")
+        expect(body).to include("<@#{user.id}> (reporter)")
+        expect(body).to include("<@#{author_id}> (offender)")
         expect(body).to include("<##{channel_id}>")
         expect(kwargs[:image]).to be_a(Bot::Discord::FileUpload)
+        expect(kwargs[:allowed_mentions]).to eq(parse: [], users: [author_id])
       end
     end
   end

--- a/spec/plugins/moderation/events/member_action_log_spec.rb
+++ b/spec/plugins/moderation/events/member_action_log_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Moderation::MemberActionLog do
     expect(Bot::ActivityLog).to have_received(:post).with(
       server_configuration,
       bot:,
+      allowed_mentions: {parse: [], users: [target.id]},
       **built_entry
     )
   end

--- a/spec/plugins/moderation/events/member_ban_log_spec.rb
+++ b/spec/plugins/moderation/events/member_ban_log_spec.rb
@@ -26,6 +26,14 @@ RSpec.describe Moderation::MemberBanLog do
     expect(Bot::ActivityLog).to have_received(:post)
   end
 
+  it "allows the banned member's mention so clients can resolve it" do
+    handle
+    expect(Bot::ActivityLog).to have_received(:post).with(
+      server_configuration,
+      hash_including(allowed_mentions: {parse: [], users: [target.id]})
+    )
+  end
+
   context "when shrkbot performed the ban" do
     let(:moderator_id) { bot_user_id }
 

--- a/spec/plugins/moderation/events/spam_guard_spec.rb
+++ b/spec/plugins/moderation/events/spam_guard_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Moderation::SpamGuard do
 
   let(:owner) { double("owner", id: 999) }
   let(:server) { double("server", id: guild_id, owner:) }
-  let(:author) { double("author", id: author_id, roles: []) }
+  let(:author) { double("author", id: author_id, roles: [], mention: "<@#{author_id}>", username: "spammer") }
   let(:message) { double("message", id: 1, webhook?: false, content: "hello world foo bar", attachments: []) }
   let(:channel) { double("channel", id: 1, pm?: false) }
   let(:log_channel) { double("log_channel") }
@@ -142,7 +142,7 @@ RSpec.describe Moderation::SpamGuard do
       expect(Bot::Discord::Components).to receive(:send_to).with(
         log_channel,
         anything,
-        allowed_mentions: hash_including(roles: array_including(staff_role_id)),
+        allowed_mentions: hash_including(users: [author_id], roles: array_including(staff_role_id)),
         attachments: nil,
         subject: "<@&#{staff_role_id}>: #{I18n.t("moderation.spam_protection.notification.title.purge")}"
       )
@@ -211,10 +211,11 @@ RSpec.describe Moderation::SpamGuard do
         simulate_message(channel_id: 3, message_id: 30)
 
         expect(ch4).to receive(:delete_message).with(40)
-        expect(Bot::Discord::Components).to receive(:send_to) do |_channel, rendered, **|
+        expect(Bot::Discord::Components).to receive(:send_to) do |_channel, rendered, **kwargs|
           body = rendered[:components].first[:components].first[:content]
           expect(body).to include("Cross-channel spam follow-up removed")
           expect(body).to include("<#4>")
+          expect(kwargs[:allowed_mentions]).to eq(parse: [], users: [author_id])
         end
 
         simulate_message(channel_id: 4, message_id: 40)
@@ -464,7 +465,7 @@ RSpec.describe Moderation::SpamGuard do
       expect(Bot::Discord::Components).to receive(:send_to).with(
         log_channel,
         anything,
-        allowed_mentions: {parse: [], roles: []},
+        allowed_mentions: {parse: [], users: [author_id], roles: []},
         attachments: nil,
         subject: I18n.t("moderation.spam_protection.notification.title.notify_only")
       )
@@ -500,7 +501,7 @@ RSpec.describe Moderation::SpamGuard do
       expect(Bot::Discord::Components).to receive(:send_to).with(
         log_channel,
         anything,
-        hash_including(allowed_mentions: {parse: [], roles: []}, attachments: nil)
+        hash_including(allowed_mentions: {parse: [], users: [author_id], roles: []}, attachments: nil)
       )
 
       simulate_message(channel_id: 1, message_id: 1)

--- a/spec/plugins/moderation/image_scanning/verdict_executor_spec.rb
+++ b/spec/plugins/moderation/image_scanning/verdict_executor_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Moderation::ImageScanning::VerdictExecutor do
   let(:image_url) { "https://cdn/x.png" }
 
   let(:server) { double("server", id: server_id) }
-  let(:member) { double("member", id: member_id) }
+  let(:member) { double("member", id: member_id, mention: "<@#{member_id}>", username: "offender") }
   let(:message_channel) { double("message_channel", delete_message: nil) }
   let(:bot) { double("bot", channel: message_channel) }
 
@@ -116,7 +116,7 @@ RSpec.describe Moderation::ImageScanning::VerdictExecutor do
         hash_including(
           title: I18n.t("moderation.image_scanning.flag.title.flagged"),
           subject: "<@&#{staff_role_id}>: #{I18n.t("moderation.image_scanning.flag.title.flagged")}",
-          allowed_mentions: {parse: [], roles: [staff_role_id]}
+          allowed_mentions: {parse: [], users: [member_id], roles: [staff_role_id]}
         )
       ) do |_config, kwargs|
         io = kwargs[:image]
@@ -159,6 +159,14 @@ RSpec.describe Moderation::ImageScanning::VerdictExecutor do
 
       expect(Bot::ActivityLog).to have_received(:post) do |_config, kwargs|
         expect(kwargs[:body]).to include("<@&#{staff_role_id}>: ")
+      end
+    end
+
+    it "includes the offender's mention and username in the body" do
+      execute
+
+      expect(Bot::ActivityLog).to have_received(:post) do |_config, kwargs|
+        expect(kwargs[:body]).to include("<@#{member_id}> (offender)")
       end
     end
 
@@ -541,7 +549,7 @@ RSpec.describe Moderation::ImageScanning::VerdictExecutor do
 
       expect(Bot::ActivityLog).to have_received(:post).with(
         server_configuration,
-        hash_including(allowed_mentions: {parse: [], roles: []})
+        hash_including(allowed_mentions: {parse: [], users: [member_id], roles: []})
       )
     end
   end
@@ -554,7 +562,7 @@ RSpec.describe Moderation::ImageScanning::VerdictExecutor do
 
       expect(Bot::ActivityLog).to have_received(:post).with(
         server_configuration,
-        hash_including(allowed_mentions: {parse: [], roles: []})
+        hash_including(allowed_mentions: {parse: [], users: [member_id], roles: []})
       )
     end
 

--- a/spec/plugins/moderation/user_label_spec.rb
+++ b/spec/plugins/moderation/user_label_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Moderation::UserLabel do
+  let(:mention) { "<@123>" }
+  let(:username) { "someuser" }
+  let(:user) { double("user", mention:, username:) }
+
+  subject(:label) { described_class.for(user) }
+
+  it "combines the mention and the username" do
+    expect(label).to eq("<@123> (someuser)")
+  end
+end


### PR DESCRIPTION
Moderation log entries showed the offender as a bare mention, with all mentions suppressed. That has two problems.

- The suppressed mention is stripped from the message's `mentions` array. A client that never saw the user renders `@unknown-user`. A banned member sits in no client's member cache, so the entry loses the offender's identity.
- The mention carries no name. It is a live pointer, not a record of who was acted on.

Changes:

- `Moderation::UserLabel.for(user)` renders `mention (username)`. It is extracted from `MemberLog::ActivityEntry`, which already used that format for the moderator.
- Image scan flags, spam guard notices, the purge follow-up, the `/report-scam` log and the ban, kick and timeout logs all use the label.
- Those posts allow the offender's user mention, so the user object rides in the message payload and the mention always resolves. A member who can still see the log channel gets a real ping. After a ban or a kick, no ping is delivered.
- `Components.send_to` forwards the allowed users into the components v2 edit. That edit hardcoded `{parse: []}` and stripped the user again. Roles stay suppressed in the edit, because the plain-text subject message already pinged staff.
- The reported author is allowed in the `/report-scam` log. The reporter is not, because staff ran the command.

Privacy policy: the log-entry paragraph now states that the entry names the member by mention and username, and that the username is rendered into the message and not stored. Date bumped to August 12th, 2026.

Gates, local:

```
$ bundle exec rspec
2907 examples, 0 failures

$ bundle exec standardrb
(no output)

$ bundle exec rake active_record_doctor
(no output)

$ bundle exec undercover --compare origin/main
undercover: ✅ No coverage is missing in latest changes

$ bundle exec i18n-tasks missing
✓ Good job! No translations are missing.

$ bundle exec i18n-tasks check-normalized
✓ Well done! All data is normalized
```