### PR TITLE
Add a voice guide for user-facing copy and apply it

### DIFF
--- a/app/bot/commands/donate.rb
+++ b/app/bot/commands/donate.rb
@@ -4,7 +4,7 @@ module Bot
   module Commands
     class Donate < BaseCommand
       command_name :donate
-      description "Find out what it costs to run shrkbot and how you can support the project."
+      description "Show what it costs to run shrkbot and how to support it."
       register_in :global
 
       COSTS = <<~COSTS.strip

--- a/app/bot/commands/info.rb
+++ b/app/bot/commands/info.rb
@@ -4,7 +4,7 @@ module Bot
   module Commands
     class Info < BaseCommand
       command_name :info
-      description "Show information about shrkbot - its code, stack, and how to add it to your server."
+      description "Show shrkbot's tech stack, where its code lives, and how you can add it to your server."
       register_in :global
 
       MASCOT_PATH = Rails.root.join("app/assets/images/shrkbot-mascot.png")

--- a/app/components/lfg/setup_guide_card.rb
+++ b/app/components/lfg/setup_guide_card.rb
@@ -27,12 +27,9 @@ class Components::Lfg::SetupGuideCard < Components::Base
   end
 
   def body
-    div(class: "border-t border-border-subtle p-5") do
-      p(class: "text-sm text-text-secondary") { t(".intro") }
-      div(class: "mt-4 flex flex-col gap-4") do
-        item("at", t(".non_mentionable.title"), t(".non_mentionable.body"))
-        item("sliders", t(".visibility.title"), t(".visibility.body"))
-      end
+    div(class: "flex flex-col gap-4 border-t border-border-subtle p-5") do
+      item("at", t(".non_mentionable.title"), t(".non_mentionable.body"))
+      item("sliders", t(".visibility.title"), t(".visibility.body"))
     end
   end
 

--- a/app/components/moderation/image_scanning_form.rb
+++ b/app/components/moderation/image_scanning_form.rb
@@ -182,18 +182,15 @@ class Components::Moderation::ImageScanningForm < Components::Base
         class: "dropdown-menu grid gap-3 px-5 py-4",
         data: {dropdown_target: "menu"}
       ) do
-        explainer_line("cpu", t(".explainer.line_memory"))
-        explainer_line("check-square", t(".explainer.line_staff"))
-        explainer_line("fingerprint", t(".explainer.line_fingerprint"))
+        explainer_line(t(".explainer.line_memory"))
+        explainer_line(t(".explainer.line_staff"))
+        explainer_line(t(".explainer.line_fingerprint"))
       end
     end
   end
 
-  def explainer_line(icon, text)
-    p(class: "flex items-start gap-2.5 text-sm text-text-secondary") do
-      render Components::Icon.new(icon, class: "size-4 mt-0.5 text-text-muted flex-none")
-      span { text }
-    end
+  def explainer_line(text)
+    p(class: "text-sm text-text-secondary") { text }
   end
 
   def keyword_options

--- a/app/components/moderation/image_scanning_form.rb
+++ b/app/components/moderation/image_scanning_form.rb
@@ -179,18 +179,20 @@ class Components::Moderation::ImageScanningForm < Components::Base
         span(class: "text-sm font-semibold flex-1") { t(".explainer.title") }
       end
       div(
-        class: "dropdown-menu grid gap-3 px-5 py-4",
+        class: "dropdown-menu px-5 py-4",
         data: {dropdown_target: "menu"}
       ) do
-        explainer_line(t(".explainer.line_memory"))
-        explainer_line(t(".explainer.line_staff"))
-        explainer_line(t(".explainer.line_fingerprint"))
+        ol(class: "list-decimal list-outside space-y-2.5 pl-5 marker:text-text-muted") do
+          explainer_line(t(".explainer.line_memory"))
+          explainer_line(t(".explainer.line_staff"))
+          explainer_line(t(".explainer.line_fingerprint"))
+        end
       end
     end
   end
 
   def explainer_line(text)
-    p(class: "text-sm text-text-secondary") { text }
+    li(class: "text-sm text-text-secondary") { text }
   end
 
   def keyword_options

