### PR TITLE
Serve the preview guild under its own /preview routes

### DIFF
--- a/app/components/app_shell.rb
+++ b/app/components/app_shell.rb
@@ -84,7 +84,7 @@ class Components::AppShell < Components::Base
   def switcher_row(server)
     current = server.id == @current_server.id
     tone = current ? "bg-accent-soft hover:bg-accent-soft" : "hover:bg-surface-sunken"
-    a(href: server_path(server.id), class: "flex items-center gap-3 px-3 py-2 text-left transition-colors #{tone}") do
+    a(href: dashboard_path_for(server), class: "flex items-center gap-3 px-3 py-2 text-left transition-colors #{tone}") do
       render Components::ServerAvatar.new(server:, size: :md)
       div(class: "min-w-0 flex-1") do
         p(class: "truncate text-sm font-semibold") { server.name }
@@ -92,6 +92,10 @@ class Components::AppShell < Components::Base
       end
       render Components::Icon.new("check", class: "size-4 flex-none text-accent") if current
     end
+  end
+
+  def dashboard_path_for(server)
+    PluginPaths.dashboard_for(server.id)
   end
 
   def wordmark

--- a/app/components/config_page.rb
+++ b/app/components/config_page.rb
@@ -34,7 +34,7 @@ class Components::ConfigPage < Components::Base
   def breadcrumb_crumbs
     crumbs = [
       {label: t(".servers"), href: servers_path},
-      {label: @server_configuration.name || t(".dashboard"), href: server_path(@server_configuration.discord_id)}
+      {label: @server_configuration.name || t(".dashboard"), href: PluginPaths.dashboard_for(@server_configuration.discord_id)}
     ]
     crumbs << @parent_crumb if @parent_crumb
     crumbs << {label: @header.title}

--- a/app/components/moderation/sub_plugin_directory.rb
+++ b/app/components/moderation/sub_plugin_directory.rb
@@ -14,7 +14,7 @@ class Components::Moderation::SubPluginDirectory < Components::Base
       div(class: "flex flex-col gap-3") do
         @context.sub_plugin_rows.each do |row|
           render Components::Moderation::SubPluginRow.new(
-            server_id: @config.discord_id,
+            server_configuration: @config,
             key: row.key,
             name: row.name,
             description: row.description,

--- a/app/components/moderation/sub_plugin_row.rb
+++ b/app/components/moderation/sub_plugin_row.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Components::Moderation::SubPluginRow < Components::Base
-  include Components::PluginNav
-
   STATUS_VARIANTS = {
     enabled: :success,
     needs_setup: :warning,
@@ -18,8 +16,8 @@ class Components::Moderation::SubPluginRow < Components::Base
     "#{key}-overview-toggle-form"
   end
 
-  def initialize(server_id:, key:, name:, description:, enabled:, configured:, settings:, group_enabled:)
-    @server_id = server_id
+  def initialize(server_configuration:, key:, name:, description:, enabled:, configured:, settings:, group_enabled:)
+    @config = server_configuration
     @key = key
     @name = name
     @description = description
@@ -80,7 +78,7 @@ class Components::Moderation::SubPluginRow < Components::Base
   end
 
   def sub_path
-    plugin_config_path(@server_id, @key)
+    PluginPaths.for(@config, @key)
   end
 
   def toggle_control

--- a/app/components/plugin_nav.rb
+++ b/app/components/plugin_nav.rb
@@ -16,18 +16,4 @@ module Components::PluginNav
   def plugin_icon(key)
     ICONS.fetch(key.to_sym)
   end
-
-  def plugin_config_path(server_id, key)
-    case key.to_sym
-    when :roles then server_roles_path(server_id)
-    when :welcomes then server_welcomes_path(server_id)
-    when :logging then server_logging_path(server_id)
-    when :reminders then server_reminders_path(server_id)
-    when :moderation then server_moderation_path(server_id)
-    when :spam_protection then server_spam_protection_path(server_id)
-    when :image_scanning then server_image_scanning_path(server_id)
-    when :lfg then server_lfg_path(server_id)
-    when :twilight_struggle then server_twilight_struggle_path(server_id)
-    end
-  end
 end

--- a/app/components/plugin_row.rb
+++ b/app/components/plugin_row.rb
@@ -9,8 +9,8 @@ class Components::PluginRow < Components::Base
     disabled: :neutral
   }.freeze
 
-  def initialize(server_id:, row:)
-    @server_id = server_id
+  def initialize(server_configuration:, row:)
+    @config = server_configuration
     @row = row
   end
 
@@ -54,7 +54,7 @@ class Components::PluginRow < Components::Base
         name: :enabled,
         checked: @row.enabled,
         label: t(".toggle", plugin: name),
-        url: server_plugin_path(@server_id, @row.key),
+        url: server_plugin_path(@config.discord_id, @row.key),
         submit_on_change: true
       )
     end
