### PR TITLE
Turn off saving in preview, and give it a way in and out

### DIFF
--- a/app/components/app_shell.rb
+++ b/app/components/app_shell.rb
@@ -5,18 +5,20 @@ class Components::AppShell < Components::Base
   include Phlex::Rails::Helpers::ButtonTo
   include Phlex::Rails::Helpers::TurboFrameTag
 
-  def initialize(user:, current_server: nil, current_server_id: nil, servers: [], plugin_counts: {}, sidebar: nil)
+  def initialize(user:, current_server: nil, current_server_id: nil, servers: [], plugin_counts: {}, sidebar: nil, server_configuration: nil)
     @user = user
     @current_server = current_server
     @current_server_id = current_server_id
     @servers = servers
     @plugin_counts = plugin_counts
     @sidebar = sidebar
+    @server_configuration = server_configuration
   end
 
   def view_template(&block)
     div(class: "flex min-h-screen flex-col") do
       top_bar
+      render Components::PreviewBanner.new if @server_configuration&.preview?
       if @sidebar
         div(class: "flex flex-1") do
           render @sidebar

--- a/app/components/config_page.rb
+++ b/app/components/config_page.rb
@@ -24,7 +24,7 @@ class Components::ConfigPage < Components::Base
       ) do
         page_header
         body(&block)
-        render Components::SaveBar.new
+        render Components::SaveBar.new(preview: @server_configuration.preview?)
       end
     end
   end

--- a/app/components/plugin_row.rb
+++ b/app/components/plugin_row.rb
@@ -41,7 +41,9 @@ class Components::PluginRow < Components::Base
   end
 
   def toggle
-    if !@row.manageable
+    if @config.preview?
+      locked_toggle(checked: @row.enabled, tooltip: t(".preview_locked"))
+    elsif !@row.manageable
       locked_toggle(checked: @row.enabled, tooltip: t(".not_manageable"))
     elsif @row.locked
       locked_toggle(checked: true, tooltip: t(".plugin.#{@row.key}.locked"))

--- a/app/components/plugin_shell.rb
+++ b/app/components/plugin_shell.rb
@@ -14,7 +14,8 @@ class Components::PluginShell < Components::Base
       current_server_id: @server_configuration.discord_id,
       servers: switcher&.configured_servers || [],
       plugin_counts: switcher&.plugin_counts || {},
-      sidebar: Components::PluginSidebar.new(server_configuration: @server_configuration, active_key: @active_key, access: view_context.plugin_access)
+      sidebar: Components::PluginSidebar.new(server_configuration: @server_configuration, active_key: @active_key, access: view_context.plugin_access),
+      server_configuration: @server_configuration
     ), &block
   end
 

--- a/app/components/preview_banner.rb
+++ b/app/components/preview_banner.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class Components::PreviewBanner < Components::Base
+  include Phlex::Rails::Helpers::ButtonTo
+
+  def view_template
+    div(class: "flex flex-none flex-wrap items-center gap-3 border-b border-accent-soft-bd bg-accent-soft px-5 py-2.5 text-sm text-accent-soft-fg") do
+      render Components::Icon.new("eye", class: "size-[18px] flex-none")
+      p(class: "flex-1 font-medium") { t(".message") }
+      div(class: "flex flex-none items-center gap-2") do
+        invite_button
+        leave_button
+      end
+    end
+  end
+
+  private
+
+  def invite_button
+    render Components::Button.new(
+      variant: :primary,
+      size: :sm,
+      href: Bot::Config.invite_url,
+      icon: "plus",
+      label: t(".invite")
+    )
+  end
+
+  def leave_button
+    button_to(
+      preview_path,
+      method: :delete,
+      class: Components::Button.css(variant: :secondary, size: :sm)
+    ) { t(".leave") }
+  end
+end