--- a/app/components/moderation/matching_explainer.rb
+++ b/app/components/moderation/matching_explainer.rb
@@ -20,10 +20,10 @@ class Components::Moderation::MatchingExplainer < Components::Base
           class: "dropdown-menu grid gap-3 px-5 py-4",
           data: {dropdown_target: "menu"}
         ) do
-          explainer_row("text-aa", t(".row_normalize"))
-          explainer_row("mask-happy", t(".row_lookalike"))
-          explainer_row("megaphone-slash", t(".row_spam"))
-          explainer_row("scan", t(".row_keywords"))
+          explainer_row(t(".row_normalize"))
+          explainer_row(t(".row_lookalike"))
+          explainer_row(t(".row_spam"))
+          explainer_row(t(".row_keywords"))
         end
       end
     end
@@ -31,10 +31,7 @@ class Components::Moderation::MatchingExplainer < Components::Base
 
   private
 
-  def explainer_row(icon, text)
-    p(class: "flex items-start gap-2.5 text-sm text-text-secondary") do
-      render Components::Icon.new(icon, class: "mt-0.5 size-4 flex-none text-text-muted")
-      span { text }
-    end
+  def explainer_row(text)
+    p(class: "text-sm text-text-secondary") { text }
   end
 end

--- a/app/components/moderation/matching_explainer.rb
+++ b/app/components/moderation/matching_explainer.rb
@@ -17,13 +17,15 @@ class Components::Moderation::MatchingExplainer < Components::Base
           span(class: "flex-1 text-sm font-semibold") { t(".title") }
         end
         div(
-          class: "dropdown-menu grid gap-3 px-5 py-4",
+          class: "dropdown-menu px-5 py-4",
           data: {dropdown_target: "menu"}
         ) do
-          explainer_row(t(".row_normalize"))
-          explainer_row(t(".row_lookalike"))
-          explainer_row(t(".row_spam"))
-          explainer_row(t(".row_keywords"))
+          ul(class: "list-['-'] list-outside space-y-2.5 pl-4 marker:text-text-muted") do
+            explainer_row(t(".row_normalize"))
+            explainer_row(t(".row_lookalike"))
+            explainer_row(t(".row_spam"))
+            explainer_row(t(".row_keywords"))
+          end
         end
       end
     end
@@ -32,6 +34,6 @@ class Components::Moderation::MatchingExplainer < Components::Base
   private
 
   def explainer_row(text)
-    p(class: "text-sm text-text-secondary") { text }
+    li(class: "pl-1 text-sm text-text-secondary") { text }
   end
 end

--- a/app/components/moderation/spam_protection_form.rb
+++ b/app/components/moderation/spam_protection_form.rb
@@ -58,7 +58,6 @@ class Components::Moderation::SpamProtectionForm < Components::Base
           unit: t(".detection.trigger_threshold.seconds_unit")
         )
       end
-      p(class: "text-xs text-text-muted mt-1.5") { t(".detection.trigger_threshold.help") }
     end
   end
 

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -57,9 +57,9 @@ en:
       servers: Servers
     cookie_notice:
       dismiss: Oh, nice!
-      message: We only set technical cookies to make the site work. No tracking, analytics,
-        or anything else from a third party. We will remember that you've seen this,
-        though - with a cookie, of course. :)
+      message: shrkbot only sets technical cookies to make the site work. No tracking,
+        analytics, or anything else from a third party. It will remember that you've
+        seen this, though - with a cookie, of course. :)
     copyable_tokens:
       copied: Copied!
       copy_failed: Copy failed
@@ -77,7 +77,7 @@ en:
         placeholder: Choose channels
       defaults_card:
         cooldown:
-          default: 300 seconds, which is 5 minutes
+          default: 300 seconds (5 minutes)
           help: How long a member must wait between posts. Set to 0 to disable the
             cooldown.
           label: Cooldown
@@ -90,10 +90,9 @@ en:
         help: Server-wide Looking for Game settings. The per-role cards below add
           extra gates on top of these.
         lifetime:
-          default: 360 minutes, which is 6 hours
-          help: The duration the "Looking for Game" post remains visible after it
-            starts. For scheduled posts, this time only starts with the actual session,
-            not during the "gathering interest" period.
+          default: 360 minutes (6 hours)
+          help: How long the "Looking for Game" post stays visible. For scheduled
+            posts, the clock starts with the session, not while it gathers interest.
           label: Post lifetime
           unit: minutes
         min_days:
@@ -145,17 +144,15 @@ en:
           Only configured roles appear in the command.
         label: Pingable roles
       setup_guide_card:
-        intro: 'Neither is required, but we recommend both for the smoothest Looking
-          for Game experience:'
         non_mentionable:
           body: In Server Settings, turn off "Allow anyone to @mention this role"
             for every role you list below. shrkbot pings them for members, so you
             can switch off general-purpose role pings entirely.
           title: Make your LFG roles non-mentionable
-        subtitle: Two optional Discord settings we recommend
+        subtitle: Two optional but recommended Discord settings
         title: Recommended setup
         visibility:
-          body: In Server Settings - Integrations - shrkbot, limit the /lfg command
+          body: In Server Settings -> Integrations -> shrkbot, limit the /lfg command
             to the channels and roles that should use it. That's your first line of
             control over who posts.
           title: Restrict who can run /lfg
@@ -256,7 +253,7 @@ en:
         row_keywords: Custom scam keywords keep digits, so entries like 50 giveaway
           match.
         row_lookalike: Stylized and lookalike characters are folded to their plain
-          form (ⓕⓡⓔⓔ, ｆｒｅｅ → free), so disguises don't help.
+          form (ⓕⓡⓔⓔ, ｆｒｅｅ -> free), so disguises don't help.
         row_normalize: 'Before comparing any text, shrkbot normalizes it: case, punctuation,
           extra spacing and invisible characters are ignored - FREE N-I-T-R-O!! and
           free nitro are the same text.'
@@ -292,9 +289,7 @@ en:
             label: Also match symbol-only messages
             recommended: 'Recommended default: Off'
           trigger_threshold:
-            channels_unit: channels
-            help: Triggers when the same message appears in 4 different channels within
-              15 seconds.
+            channels_unit: different channels
             label: Trigger threshold
             seconds_unit: seconds
             within: within
@@ -308,7 +303,7 @@ en:
             label: Also punish the sender
       staff_ping_card:
         help: Mention the staff role at the top of every moderation log entry. Turn
-          it off for a quieter log staff check on their own.
+          it off for a quieter log that staff can check on their own.
         label: Ping staff on alerts
       staff_role_card:
         help: Shared by every Moderation sub-plugin, and exempt from spam detection.
@@ -323,8 +318,8 @@ en:
         placeholder: Pick a role…
         staff_permission_warning_body: It doesn't have the Manage Messages permission,
           so its members won't see staff-only commands like Report as scam. Give the
-          role Manage Messages, or grant it access under Server Settings → Integrations
-          → shrkbot.
+          role Manage Messages, or grant it access under Server Settings -> Integrations
+          -> shrkbot.
         staff_permission_warning_bold: This role can't see staff commands.
       sub_plugin_directory:
         eyebrow: Sub-plugins
@@ -404,9 +399,9 @@ en:
           label: Force reminder delivery via DM
     roles:
       config_form:
-        bot_at_bottom: shrkbot can only assign roles below its own, and it looks like
-          its role is at the very bottom. Please move shrkbot's role up if you want
-          it to be able to assign roles.
+        bot_at_bottom: shrkbot can only assign roles below its own, and its role sits
+          at the very bottom. Move it up in Server Settings so shrkbot can assign
+          roles.
         channel:
           help: Each role set posts here unless it has its own channel override.
           label: Default channel for role menus
@@ -501,8 +496,8 @@ en:
           usa: USA
           ussr: USSR
           winner: Winner
-        help: Anything in braces is replaced when the message is built. A token we
-          do not know is left exactly as you typed it. Click a token to copy it.
+        help: Anything in braces is replaced when the message is built. A token shrkbot
+          doesn't know is left exactly as you typed it. Click a token to copy it.
         label: Tokens
         tokens:
           game_id: The game's code on twilight-struggle.com, such as G372.
@@ -630,7 +625,7 @@ en:
       saved: Welcomes settings saved.
   sessions:
     failed: Sign-in failed or was canceled.