@@ -114,6 +114,6 @@ class Components::PluginRow < Components::Base
   end
 
   def configure_href
-    plugin_config_path(@server_id, @row.key) || "#"
+    PluginPaths.for(@config, @row.key)
   end
 end

--- a/app/components/plugin_sidebar.rb
+++ b/app/components/plugin_sidebar.rb
@@ -40,7 +40,7 @@ class Components::PluginSidebar < Components::Base
   end
 
   def items
-    all_rows.select { |row| plugin_config_path(@config.discord_id, row.key) }
+    all_rows.select { |row| PluginPaths.for(@config, row.key) }
   end
 
   def sub_plugin?(key)
@@ -65,7 +65,7 @@ class Components::PluginSidebar < Components::Base
   def group_items
     overview = {
       label: t(".overview"),
-      href: server_moderation_path(@config.discord_id),
+      href: PluginPaths.for(@config, :moderation),
       active: @active_key == :moderation,
       status: nil
     }
@@ -76,7 +76,7 @@ class Components::PluginSidebar < Components::Base
     row = all_rows.find { |candidate| candidate.key == key }
     {
       label: PluginCatalog.find(key).name,
-      href: plugin_config_path(@config.discord_id, key),
+      href: PluginPaths.for(@config, key),
       active: @active_key == key,
       status: sub_status(row)
     }
@@ -90,7 +90,7 @@ class Components::PluginSidebar < Components::Base
 
   def back_link
     a(
-      href: server_path(@config.discord_id),
+      href: PluginPaths.dashboard_for(@config.discord_id),
       class: "group flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors hover:bg-surface-card"
     ) do
       render Components::Icon.new("arrow-left", class: "size-4 flex-none text-text-muted")
@@ -102,7 +102,7 @@ class Components::PluginSidebar < Components::Base
     active = row.key == @active_key
     tone = active ? "bg-accent-soft font-semibold text-accent-soft-fg" : "text-text-secondary hover:bg-surface-card"
     a(
-      href: plugin_config_path(@config.discord_id, row.key),
+      href: PluginPaths.for(@config, row.key),
       aria_current: ("page" if active),
       class: "flex items-center gap-2.5 rounded-md px-2.5 py-2 transition-colors #{tone}"
     ) do

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  include EstablishesPreviewIdentity
+
   allow_browser versions: :modern
   stale_when_importmap_changes
 

--- a/app/controllers/concerns/establishes_preview_identity.rb
+++ b/app/controllers/concerns/establishes_preview_identity.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module EstablishesPreviewIdentity
+  extend ActiveSupport::Concern
+
+  included do
+    prepend_before_action :establish_preview_identity
+  end
+
+  private
+
+  def establish_preview_identity
+    return unless params[:preview].present?
+    return if current_user
+
+    session[:user_id] = Ops::Users::Previews::Ensure.call.value.id
+    session[:preview_identity] = true
+  end
+end

--- a/app/controllers/concerns/requires_manageable_server.rb
+++ b/app/controllers/concerns/requires_manageable_server.rb
@@ -8,6 +8,7 @@ module RequiresManageableServer
 
   included do
     before_action :require_manageable_server
+    before_action :block_preview_writes
     before_action :require_plugin_access
     helper_method :server_switcher, :plugin_access
   end
@@ -15,10 +16,24 @@ module RequiresManageableServer
   private
 
   def require_manageable_server
-    @server_configuration = ServerConfiguration.find_by(discord_id: params[:server_id])
-    return if @server_configuration && visible_now?(params[:server_id])
+    @server_configuration = resolve_server_configuration
+    return if @server_configuration && (preview_request? || visible_now?(params[:server_id]))
 
     redirect_to servers_path, alert: t("servers.not_found")
+  end
+
+  def resolve_server_configuration
+    if preview_request?
+      ServerConfiguration.previews.find_by(discord_id: PreviewData.guild[:discord_id])
+    else
+      ServerConfiguration.real.find_by(discord_id: params[:server_id])
+    end
+  end
+
+  def block_preview_writes
+    return if request.get? || !@server_configuration.preview?
+
+    redirect_back fallback_location: preview_path, alert: t("servers.preview_read_only")
   end
 
   def require_plugin_access
@@ -37,8 +52,16 @@ module RequiresManageableServer
 
   def server_switcher
     @server_switcher ||= CachedDashboard.for(
-      discord_id: params[:server_id].to_i,
-      manageable_ids: visible_server_ids
+      discord_id: switcher_discord_id,
+      manageable_ids: switcher_manageable_ids
     )
+  end
+
+  def switcher_discord_id
+    preview_request? ? @server_configuration.discord_id : params[:server_id].to_i
+  end
+
+  def switcher_manageable_ids
+    preview_request? ? [@server_configuration.discord_id] : visible_server_ids
   end
 end

