### PR TITLE
Give toasts an opaque background in the dark theme

### DIFF
--- a/app/assets/tailwind/theme.css
+++ b/app/assets/tailwind/theme.css
@@ -45,6 +45,8 @@
   --color-danger: var(--danger);
   --color-danger-soft: var(--danger-soft);
   --color-danger-soft-bd: var(--danger-soft-bd);
+  --color-success-solid: var(--success-solid);
+  --color-danger-solid: var(--danger-solid);
 
   --color-surface-page: var(--surface-page);
   --color-surface-card: var(--surface-card);

--- a/app/assets/tailwind/tokens.css
+++ b/app/assets/tailwind/tokens.css
@@ -46,6 +46,9 @@
   --warning-soft-bd: color-mix(in srgb, var(--warning) 34%, transparent);
   --danger-soft-bd: color-mix(in srgb, var(--danger) 34%, transparent);
 
+  --success-solid: var(--success-soft);
+  --danger-solid: var(--danger-soft);
+
   --text-primary: var(--ink-900);
   --text-secondary: var(--ink-600);
   --text-muted: var(--ink-400);
@@ -144,6 +147,9 @@
   --success-soft-bd: color-mix(in srgb, var(--success) 22%, transparent);
   --warning-soft-bd: color-mix(in srgb, var(--warning) 22%, transparent);
   --danger-soft-bd: color-mix(in srgb, var(--danger) 22%, transparent);
+
+  --success-solid: color-mix(in srgb, var(--success) 14%, var(--surface-card));
+  --danger-solid: color-mix(in srgb, var(--danger) 14%, var(--surface-card));
 
   --focus-ring: color-mix(in srgb, #46817a 42%, transparent);
 

--- a/app/components/toast.rb
+++ b/app/components/toast.rb
@@ -2,8 +2,8 @@
 
 class Components::Toast < Components::Base
   LEVELS = {
-    "alert" => {icon: "warning", tone: "border-danger/30 bg-danger-soft text-danger"},
-    "notice" => {icon: "check-circle", tone: "border-success/30 bg-success-soft text-success"}
+    "alert" => {icon: "warning", tone: "border-danger/30 bg-danger-solid text-danger"},
+    "notice" => {icon: "check-circle", tone: "border-success/30 bg-success-solid text-success"}
   }.freeze
 
   def initialize(level:, message:)


### PR DESCRIPTION
Alert and notice toasts are hard to read in the dark theme. `--danger-soft` and `--success-soft` are `rgba(..., 0.14)` there, and a toast floats over the page rather than sitting on a card, so the content behind it shows through the message.

The two new `-solid` tokens mix the same 14% tint into `--surface-card` instead of into transparency. The dark theme keeps the appearance it was meant to have, and the light theme keeps the opaque colour it already defined.

Only `Components::Toast` changes. Callouts, badges and the hover tints keep the soft tokens, because those all sit on a solid surface where the translucency is correct.

Worth eyeballing in both themes before merge - I can't render the page here.

Gates: `bundle exec rspec` 2937 examples, 0 failures. `standardrb` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