-    reauth_failed: We couldn't refresh your Discord sign-in. Please sign in again.
+    reauth_failed: Your Discord sign-in couldn't be refreshed. Please sign in again.
     signed_in: Signed in as %{name}.
     signed_out: Signed out.
   views:
@@ -697,8 +692,8 @@ en:
     home:
       add_to_server: Sign in to add shrkbot to your servers
       lede: 'shrkbot provides tools where Discord doesn''t, and gets out of your way
-        otherwise. Your members'' privacy is a priority and a guarantee: moderation
-        happens in memory, your messages are never stored. Manage everything from
+        otherwise. Your members'' privacy is guaranteed, and it stays that way: moderation
+        happens in memory, and your messages are never stored. Manage everything from
         one dashboard, and let shrkbot handle the rest.'
       more_plugins: More plugins are on the way.
       plugins:
@@ -718,8 +713,7 @@ en:
       tagline_accent: With teeth when needed.
       view_source: View on GitHub
     reauth:
-      body: Your Discord sign-in expired. Please stand by - we're refreshing it for
-        you.
+      body: Your Discord sign-in expired. Please stand by - this only takes a moment.
       continue: Continue
       title: Signing you back in
     servers:
@@ -749,7 +743,8 @@ en:
         empty_body: You need Manage Server permissions and shrkbot must be present.
           Invite it to get started.
         empty_title: shrkbot isn't in any of your servers yet
-        error: We couldn't reach Discord to load your servers. Try again in a moment.
+        error: shrkbot couldn't reach Discord to load your servers. Try again in a
+          moment.
         invite: Invite shrkbot
         members:
           one: "%{formatted} member"
@@ -852,7 +847,7 @@ en:
           description: Tournaments pushed to shrkbot by twilight-struggle.com. Subscribe
             to the ones you want posted in this server.
           empty_archived: Nothing has been archived.
-          empty_body: twilight-struggle.com has not sent us any tournaments yet. They
+          empty_body: twilight-struggle.com has not sent any tournaments yet. They
             appear here as soon as it does.
           empty_title: No tournaments yet
           gate_message: Enable Twilight Struggle to subscribe this server to tournaments.

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,6 +59,7 @@ not documentation — nothing in it is maintained.
 
 ## Cross-cutting
 
+- [voice.md](voice.md) — how shrkbot's copy sounds: the three surfaces and their registers, the rules derived from the Discord strings, and the weak-to-better ledger every rewrite adds to.
 - [privacy.md](privacy.md) — what personal data is stored, the two erasure paths (`Ops::Users::Destroy` and `Ops::ServerConfiguration::Destroy`), and the same-chunk obligations for any change that stores new data.
 
 ## Public API docs

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -219,8 +219,10 @@ An icon has to encode something the text does not already carry: state
 copy names outright (`at` beside "Allow anyone to @mention this role"). An icon
 that pictures a noun the sentence already said is decoration, and a column of
 them down a list of one-line facts reads as a generated feature list. The
-explainer dropdowns on the Server Shield pages are plain sentences for that
-reason.
+explainer dropdowns on the Server Shield pages use real lists instead, and the
+list type carries the meaning: `ol` on the image-scanning explainer, whose rows
+are the pipeline in order, and dash-marked `ul` on the matching explainer, whose
+rows are parallel facts. Number a list only where the order is real.
 
 ## Where it lives
 

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -214,6 +214,14 @@ duplicated class strings:
 `Components::Icon` wraps Phosphor; names not in Phosphor (the `megaphone-slash`
 sub-plugin glyph) are served from its `CUSTOM_GLYPHS` map of inline SVGs.
 