--- a/app/controllers/concerns/sets_visible_servers.rb
+++ b/app/controllers/concerns/sets_visible_servers.rb
@@ -9,12 +9,19 @@ module SetsVisibleServers
   private
 
   def visible_servers
-    @visible_servers ||= begin
-      servers = VisibleServers.for(session[:discord_token], current_user.discord_id)
-      remember_server_access(servers)
-      session.delete(:reauth_attempted)
-      servers
-    end
+    @visible_servers ||=
+      if preview_request?
+        [PreviewData.demo_guild]
+      else
+        servers = VisibleServers.for(session[:discord_token], current_user.discord_id)
+        remember_server_access(servers)
+        session.delete(:reauth_attempted)
+        servers
+      end
+  end
+
+  def preview_request?
+    params[:preview].present?
   end
 
   def remember_server_access(servers)

--- a/app/controllers/previews_controller.rb
+++ b/app/controllers/previews_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class PreviewsController < ApplicationController
+  def show
+    render Views::Servers::Show.new(
+      server: PreviewData.demo_guild,
+      server_configuration:,
+      plugins: PluginStatus.rows(server_configuration, access: plugin_access),
+      user: current_user,
+      servers: [PreviewData.demo_guild],
+      plugin_counts: PluginActivation.enabled_counts_for([server_configuration.discord_id])
+    )
+  end
+
+  def destroy
+    session.delete(:user_id) if session.delete(:preview_identity)
+    redirect_to root_path
+  end
+
+  private
+
+  def server_configuration
+    @server_configuration ||= ServerConfiguration.previews.find_by!(discord_id: PreviewData.guild[:discord_id])
+  end
+
+  def plugin_access
+    @plugin_access ||= PluginAccess.new(user: current_user, server_configuration:, manages_server: true)
+  end
+end

--- a/app/controllers/servers/roles_controller.rb
+++ b/app/controllers/servers/roles_controller.rb
@@ -6,6 +6,8 @@ class Servers::RolesController < ApplicationController
   include VerifiesGuildChannels
 
   def show
+    preload_role_sets
+
     render Views::Servers::Roles::Show.new(
       server_configuration: @server_configuration,
       user: current_user,
@@ -37,6 +39,13 @@ class Servers::RolesController < ApplicationController
   end
 
   private
+
+  def preload_role_sets
+    ActiveRecord::Associations::Preloader.new(
+      records: [@server_configuration.role_setting],
+      associations: {role_sets: :assignable_roles}
+    ).call
+  end
 
   def submitted_sets
     raw = roles_params[:role_sets]

--- a/app/models/preview_data.rb
+++ b/app/models/preview_data.rb
@@ -8,6 +8,21 @@ class PreviewData
       data[:guild]
     end
 
+    def user
+      data[:user]
+    end
+
+    def demo_guild
+      @demo_guild ||= Bot::Discord::Guild.new(
+        id: guild[:discord_id],
+        name: guild[:name],
+        owner: true,
+        permissions: 0,
+        icon: guild[:icon_hash],
+        member_count: guild[:member_count]
+      )
+    end
+
     def channels
       @channels ||= data[:channels].map { |channel| channel_attributes(channel) }
     end

--- a/app/operations/users/previews/ensure.rb
+++ b/app/operations/users/previews/ensure.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Ops
+  module Users
+    module Previews
+      class Ensure < ApplicationOperation
+        def call
+          user = ::User.find_or_create_by!(discord_id: PreviewData.user[:discord_id]) do |record|
+            record.username = PreviewData.user[:username]
+            record.display_name = PreviewData.user[:display_name]
+          end
+          ok(user)
+        end
+      end
+    end
+  end
+end

--- a/app/presenters/plugin_paths.rb
+++ b/app/presenters/plugin_paths.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class PluginPaths
+  def self.dashboard_for(discord_id)
+    helpers = Rails.application.routes.url_helpers
+    discord_id.negative? ? helpers.preview_path : helpers.server_path(discord_id)
+  end
+
+  def self.for(server_configuration, key)
+    raise ArgumentError, "unknown plugin key #{key.inspect}" unless known?(key)
+
+    helpers = Rails.application.routes.url_helpers
+    if server_configuration.preview?
+      raise ArgumentError, "no preview route for bespoke plugin #{key.inspect}" if bespoke?(key)
+
+      helpers.public_send("preview_#{key}_path")
+    else
+      helpers.public_send("server_#{key}_path", server_configuration.discord_id)
+    end
+  end
+
+  private_class_method def self.known?(key)
+    PluginCatalog.find(key).present? || PluginCatalog::GLOBAL_KEYS.include?(key.to_sym)
+  end
+
+  private_class_method def self.bespoke?(key)
+    PluginCatalog.find(key)&.bespoke || false
+  end
+end

--- a/app/views/servers/image_scanning/show.rb
+++ b/app/views/servers/image_scanning/show.rb
@@ -11,10 +11,6 @@ class Views::Servers::ImageScanning::Show < Views::Servers::Moderation::SubPlugi
     "scan"
   end
 
-  def url
-    server_image_scanning_path(@config.discord_id)
-  end
-
   def enable_field
     "image_scanning[enabled]"
   end

--- a/app/views/servers/lfg/show.rb
+++ b/app/views/servers/lfg/show.rb
@@ -16,7 +16,7 @@ class Views::Servers::Lfg::Show < Views::Base
           description: t(".description")
         ),
         server_configuration: @config,