--- a/app/components/save_bar.rb
+++ b/app/components/save_bar.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class Components::SaveBar < Components::Base
+  def initialize(preview: false)
+    @preview = preview
+  end
+
   def view_template
     div(
       class: "save-bar fixed bottom-6 z-40 hidden w-[30rem] max-w-[calc(100vw-2.5rem)] rounded-xl",
@@ -9,7 +13,7 @@ class Components::SaveBar < Components::Base
       div(class: "flex items-center justify-between gap-6 rounded-xl border border-border-default bg-surface-card px-5 py-3 shadow-lg") do
         p(class: "flex items-center gap-2 text-sm text-text-secondary") do
           span(class: "size-2 flex-none rounded-full bg-warning")
-          plain t(".unsaved")
+          plain(@preview ? t(".preview_message") : t(".unsaved"))
         end
         div(class: "flex items-center gap-2") do
           render Components::Button.new(
@@ -23,7 +27,8 @@ class Components::SaveBar < Components::Base
             size: :sm,
             type: "submit",
             icon: "check",
-            label: t(".save")
+            label: t(".save"),
+            disabled: @preview
           )
         end
       end

--- a/app/views/servers/index.rb
+++ b/app/views/servers/index.rb
@@ -93,6 +93,7 @@ class Views::Servers::Index < Views::Base
   def empty_state
     render Components::EmptyState.new(title: t(".empty_title"), body: t(".empty_body")) do
       render Components::Button.new(variant: :primary, size: :lg, href: generic_invite_url, icon: "plus", label: t(".invite"))
+      render Components::Button.new(variant: :secondary, size: :lg, href: preview_path, icon: "eye", label: t(".preview"))
       render Components::Button.new(variant: :secondary, size: :lg, href: servers_path, icon: "arrows-clockwise", label: t(".refresh"))
     end
   end

--- a/app/views/servers/show.rb
+++ b/app/views/servers/show.rb
@@ -11,7 +11,7 @@ class Views::Servers::Show < Views::Base
   end
 
   def view_template
-    render Components::AppShell.new(user: @user, current_server: @server, servers: @servers, plugin_counts: @plugin_counts) do
+    render Components::AppShell.new(user: @user, current_server: @server, servers: @servers, plugin_counts: @plugin_counts, server_configuration: @server_configuration) do
       div(class: "mx-auto max-w-3xl px-6 py-8") do
         render Components::Breadcrumb.new(
           [

--- a/config/locales/web.en.yml
+++ b/config/locales/web.en.yml
@@ -374,6 +374,8 @@ en:
         welcomes:
           description: Greet new members and say goodbye when they leave.
           name: Welcomes
+      preview_locked: Preview doesn't save - add shrkbot to your server to turn plugins
+        on there.
       status:
         disabled: Disabled
         enabled: Enabled
@@ -385,6 +387,10 @@ en:
       locked: You can't configure this plugin on this server.
       overview: Overview
       plugins: Plugins
+    preview_banner:
+      invite: Invite shrkbot
+      leave: Leave preview
+      message: You're looking at a preview server - nothing you change here is saved.
     public_shell:
       dashboard: Dashboard
       sign_in: Sign in with Discord
@@ -435,6 +441,8 @@ en:
     save_bar:
       discard: Discard
       discarded: Changes discarded
+      preview_message: Preview doesn't save - add shrkbot to your server to change
+        these settings for real.
       save: Save
       unsaved: Unsaved changes
     site_footer:
@@ -757,6 +765,7 @@ en:
         plugins_enabled:
           one: "%{count} plugin enabled"
           other: "%{count} plugins enabled"
+        preview: Preview a server
         refresh: Refresh
         subtitle: Pick a server to configure shrkbot.
         title: Your servers

--- a/docs/web/preview.md
+++ b/docs/web/preview.md
@@ -30,6 +30,38 @@ a preview `ServerChannel`'s `.server_configuration` would return `nil` and break
 every child-to-parent traversal in the views — `ServerChannel#everyone_visible?`
 does exactly that — and it stamps its own condition onto `create`.
 
+## Read-only, permanently
+
+Preview was originally planned to accept writes against its own row, scoped so
+a visitor's edits never touched a real guild. That plan was cancelled - the
+value of preview is letting a prospective admin see the real config pages
+against real-looking data, not giving anonymous visitors a scratch database.
+Preview is read-only by design now, not as a stepping stone to writable.
+
+The guard lives server-side: `block_preview_writes` in
+`app/controllers/concerns/requires_manageable_server.rb` redirects any
+non-`GET` request against a preview `ServerConfiguration` back to `/preview`
+with an alert, before the action runs. That is the actual enforcement - it
+holds even if a request reaches the server some other way.
+
+The UI never gives a visitor a control that would hit that guard:
+
+- `Components::SaveBar` (rendered by `Components::ConfigPage`) renders its
+  submit button disabled on a preview page, and swaps its message for the
+  preview explanation. Discard still works - it reloads the page client-side
+  and touches no route.
+- `Components::PluginRow`'s dashboard toggle POSTs on change, so on a preview
+  row it renders in the same disabled-with-tooltip state used elsewhere for a
+  toggle the visitor isn't allowed to flip.
+- Every other control - text fields, dropdowns, switches inside a form -
+  stays interactive, because only saving is blocked.
+
+`Components::PreviewBanner`, rendered once in `Components::AppShell` whenever
+it is handed a preview `ServerConfiguration`, names the read-only state on
+every preview page and offers the way out: an invite link to add the real bot,
+and a `Leave preview` button hitting `DELETE /preview`
+(`PreviewsController#destroy`).
+
 ## The single source of mock data
 
 `config/preview_data.yml` is the only place preview content is written. It holds

--- a/spec/components/plugin_row_spec.rb
+++ b/spec/components/plugin_row_spec.rb
@@ -52,6 +52,18 @@ RSpec.describe Components::PluginRow do
     end
   end
 
+  context "when the server configuration is a preview" do
+    let(:server_configuration) { create(:server_configuration, :preview) }
+
+    it "disables the toggle instead of letting it submit" do
+      expect(html).to include("disabled")
+    end
+
+    it "says why in the tooltip" do
+      expect(html).to include(CGI.escapeHTML(I18n.t("components.plugin_row.preview_locked")))
+    end
+  end
+
   context "when the plugin is bespoke" do
     let(:bespoke) { true }
 

--- a/spec/components/preview_banner_spec.rb
+++ b/spec/components/preview_banner_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::PreviewBanner do
+  include_context "component view context"
+
+  subject(:html) { described_class.new.render_in(view_context) }
+
+  it "states that this is a preview and nothing is saved" do
+    expect(html).to include(CGI.escapeHTML(I18n.t("components.preview_banner.message")))
+  end
+
+  it "offers the bot-invite call to action" do
+    expect(html).to include(Bot::Config.invite_url).and include(I18n.t("components.preview_banner.invite"))
+  end
+
+  it "offers a way out that hits DELETE /preview" do
+    expect(html).to include('action="/preview"')
+    expect(html).to include('value="delete"')
+    expect(html).to include(I18n.t("components.preview_banner.leave"))
+  end
+end

--- a/spec/components/save_bar_spec.rb
+++ b/spec/components/save_bar_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::SaveBar do
+  include_context "component view context"
+
+  subject(:html) { described_class.new(preview:).render_in(view_context) }
+
+  let(:preview) { false }
+
+  context "when not previewing" do
+    it "shows the unsaved-changes message" do
+      expect(html).to include(I18n.t("components.save_bar.unsaved"))
+    end
+
+    it "leaves the save button enabled" do
+      expect(html).not_to include("disabled")
+    end
+  end
+
+  context "when previewing" do
+    let(:preview) { true }
+
+    it "shows the preview explanation instead of the unsaved-changes message" do
+      expect(html).to include(CGI.escapeHTML(I18n.t("components.save_bar.preview_message")))
+      expect(html).not_to include(I18n.t("components.save_bar.unsaved"))
+    end
+
+    it "disables the save button" do
+      expect(html).to include("disabled")
+    end
+
+    it "keeps the discard button wired up" do
+      expect(html).to include(%(data-action="save-bar#discard"))
+    end
+  end
+end

--- a/spec/requests/previews_spec.rb
+++ b/spec/requests/previews_spec.rb
@@ -79,6 +79,50 @@ RSpec.describe "Preview", type: :request do
     end
   end
 
+  describe "the read-only surface on a preview config page" do
+    subject(:get_preview_roles) { get preview_roles_path }
+
+    before { get preview_path }
+
+    it "renders the preview banner" do
+      get_preview_roles
+
+      expect(response.body).to include(CGI.escapeHTML(I18n.t("components.preview_banner.message")))
+      expect(response.body).to include(I18n.t("components.preview_banner.leave"))
+    end
+
+    it "renders the save button disabled" do
+      get_preview_roles
+
+      expect(response.body).to match(/<button[^>]*type="submit"[^>]*disabled[^>]*>/)
+    end
+  end
+
+  describe "a real server's config page" do
+    subject(:get_server_roles) { get server_roles_path(guild.id) }
+
+    let(:guild) { Bot::Discord::Guild.new(id: 900_000_001, name: "Dev Refuge", owner: true, permissions: 0, icon: nil, member_count: 5) }
+    let(:config) { ServerConfiguration.find_by(discord_id: guild.id) }
+    let!(:roles) { create(:plugin, key: "roles", name: "Roles") }
+
+    before do
+      post "/auth/discord/callback"
+      create(:server_configuration, discord_id: guild.id, bot_role_position: 100)
+      config.create_role_setting!
+      create(:server_channel, server_configuration: config, name: "get-roles", discord_id: 111)
+      create(:server_role, server_configuration: config, discord_id: 222, name: "Member", position: 1)
+      allow(Bot::Discord::UserGuilds).to receive(:call).and_return([guild])
+      get server_path(guild.id)
+    end
+
+    it "renders neither the preview banner nor a disabled submit button" do
+      get_server_roles
+
+      expect(response.body).not_to include(CGI.escapeHTML(I18n.t("components.preview_banner.message")))
+      expect(response.body).not_to match(/<button[^>]*type="submit"[^>]*disabled[^>]*>/)
+    end
+  end
+
   describe "GET /preview/welcomes" do
     before { get preview_path }
 

--- a/spec/requests/server_picker_spec.rb
+++ b/spec/requests/server_picker_spec.rb
@@ -126,6 +126,12 @@ RSpec.describe "Server picker", type: :request do
           get_servers
           expect(response.body).to include("in any of your servers yet")
         end
+
+        it "offers a way to preview a server without the bot" do
+          get_servers
+          expect(response.body).to include("Preview a server")
+          expect(response.body).to include(%(href="/preview"))
+        end
       end
 
       context "when Discord cannot be reached" do


### PR DESCRIPTION
Stacked on #247 - review that first, and this diff reads clean only once it is merged.

The visible half of preview mode, and the last of it. Preview is read-only for good; the writable follow-up is cancelled, so there are no clones, no sweep job and no per-visitor rows.

Saving is the only thing turned off. Fields, dropdowns and Discard all still work, because showing the real pages is the point. Two controls are disabled: the save button, and the dashboard plugin switch, which submits the moment it is flipped and so is that row's save action. `block_preview_writes` still refuses preview writes server-side; this stops the UI from asking.

The servers index now offers "Preview a server" beside the invite button, where someone with no server is already looking. Every preview page carries a banner saying nothing is saved, with the invite link and a way back out.

Worth eyeballing in a browser, in both themes - I cannot render here:

- the banner sits directly under the top bar, above the sidebar on plugin pages
- the disabled save button, which should read as locked rather than broken
- the empty state now has three buttons in a row, at narrow widths especially
- the plugin-row tooltip is longer than its neighbours in that slot

Gates: `bundle exec rspec` 2988 examples, 0 failures. `standardrb`, `active_record_doctor`, `i18n-tasks missing` and `check-normalized` clean. `undercover --compare origin/main` reports "No coverage is missing in latest changes".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