+An icon has to encode something the text does not already carry: state
+(`caret-down` on a dropdown summary), identity (a plugin tile), or a symbol the
+copy names outright (`at` beside "Allow anyone to @mention this role"). An icon
+that pictures a noun the sentence already said is decoration, and a column of
+them down a list of one-line facts reads as a generated feature list. The
+explainer dropdowns on the Server Shield pages are plain sentences for that
+reason.
+
 ## Where it lives
 
 - `app/assets/tailwind/` — the stylesheet, split into focused partials that

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -1,0 +1,229 @@
+# Voice
+
+How shrkbot's copy sounds. Read this before writing or changing any user-facing
+string: Discord messages and command descriptions, website copy, and PR
+descriptions.
+
+Rules are derived from the Discord copy already in the repo, which is the
+surface that has had the most correction passes. Examples are real strings, not
+invented ones.
+
+## The three surfaces
+
+Each has a different reader, so each has a different register. Copy that fits one
+surface is usually wrong on another.
+
+**Discord** - largely non-technical readers, mid-task, often on a phone. The
+least technical surface and the cleanest one. Say the minimum that answers "what
+happened and what do I do now". Detail the reader did not ask for is noise.
+
+**Website** - readers who can set up a Discord bot but are not software
+engineers. This is the surface people judge the project by, so the prose has to
+be clean. Technical, but no engineering vocabulary that a competent server admin
+would have to look up.
+
+**PR descriptions** - written for software engineers, usually exactly one
+reader. The most technical surface, and the one where an awkward sentence costs
+least. Optimise for a reviewer making a decision.
+
+## Rules for every surface
+
+**State what happened, never that it succeeded.**
+
+```
+Roles updated.
+Timeout cleared for %{user}.
+```
+
+No "Successfully", no "has been". If nothing went wrong, the outcome is the
+message.
+
+**Add the consequence when the reader would otherwise have to ask.**
+
+```
+Confirmed as a scam by %{actor} - the bot will remember this image.
+The member was kicked; a kick can't be undone.
+```
+
+**Every failure names a cause or a fix.**
+
+```
+I couldn't understand that duration. Try something like `1d2h30m`.
+Could not post the role message - check the channel.
+```
+
+**No internals.** No error codes, class names, "validation failed", "invalid
+input", "an error occurred". The reader cannot act on any of it.
+
+**Second person for what the reader must do, and for the one thing you want them
+to do.** Use it sparingly. If every clause is "you", none of them stand out.
+
+```
+You need the staff role or the Manage Messages permission to do that.
+Show shrkbot's tech stack, where its code lives, and how you can add it to your server.
+```
+
+**The joiner is ` - `.** Never an em dash, anywhere, on any surface.
+
+**ASCII over glyphs.** `->` for a UI path or a transformation, `:)` over an
+emoji. The design guidelines lean the same way. The one deliberate exception is
+the `♥` in the site footer.
+
+```
+In Server Settings -> Integrations -> shrkbot, limit the /lfg command to the channels and roles that should use it.
+Stylized and lookalike characters are folded to their plain form (ⓕⓡⓔⓔ, ｆｒｅｅ -> free), so disguises don't help.
+```
+
+**Never "we".** shrkbot is one developer. Name shrkbot when something acts, use
+the passive when no actor matters, and use "I" only where the developer speaks
+personally, as on the bespoke-plugins page. "We" is correct in exactly one case:
+when it means the developer and the reader together.
+
+```
+A token shrkbot doesn't know is left exactly as you typed it.
+Two optional but recommended Discord settings
+Let me know what your general idea is, and we'll figure out together if and how shrkbot can work for you.
+```
+
+**Say nothing the controls already say.** A form field that reads
+`4 different channels within 15 seconds` needs no help text repeating it, and
+help text that hardcodes a default goes stale the moment a server changes it.
+Delete it rather than restate it.
+
+**Don't restate a heading in the text under it.** A card subtitled "Two optional
+but recommended Discord settings" does not open with "Neither is required, but
+we recommend both".
+
+**Offer, don't instruct, when the reader has a choice.** "a quieter log that
+staff can check on their own" leaves it optional. Dropping "can" turns the same
+sentence into an order.
+
+**Interpolate the real number or name.** Never "some", "several", "a while".
+
+```
+the account is only %{days} days old
+matched %{count} custom keywords
+```
+
+**Apologise only for harm the bot actually caused.** Routine failure is not
+harm. There is exactly one apology in the codebase, and it is for a member the
+bot punished by mistake:
+
+```
+Sorry - you were automatically moderated in %{server} by mistake, and a staff member has reversed it.
+```
+
+**The verb must match what the reader actually gets.** A command that links to
+the repository shows where the code lives. It does not show the code.
+
+## Rules for Discord
+
+**One sentence.** A second sentence earns its place only as a constraint, an
+example, or a consequence.
+
+```
+Cancel one of your reminders.
+Set a reminder to be sent to you after a delay (e.g. 1d2h30m).
+```
+
+**"I" only when the bot itself failed.** Everywhere else the bot is "shrkbot" or
+the sentence is passive. The bot never narrates its own successes in first
+person.
+
+```
+I couldn't reverse that - I may be missing permissions.
+```
+
+**Fragments that compose into a larger sentence stay lowercase and take no
+terminal period.** Check how the string is interpolated before you punctuate it.
+
+```
+on cooldown (%{time} left)
+that role isn't set up for Looking for Game
+```
+
+**Command descriptions lead with an imperative verb.** Constraints are appended
+as a fragment.
+
+```
+List your active reminders.
+Broadcast a message to the owner of every server shrkbot is in. Bot owner only.
+```
+
+## Rules for the website
+
+Everything under "every surface" applies. Two more, both from settings pages:
+
+**Sibling help texts share a shape.** If the fields around yours all open "How
+long a member must...", yours does too. A single field that switches to a
+noun-phrase register reads as though someone else wrote it.
+
+**Warn before the setting, and say what it costs.** Put the limitation ahead of
+the control it applies to, and name the trade-off rather than grading it.
+
+```
+1 is aggressive - a single matched word can delete an image. 2 or more keeps one stray word from triggering.
+Acts only on unmistakable scams. Fewest false positives; more scams slip through.
+A ban is permanent until a mod lifts it, and shrkbot can't undo it.
+```
+
+## Rules for PR descriptions
+
+As short as possible while carrying every fact a reviewer needs to decide. Cut
+anything the diff already says. Applies to every repository, not only this one.
+
+**Default budget is 15 lines.** Going over is fine when the change earns it, but
+then the body opens with one line saying why it is long. The overrun is a
+deliberate act, not drift.
+
+**Controlled English** (the writing rules of ASD-STE100, without its restricted
+dictionary): one idea per sentence; active voice; simple present or simple past;
+keep articles and full sentences; one term for one thing, never a synonym for
+variety; no gerund used as a verb; noun clusters of three words maximum;
+procedural sentences of 20 words or fewer, descriptive 25 or fewer; write a
+warning or a limitation before the thing it applies to.
+
+**Cut the patterns that bite in a PR body:** importance puffery, `-ing` clauses
+pretending to explain, fake-strong verbs, binary contrasts, colon reveals,
+summary-recap endings, decorative em dashes.
+
+**Show, do not claim.** Paste the failing command, the error line, the test
+counts, the measured numbers. A reviewer should be able to check every claim
+without trusting the author.
+
+## Weak to better
+
+Strings that were rewritten, and the fault each one had. Add to this list
+whenever copy is corrected - the pairs teach more than the rules do.
+
+| Weak | Better | Fault |
+| --- | --- | --- |
+| `Show information about shrkbot - its code, stack, and how to add it to your server.` | `Show shrkbot's tech stack, where its code lives, and how you can add it to your server.` | "Show information about" is a filler verb phrase, and the command shows a link to the repository rather than the code. |
+| `Find out what it costs to run shrkbot and how you can support the project.` | `Show what it costs to run shrkbot and how to support it.` | "Find out what it costs" says what "Show what it costs" says in less. Donating is a soft sell, so it keeps the lighter "how to support it" while the invite string above keeps the second person. |
+| `Triggers when the same message appears in 4 different channels within 15 seconds.` | Deleted. The unit label became `different channels`. | The two steppers beside it are the real controls. The sentence restated them and hardcoded their defaults, so it would have lied as soon as a server changed either one. |
+| `Neither is required, but we recommend both for the smoothest Looking for Game experience:` | Deleted. | It restated the card's own subtitle, and "the smoothest ... experience" is puffery. |
+| `Two optional Discord settings we recommend` | `Two optional but recommended Discord settings` | "We" is one developer. The compound modifier takes no internal commas. |
+| `shrkbot can only assign roles below its own, and it looks like its role is at the very bottom. Please move shrkbot's role up if you want it to be able to assign roles.` | `shrkbot can only assign roles below its own, and its role sits at the very bottom. Move it up in Server Settings so shrkbot can assign roles.` | `bot_at_bottom?` is a definite position check, so "it looks like" hedged on a known fact. The old second sentence restated the first. |
+| `Turn it off for a quieter log staff check on their own.` | `Turn it off for a quieter log that staff can check on their own.` | Missing relative pronoun made a garden path ("log-staff-check"). "Can" keeps it an option rather than an order. |
+| `300 seconds, which is 5 minutes` | `300 seconds (5 minutes)` | "Which is" is filler around a conversion. |
+| `The duration the "Looking for Game" post remains visible after it starts. For scheduled posts, this time only starts with the actual session, not during the "gathering interest" period.` | `How long the "Looking for Game" post stays visible. For scheduled posts, the clock starts with the session, not while it gathers interest.` | Its two sibling fields both open "How long a member must...", so the noun-phrase register was the odd one out. Second sentence ran 24 words. |
+| `We couldn't reach Discord to load your servers.` | `shrkbot couldn't reach Discord to load your servers.` | Six strings across the site said "we". Each took one of three fixes: name shrkbot where something acts, use the passive where no actor matters (`Your Discord sign-in couldn't be refreshed.`), or delete the clause where the heading already said it (`Please stand by - this only takes a moment.`, under a page titled "Signing you back in"). |
+| `Your members' privacy is a priority and a guarantee: moderation happens in memory, your messages are never stored.` | `Your members' privacy is guaranteed, and it stays that way: moderation happens in memory, and your messages are never stored.` | A guarantee outranks a priority, so leading with the weaker word read as a hedge on the stronger one. The rewrite keeps the ongoing commitment without discounting the promise. |
+
+## Kept on purpose
+
+Copy that breaks a rule above and stays. Recorded so it does not get "fixed"
+later.
+
+| Copy | Rule it breaks | Why it stays |
+| --- | --- | --- |
+| `Your server's aegis: automated moderation beyond Discord's AutoMod.` | Colon reveal, and a word some readers will look up. | The personality is the point, and no plainer wording carried it. Deliberate. |
+| `...for you it lives right alongside the functionality you know and love.` | Stock phrase. | The bespoke-plugins page is written in the developer's own voice, first person throughout. It is the one page where personality outranks the rules. |
+| `♥` in the site footer | ASCII over glyphs. | One glyph, one place, load-bearing for the line it sits in. |
+
+## Standing rule
+
+Copy changes land in this file in the same chunk that makes them. A rewritten
+string adds a row to "Weak to better"; a new rule that came out of the rewrite
+adds itself to the right section. Reviewing copy and then losing the reasoning is
+how the same correction gets made twice.