-        url: server_lfg_path(@config.discord_id),
+        url: PluginPaths.for(@config, :lfg),
         toggle: {field: "lfg[enabled]", enabled: @enabled},
         gate: {type: :enable, message: t(".gate_message")}
       ) do

--- a/app/views/servers/logging/show.rb
+++ b/app/views/servers/logging/show.rb
@@ -11,10 +11,6 @@ class Views::Servers::Logging::Show < Views::Servers::PluginConfigShow
     "scroll"
   end
 
-  def url
-    server_logging_path(@config.discord_id)
-  end
-
   def form
     render Components::Logging::ConfigForm.new(server_configuration: @config)
   end

--- a/app/views/servers/moderation/show.rb
+++ b/app/views/servers/moderation/show.rb
@@ -2,7 +2,6 @@
 
 class Views::Servers::Moderation::Show < Views::Base
   include Phlex::Rails::Helpers::FormWith
-  include Components::PluginNav
 
   def initialize(server_configuration:, user:, context:)
     @config = server_configuration
@@ -23,7 +22,7 @@ class Views::Servers::Moderation::Show < Views::Base
           description: t(".description")
         ),
         server_configuration: @config,
-        url: server_moderation_path(@config.discord_id),
+        url: PluginPaths.for(@config, :moderation),
         gate: shell_gate,
         toggle: shell_toggle
       ) do
@@ -42,7 +41,7 @@ class Views::Servers::Moderation::Show < Views::Base
   def sub_plugin_toggle_forms
     PluginCatalog.sub_plugin_keys(:moderation).each do |key|
       form_with(
-        url: plugin_config_path(@config.discord_id, key),
+        url: PluginPaths.for(@config, key),
         method: :patch,
         id: Components::Moderation::SubPluginRow.toggle_form_id(key),
         class: "hidden"
@@ -59,7 +58,7 @@ class Views::Servers::Moderation::Show < Views::Base
         title: t(".prereq_gate_title"),
         message: t(".prereq_gate_message"),
         cta_label: t(".prereq_gate_cta"),
-        cta_href: server_logging_path(@config.discord_id)
+        cta_href: PluginPaths.for(@config, :logging)
       }
     elsif !@context.group_enabled?
       {

--- a/app/views/servers/moderation/sub_plugin_show.rb
+++ b/app/views/servers/moderation/sub_plugin_show.rb
@@ -23,7 +23,7 @@ class Views::Servers::Moderation::SubPluginShow < Views::Base
         url:,
         gate: shell_gate,
         toggle: shell_toggle,
-        parent_crumb: {label: PluginCatalog.find(:moderation).name, href: server_moderation_path(@config.discord_id)}
+        parent_crumb: {label: PluginCatalog.find(:moderation).name, href: moderation_path}
       ) do
         group_subline
         no_role_callout
@@ -34,6 +34,14 @@ class Views::Servers::Moderation::SubPluginShow < Views::Base
 
   private
 
+  def url
+    PluginPaths.for(@config, active_key)
+  end
+
+  def moderation_path
+    PluginPaths.for(@config, :moderation)
+  end
+
   def shell_gate
     return if @context.group_enabled?
 
@@ -43,7 +51,7 @@ class Views::Servers::Moderation::SubPluginShow < Views::Base
       title: t(".prereq_gate_title"),
       message: t(".prereq_gate_message"),
       cta_label: t(".prereq_gate_cta"),
-      cta_href: server_moderation_path(@config.discord_id)
+      cta_href: moderation_path
     }
   end
 
@@ -71,7 +79,7 @@ class Views::Servers::Moderation::SubPluginShow < Views::Base
       render Components::Icon.new("shield", class: "size-4")
       span do
         plain t(".subline_prefix")
-        a(href: server_moderation_path(@config.discord_id), class: "underline hover:text-text-secondary") do
+        a(href: moderation_path, class: "underline hover:text-text-secondary") do
           plain t(".subline_link")
         end
         plain t(".subline_suffix")
@@ -88,7 +96,7 @@ class Views::Servers::Moderation::SubPluginShow < Views::Base
         plain " "
         plain t(".no_role_callout_body")
         plain " "
-        a(href: server_moderation_path(@config.discord_id), class: "underline") { t(".no_role_callout_link") }
+        a(href: moderation_path, class: "underline") { t(".no_role_callout_link") }
         plain t(".no_role_callout_suffix")
       end
     end

--- a/app/views/servers/plugin_config_show.rb
+++ b/app/views/servers/plugin_config_show.rb
@@ -28,6 +28,10 @@ class Views::Servers::PluginConfigShow < Views::Base
 
   private
 
+  def url
+    PluginPaths.for(@config, plugin_key)
+  end
+
   def channel_setting
     @config.public_send(PluginCatalog.find(plugin_key).channel_setting)
   end

--- a/app/views/servers/plugins/update.turbo_stream.erb
+++ b/app/views/servers/plugins/update.turbo_stream.erb
@@ -1,2 +1,2 @@
-<%= turbo_stream.replace "plugin-#{@plugin.key}", html: render(Components::PluginRow.new(server_id: params[:server_id], row: @row)) %>
+<%= turbo_stream.replace "plugin-#{@plugin.key}", html: render(Components::PluginRow.new(server_configuration: @server_configuration, row: @row)) %>
 <%= turbo_stream.append "toasts", html: render(Components::Toast.new(**@toast)) %>

--- a/app/views/servers/reminders/show.rb
+++ b/app/views/servers/reminders/show.rb
@@ -16,7 +16,7 @@ class Views::Servers::Reminders::Show < Views::Base
           badge: t(".badge")
         ),
         server_configuration: @config,
-        url: server_reminders_path(@config.discord_id)
+        url: PluginPaths.for(@config, :reminders)
       ) do
         render Components::Reminders::ConfigForm.new(server_configuration: @config)
       end

--- a/app/views/servers/roles/show.rb
+++ b/app/views/servers/roles/show.rb
@@ -11,10 +11,6 @@ class Views::Servers::Roles::Show < Views::Servers::PluginConfigShow
     "users-three"
   end
 
-  def url
-    server_roles_path(@config.discord_id)
-  end
-
   def form
     render Components::Roles::ConfigForm.new(server_configuration: @config)
   end

--- a/app/views/servers/show.rb
+++ b/app/views/servers/show.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Views::Servers::Show < Views::Base
-  include Components::PluginNav
-
   def initialize(server:, server_configuration:, plugins:, user:, servers: [], plugin_counts: {})
     @server = server
     @server_configuration = server_configuration
@@ -76,13 +74,13 @@ class Views::Servers::Show < Views::Base
   end
 
   def visible_plugins
-    @plugins.select { |row| plugin_config_path(@server.id, row.key) && !PluginCatalog.sub_plugin?(row.key) }
+    @plugins.select { |row| PluginPaths.for(@server_configuration, row.key) && !PluginCatalog.sub_plugin?(row.key) }
   end
 
   def plugin_group(rows)
     div(class: "flex flex-col gap-3") do
       rows.each do |row|
-        render Components::PluginRow.new(server_id: @server.id, row:)
+        render Components::PluginRow.new(server_configuration: @server_configuration, row:)
       end
     end
   end

--- a/app/views/servers/spam_protection/show.rb
+++ b/app/views/servers/spam_protection/show.rb
@@ -11,10 +11,6 @@ class Views::Servers::SpamProtection::Show < Views::Servers::Moderation::SubPlug
     "megaphone-slash"
   end
 
-  def url
-    server_spam_protection_path(@config.discord_id)
-  end
-
   def enable_field
     "spam_protection[enabled]"
   end

--- a/app/views/servers/welcomes/show.rb
+++ b/app/views/servers/welcomes/show.rb
@@ -11,10 +11,6 @@ class Views::Servers::Welcomes::Show < Views::Servers::PluginConfigShow
     "hand-waving"
   end
 
-  def url
-    server_welcomes_path(@config.discord_id)
-  end
-
   def form
     render Components::Welcomes::ConfigForm.new(server_configuration: @config)
   end

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -605,6 +605,8 @@ en:
     plugin_disabled: "%{plugin} disabled."
     plugin_enabled: "%{plugin} enabled."
     plugin_locked: You can't configure that plugin on this server.
+    preview_read_only: Preview can't be edited - add shrkbot to a server to configure
+      it for real.
     reminders:
       saved: Reminder settings saved.
     role_sets:

--- a/config/preview_data.yml
+++ b/config/preview_data.yml
@@ -6,6 +6,11 @@ guild:
   bot_role_position: 50
   force_dm_reminders: false
 
+user:
+  discord_id: -1
+  username: reef-guest
+  display_name: Reef Guest
+
 channels:
   - discord_id: 100
     name: COMMUNITY

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,4 +50,18 @@ Rails.application.routes.draw do
       end
     end
   end
+
+  get "/preview", to: "previews#show", as: :preview, defaults: {preview: true}
+  delete "/preview", to: "previews#destroy"
+
+  scope "/preview", as: :preview, module: :servers, defaults: {preview: true} do
+    resource :welcomes, only: [:show, :update]
+    resource :logging, only: [:show, :update], controller: "logging"
+    resource :roles, only: [:show, :update]
+    resource :reminders, only: [:show, :update]
+    resource :moderation, only: [:show, :update], controller: "moderation"
+    resource :lfg, only: [:show, :update], controller: "lfg"
+    resource :spam_protection, only: [:show, :update], controller: "spam_protection"
+    resource :image_scanning, only: [:show, :update], controller: "image_scanning"
+  end
 end