--- a/spec/components/cookie_notice_spec.rb
+++ b/spec/components/cookie_notice_spec.rb
@@ -16,6 +16,6 @@ RSpec.describe Components::CookieNotice do
   end
 
   it "shows the no-tracking message and dismiss label" do
-    expect(html).to include("only set technical cookies").and include("Oh, nice!")
+    expect(html).to include("only sets technical cookies").and include("Oh, nice!")
   end
 end


### PR DESCRIPTION
Adds `docs/voice.md`, a standard for user-facing copy, and applies it.

The Discord strings already follow a consistent register after many correction passes, but the rules behind them were written down nowhere. The guide derives its rules from those strings rather than importing an external style guide. It covers three surfaces with different readers: Discord, the website, and PR descriptions.

Copy changes:

- `spam_protection_form` help text stated "4 different channels within 15 seconds" as a rule. Those are the defaults of two live steppers (`channel_threshold` 2-500, `window_seconds` 1-60), so the text lied as soon as a server changed either one. Deleted, and the unit label now reads `different channels` so the row says it itself.
- Six strings said "we". shrkbot has one developer.
- Three notations were in use for one Discord menu path: ` - `, `->`, `→`. All `->` now.
- `bot_at_bottom` hedged with "it looks like" on a definite position check, then repeated itself.
- Two command descriptions led with filler verbs. One promised the code where it links to the repository.

- The Server Shield explainer dropdowns lost their per-row icons. Each pictured a noun its own sentence already said (`cpu` for "reads image text in memory"). The `caret-down` on each summary stays; it encodes open/closed state.

`bundle exec rspec`: 2907 examples, 0 failures. standardrb, active_record_doctor, i18n-tasks missing + check-normalized, and undercover are clean.