--- a/docs/web/preview.md
+++ b/docs/web/preview.md
@@ -33,12 +33,15 @@ does exactly that — and it stamps its own condition onto `create`.
 ## The single source of mock data
 
 `config/preview_data.yml` is the only place preview content is written. It holds
-a `guild:` section, `channels:`, `roles:`, and a `plugins:` list — one entry per
+a `guild:` section, a `user:` section for the demo identity a logged-out visitor
+gets signed in as, `channels:`, `roles:`, and a `plugins:` list — one entry per
 toggleable plugin, each carrying that plugin's settings and, where relevant,
 records like role sets or LFG pingable roles. `PreviewData` (`app/models/preview_data.rb`)
 is the read-only accessor: it parses the file once, memoizes it, and shapes the
 channel hashes the way `Ops::ServerConfiguration::ServerChannels::Sync` expects
-(`channel_type`, `overwrites: []`).
+(`channel_type`, `overwrites: []`). `PreviewData.demo_guild` builds the
+`Bot::Discord::Guild` the web layer treats as the preview server everywhere it
+would otherwise call Discord.
 
 `Ops::ServerConfiguration::Previews::Create` seeds the file into real rows:
 

--- a/spec/components/moderation/sub_plugin_row_spec.rb
+++ b/spec/components/moderation/sub_plugin_row_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Components::Moderation::SubPluginRow do
 
   let(:base_attrs) do
     {
-      server_id: config.discord_id,
+      server_configuration: config,
       key: :spam_protection,
       name: "Cross-Channel Spam Guard",
       description: "Purges the same message posted across several channels within seconds.",
@@ -82,7 +82,7 @@ RSpec.describe Components::Moderation::SubPluginRow do
 
     subject(:html) do
       described_class.new(
-        server_id: config.discord_id,
+        server_configuration: config,
         key: :image_scanning,
         name: "Scam Image Detection",
         description: "Reads the text in images and fingerprints known scam images.",
@@ -128,7 +128,7 @@ RSpec.describe Components::Moderation::SubPluginRow do
 
     subject(:html) do
       described_class.new(
-        server_id: config.discord_id,
+        server_configuration: config,
         key: :image_scanning,
         name: "Scam Image Detection",
         description: "Reads the text in images and fingerprints known scam images.",
@@ -151,7 +151,7 @@ RSpec.describe Components::Moderation::SubPluginRow do
 
     subject(:html) do
       described_class.new(
-        server_id: config.discord_id,
+        server_configuration: config,
         key: :image_scanning,
         name: "Scam Image Detection",
         description: "Reads the text in images and fingerprints known scam images.",

--- a/spec/components/plugin_row_spec.rb
+++ b/spec/components/plugin_row_spec.rb
@@ -6,9 +6,10 @@ RSpec.describe Components::PluginRow do
   include_context "component view context"
 
   subject(:html) do
-    described_class.new(server_id: 900_000_001, row:).render_in(view_context)
+    described_class.new(server_configuration:, row:).render_in(view_context)
   end
 
+  let(:server_configuration) { create(:server_configuration, discord_id: 900_000_001) }
   let(:row) { PluginStatus::Row.new(key: :roles, enabled: true, configured: true, manageable:, toggleable:, bespoke:) }
   let(:manageable) { true }
   let(:toggleable) { true }

--- a/spec/operations/users/previews/ensure_spec.rb
+++ b/spec/operations/users/previews/ensure_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Ops::Users::Previews::Ensure do
+  subject(:result) { described_class.call }
+
+  it "creates the demo user at the preview data's negative discord_id" do
+    expect { result }.to change {
+      User.where(discord_id: PreviewData.user[:discord_id]).count
+    }.from(0).to(1)
+  end
+
+  it "sets the username and display name from the preview data" do
+    user = result.value
+
+    expect(user.username).to eq(PreviewData.user[:username])
+    expect(user.display_name).to eq(PreviewData.user[:display_name])
+  end
+
+  describe "calling it twice" do
+    it "does not create a second user" do
+      described_class.call
+
+      expect { described_class.call }.not_to change(User, :count)
+    end
+
+    it "returns the same user" do
+      first = described_class.call.value
+
+      expect(described_class.call.value).to eq(first)
+    end
+  end
+end

--- a/spec/presenters/plugin_paths_spec.rb
+++ b/spec/presenters/plugin_paths_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PluginPaths do
+  describe ".for" do
+    subject(:path) { described_class.for(server_configuration, key) }
+
+    context "with a real server configuration" do
+      let(:server_configuration) { create(:server_configuration, discord_id: 900_000_001) }
+
+      context "with a catalog plugin key" do
+        let(:key) { :roles }
+
+        it "builds the real config page path" do
+          expect(path).to eq("/servers/900000001/roles")
+        end
+      end
+
+      context "with a global plugin key" do
+        let(:key) { :reminders }
+
+        it "builds the real config page path" do
+          expect(path).to eq("/servers/900000001/reminders")
+        end
+      end
+
+      context "with a bespoke plugin key" do
+        let(:key) { :twilight_struggle }
+
+        it "builds the real config page path" do
+          expect(path).to eq("/servers/900000001/twilight_struggle")
+        end
+      end
+
+      context "with a key PluginCatalog does not recognize" do
+        let(:key) { :nonsense }
+
+        it "raises the unknown-key guard" do
+          expect { path }.to raise_error(ArgumentError, /unknown plugin key/)
+        end
+      end
+    end
+
+    context "with a preview server configuration" do
+      let(:server_configuration) { create(:server_configuration, :preview) }
+
+      context "with a catalog plugin key" do
+        let(:key) { :roles }
+
+        it "builds the preview config page path" do
+          expect(path).to eq("/preview/roles")
+        end
+      end
+
+      context "with a global plugin key" do
+        let(:key) { :reminders }
+
+        it "builds the preview config page path" do
+          expect(path).to eq("/preview/reminders")
+        end
+      end
+
+      context "with a bespoke plugin key" do
+        let(:key) { :twilight_struggle }
+
+        it "raises, since there is no preview route for a bespoke plugin" do
+          expect { path }.to raise_error(ArgumentError, /bespoke/)
+        end
+      end
+    end
+  end
+
+  describe ".dashboard_for" do
+    subject(:dashboard_path) { described_class.dashboard_for(discord_id) }
+
+    context "with a real server discord id" do
+      let(:discord_id) { 900_000_001 }
+
+      it "builds the server dashboard path" do
+        expect(dashboard_path).to eq("/servers/900000001")
+      end
+    end
+
+    context "with a preview discord id" do
+      let(:discord_id) { -1 }
+
+      it "builds the preview dashboard path" do
+        expect(dashboard_path).to eq("/preview")
+      end
+    end
+  end
+end

--- a/spec/requests/previews_spec.rb
+++ b/spec/requests/previews_spec.rb
@@ -1,0 +1,213 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Preview", type: :request do
+  include_context "discord auth"
+
+  let!(:plugins) do
+    Plugin.insert_all(
+      PluginCatalog.all.map do |definition|
+        {key: definition.key.to_s, name: definition.name, description: definition.description, created_at: Time.current, updated_at: Time.current}
+      end
+    )
+  end
+
+  let!(:preview_configuration) { Ops::ServerConfiguration::Previews::Create.call.value }
+
+  describe "GET /preview" do
+    subject(:get_preview) { get preview_path }
+
+    context "when signed out" do
+      it "renders the preview dashboard" do
+        get_preview
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("The Reef")
+      end
+
+      it "creates the demo user identity" do
+        expect { get_preview }.to change(User, :count).by(1)
+      end
+
+      it "signs the visitor in as the demo user" do
+        get_preview
+        expect(session[:user_id]).to eq(User.find_by(discord_id: PreviewData.user[:discord_id]).id)
+      end
+
+      it "flags the identity as preview-created" do
+        get_preview
+        expect(session[:preview_identity]).to be(true)
+      end
+    end
+
+    context "when a real user is signed in" do
+      before { post "/auth/discord/callback" }
+
+      it "renders the preview dashboard" do
+        get_preview
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "leaves the signed-in user's session id unchanged" do
+        expect { get_preview }.not_to change { session[:user_id] }
+      end
+
+      it "does not create a demo user" do
+        expect { get_preview }.not_to change(User, :count)
+      end
+
+      it "does not flag the identity as preview-created" do
+        get_preview
+        expect(session[:preview_identity]).to be_nil
+      end
+    end
+  end
+
+  describe "GET /preview/roles" do
+    before { get preview_path }
+
+    it "renders the real roles config page against the preview guild" do
+      get preview_roles_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Roles")
+      expect(response.body).to include("Pronouns")
+    end
+
+    it "never links or posts back to the real server routes" do
+      get preview_roles_path
+      expect(response.body).not_to match(%r{(href|action)="/servers/})
+    end
+  end
+
+  describe "GET /preview/welcomes" do
+    before { get preview_path }
+
+    it "renders the real welcomes config page against the preview guild" do
+      get preview_welcomes_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Welcome to The Reef")
+    end
+
+    it "never links or posts back to the real server routes" do
+      get preview_welcomes_path
+      expect(response.body).not_to match(%r{(href|action)="/servers/})
+    end
+  end
+
+  describe "a deep link into a preview page" do
+    subject(:deep_link) { get preview_welcomes_path }
+
+    context "when the visitor is signed out and has never opened the dashboard" do
+      it "renders the page instead of bouncing to the login screen" do
+        deep_link
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "establishes the demo identity on the way in" do
+        expect { deep_link }.to change(User, :count).by(1)
+      end
+    end
+  end
+
+  describe "the Discord seam" do
+    before do
+      allow(Bot::Discord::UserGuilds).to receive(:call)
+    end
+
+    it "is never called for a preview visit" do
+      get preview_path
+      get preview_welcomes_path
+      expect(Bot::Discord::UserGuilds).not_to have_received(:call)
+    end
+
+    it "does not write authorized or managed server ids into the session" do
+      get preview_path
+      get preview_welcomes_path
+      expect(session[:authorized_server_ids]).to be_nil
+      expect(session[:managed_server_ids]).to be_nil
+    end
+  end
+
+  describe "PATCH /preview/roles" do
+    before { get preview_path }
+
+    it "blocks the write and leaves the configuration unchanged" do
+      expect {
+        patch preview_roles_path, params: {roles: {channel_id: "", enabled: "1", role_sets: {}}}
+      }.not_to change { preview_configuration.reload.role_setting.channel_id }
+    end
+
+    it "redirects with an alert instead of running the action" do
+      patch preview_roles_path, params: {roles: {channel_id: "", enabled: "1", role_sets: {}}}
+      expect(response).to redirect_to(preview_path)
+      expect(flash[:alert]).to be_present
+    end
+  end
+
+  describe "reaching the preview guild through the real server routes" do
+    subject(:sneak) { patch server_plugin_path(preview_configuration.discord_id, :roles), params: {enabled: "0"} }
+
+    before do
+      get preview_path
+      allow(Bot::ConfigBus).to receive(:publish)
+    end
+
+    it "does not toggle the plugin" do
+      expect { sneak }.not_to change {
+        preview_configuration.plugin_activations.joins(:plugin).find_by(plugins: {key: "roles"}).enabled
+      }
+    end
+
+    it "never asks the bot to sync commands for a guild it is not in" do
+      sneak
+
+      expect(Bot::ConfigBus).not_to have_received(:publish)
+    end
+  end
+
+  describe "leaving preview by navigating away" do
+    subject(:real_dashboard) { get servers_path }
+
+    before do
+      post "/auth/discord/callback"
+      get preview_path
+    end
+
+    it "shows a signed-in user their own servers again, with no exit step" do
+      real_dashboard
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).not_to include("The Reef")
+    end
+  end
+
+  describe "DELETE /preview" do
+    context "when the demo identity was created for a logged-out visitor" do
+      before { get preview_path }
+
+      it "signs the demo identity back out" do
+        delete preview_path
+
+        expect(session[:user_id]).to be_nil
+        expect(session[:preview_identity]).to be_nil
+      end
+
+      it "redirects to the root path" do
+        delete preview_path
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "when a real user is signed in" do
+      before do
+        post "/auth/discord/callback"
+        get preview_path
+      end
+
+      it "leaves the real user signed in" do
+        expect { delete preview_path }.not_to change { session[:user_id] }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Chunk 2a of preview mode: `/preview` and `/preview/<plugin>` now render the real config pages against the preview guild, signed in or signed out. No banner or entry-point link yet - that is 2b, so today you reach it by typing the URL.

The pages and controllers are the existing ones. Only two things differ for a preview request: `SetsVisibleServers` returns the demo guild instead of calling Discord, and `RequiresManageableServer` resolves the preview configuration instead of one from `params[:server_id]`. Writes are blocked until chunk 3.

Preview never fakes who you are. A signed-in user stays signed in as themselves; only a signed-out visitor gets the demo `User`. That identity is established in its own concern, prepended so it runs before the login check - otherwise a signed-out visitor following a link to `/preview/roles` lands on the login screen, and deep links are the ones people share.

Two problems the review caught, both fixed with a failing spec written first:

- `PATCH /servers/-1/plugins/roles` resolved the preview row through the normal route tree, missed the write guard, and reached `ConfigBus.sync_commands` - asking the bot to sync commands for a guild it is not in. The real-guild lookup is now scoped `.real`, and the write guard asks the resolved configuration rather than the URL shape.
- Preview state was kept in the session, so a signed-in user who looked at preview once had their own servers replaced by the demo guild for the rest of the session. It is read from the route now and never stored.

Also here, both found by the preview data rather than planned: the roles config page ran a query per role set (`app/components/roles/config_form.rb`), which every real guild with two sets was already paying; and `PluginPaths` replaces roughly forty hand-built paths across views and components, which deletes the per-page `url` methods.

Gates: `bundle exec rspec` 2974 examples, 0 failures. `standardrb`, `active_record_doctor`, `i18n-tasks missing` and `check-normalized` clean. `undercover --compare origin/main` reports "No coverage is missing in latest changes".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
