### PR TITLE
Share the plugin config specs' auth preamble

### DIFF
--- a/spec/requests/image_scanning_config_spec.rb
+++ b/spec/requests/image_scanning_config_spec.rb
@@ -3,18 +3,11 @@
 require "rails_helper"
 
 RSpec.describe "Image scanning config", type: :request do
-  include_context "discord auth"
+  include_context "plugin config request"
 
-  let(:guild) { Bot::Discord::Guild.new(id: 900_000_001, name: "Dev Refuge", owner: true, permissions: 0, icon: nil, member_count: 5) }
-  let(:config) { ServerConfiguration.find_by(discord_id: guild.id) }
-  let(:turbo) { {headers: {"Accept" => "text/vnd.turbo-stream.html"}} }
+  let(:plugin_path) { server_image_scanning_path(guild.id) }
 
-  context "when signed out" do
-    it "redirects to the sign-in page" do
-      get server_image_scanning_path(900_000_001)
-      expect(response).to redirect_to(root_path)
-    end
-  end
+  it_behaves_like "a config page that requires sign-in"
 
   context "when signed in" do
     let!(:moderation_plugin) { create(:plugin, key: "moderation", name: "Server Shield") }
@@ -29,16 +22,7 @@ RSpec.describe "Image scanning config", type: :request do
       allow(Bot::Discord::UserGuilds).to receive(:call).and_return([guild])
     end
 
-    context "when the user no longer manages the server" do
-      before do
-        allow(Bot::Discord::UserGuilds).to receive(:call).and_return([])
-      end
-
-      it "redirects to the picker" do
-        get server_image_scanning_path(guild.id)
-        expect(response).to redirect_to(servers_path)
-      end
-    end
+    it_behaves_like "a config page that requires a manageable server"
 
     context "after loading the dashboard authorizes the server" do
       before { get server_path(guild.id) }

--- a/spec/requests/lfg_config_spec.rb
+++ b/spec/requests/lfg_config_spec.rb
@@ -3,18 +3,11 @@
 require "rails_helper"
 
 RSpec.describe "LFG config", type: :request do
-  include_context "discord auth"
+  include_context "plugin config request"
 
-  let(:guild) { Bot::Discord::Guild.new(id: 900_000_001, name: "Dev Refuge", owner: true, permissions: 0, icon: nil, member_count: 5) }
-  let(:config) { ServerConfiguration.find_by(discord_id: guild.id) }
-  let(:turbo) { {headers: {"Accept" => "text/vnd.turbo-stream.html"}} }
+  let(:plugin_path) { server_lfg_path(guild.id) }
 
-  context "when signed out" do
-    it "redirects to the sign-in page" do
-      get server_lfg_path(900_000_001)
-      expect(response).to redirect_to(root_path)
-    end
-  end
+  it_behaves_like "a config page that requires sign-in"
 
   context "when signed in" do
     let!(:lfg_plugin) { create(:plugin, key: "lfg", name: "Looking for Game") }
@@ -29,16 +22,7 @@ RSpec.describe "LFG config", type: :request do
       allow(Bot::Discord::UserGuilds).to receive(:call).and_return([guild])
     end
 
-    context "when the user no longer manages the server" do
-      before do
-        allow(Bot::Discord::UserGuilds).to receive(:call).and_return([])
-      end
-
-      it "redirects to the picker" do
-        get server_lfg_path(guild.id)
-        expect(response).to redirect_to(servers_path)
-      end
-    end
+    it_behaves_like "a config page that requires a manageable server"
 
     context "after loading the dashboard authorizes the server" do
       before do

--- a/spec/requests/logging_config_spec.rb
+++ b/spec/requests/logging_config_spec.rb
@@ -3,18 +3,11 @@
 require "rails_helper"
 
 RSpec.describe "Logging config", type: :request do
-  include_context "discord auth"
+  include_context "plugin config request"
 
-  let(:guild) { Bot::Discord::Guild.new(id: 900_000_001, name: "Dev Refuge", owner: true, permissions: 0, icon: nil, member_count: 5) }
-  let(:config) { ServerConfiguration.find_by(discord_id: guild.id) }
-  let(:turbo) { {headers: {"Accept" => "text/vnd.turbo-stream.html"}} }
+  let(:plugin_path) { server_logging_path(guild.id) }
 
-  context "when signed out" do
-    it "redirects to the sign-in page" do
-      get server_logging_path(900_000_001)
-      expect(response).to redirect_to(root_path)
-    end
-  end
+  it_behaves_like "a config page that requires sign-in"
 
   context "when signed in" do
     let!(:logging) { create(:plugin, key: "logging", name: "Logging") }
@@ -26,16 +19,7 @@ RSpec.describe "Logging config", type: :request do
       allow(Bot::Discord::UserGuilds).to receive(:call).and_return([guild])
     end
 
-    context "when the user no longer manages the server" do
-      before do
-        allow(Bot::Discord::UserGuilds).to receive(:call).and_return([])
-      end
-
-      it "redirects to the picker" do
-        get server_logging_path(guild.id)
-        expect(response).to redirect_to(servers_path)
-      end
-    end
+    it_behaves_like "a config page that requires a manageable server"
 
     context "after loading the dashboard authorizes the server" do
       before do

--- a/spec/requests/moderation_config_spec.rb
+++ b/spec/requests/moderation_config_spec.rb
@@ -3,18 +3,11 @@
 require "rails_helper"
 
 RSpec.describe "Moderation config", type: :request do
-  include_context "discord auth"
+  include_context "plugin config request"
 
-  let(:guild) { Bot::Discord::Guild.new(id: 900_000_001, name: "Dev Refuge", owner: true, permissions: 0, icon: nil, member_count: 5) }
-  let(:config) { ServerConfiguration.find_by(discord_id: guild.id) }
-  let(:turbo) { {headers: {"Accept" => "text/vnd.turbo-stream.html"}} }
+  let(:plugin_path) { server_moderation_path(guild.id) }
 
-  context "when signed out" do
-    it "redirects to the sign-in page" do
-      get server_moderation_path(900_000_001)
-      expect(response).to redirect_to(root_path)
-    end
-  end
+  it_behaves_like "a config page that requires sign-in"
 
   context "when signed in" do
     let!(:logging_plugin) { create(:plugin, key: "logging", name: "Logging") }
@@ -31,16 +24,7 @@ RSpec.describe "Moderation config", type: :request do
       allow(Bot::Discord::UserGuilds).to receive(:call).and_return([guild])
     end
 
-    context "when the user no longer manages the server" do
-      before do
-        allow(Bot::Discord::UserGuilds).to receive(:call).and_return([])
-      end
-
-      it "redirects to the picker" do
-        get server_moderation_path(guild.id)
-        expect(response).to redirect_to(servers_path)
-      end
-    end
+    it_behaves_like "a config page that requires a manageable server"
 
     context "after loading the dashboard authorizes the server" do
       before do

--- a/spec/requests/reminders_config_spec.rb
+++ b/spec/requests/reminders_config_spec.rb
@@ -3,18 +3,11 @@
 require "rails_helper"
 
 RSpec.describe "Reminders config", type: :request do
-  include_context "discord auth"
+  include_context "plugin config request"
 
-  let(:guild) { Bot::Discord::Guild.new(id: 900_000_001, name: "Dev Refuge", owner: true, permissions: 0, icon: nil, member_count: 5) }
-  let(:config) { ServerConfiguration.find_by(discord_id: guild.id) }
-  let(:turbo) { {headers: {"Accept" => "text/vnd.turbo-stream.html"}} }
+  let(:plugin_path) { server_reminders_path(guild.id) }
 
-  context "when signed out" do
-    it "redirects to the sign-in page" do
-      get server_reminders_path(900_000_001)
-      expect(response).to redirect_to(root_path)
-    end
-  end
+  it_behaves_like "a config page that requires sign-in"
 
   context "when signed in" do
     before do
@@ -23,16 +16,7 @@ RSpec.describe "Reminders config", type: :request do
       allow(Bot::Discord::UserGuilds).to receive(:call).and_return([guild])
     end
 
-    context "when the user no longer manages the server" do
-      before do
-        allow(Bot::Discord::UserGuilds).to receive(:call).and_return([])
-      end
-
-      it "redirects to the picker" do
-        get server_reminders_path(guild.id)
-        expect(response).to redirect_to(servers_path)
-      end
-    end
+    it_behaves_like "a config page that requires a manageable server"
 
     context "after loading the dashboard authorizes the server" do
       before do

--- a/spec/requests/roles_config_spec.rb
+++ b/spec/requests/roles_config_spec.rb
@@ -3,18 +3,11 @@
 require "rails_helper"
 
 RSpec.describe "Roles config", type: :request do
-  include_context "discord auth"
+  include_context "plugin config request"
 
-  let(:guild) { Bot::Discord::Guild.new(id: 900_000_001, name: "Dev Refuge", owner: true, permissions: 0, icon: nil, member_count: 5) }
-  let(:config) { ServerConfiguration.find_by(discord_id: guild.id) }
-  let(:turbo) { {headers: {"Accept" => "text/vnd.turbo-stream.html"}} }
+  let(:plugin_path) { server_roles_path(guild.id) }
 
-  context "when signed out" do
-    it "redirects to the sign-in page" do
-      get server_roles_path(900_000_001)
-      expect(response).to redirect_to(root_path)
-    end
-  end
+  it_behaves_like "a config page that requires sign-in"
 
   context "when signed in" do
     let!(:roles) { create(:plugin, key: "roles", name: "Roles") }
@@ -28,16 +21,7 @@ RSpec.describe "Roles config", type: :request do
       allow(Bot::Discord::UserGuilds).to receive(:call).and_return([guild])
     end
 
-    context "when the user no longer manages the server" do
-      before do
-        allow(Bot::Discord::UserGuilds).to receive(:call).and_return([])
-      end
-
-      it "redirects to the picker" do
-        get server_roles_path(guild.id)
-        expect(response).to redirect_to(servers_path)
-      end
-    end
+    it_behaves_like "a config page that requires a manageable server"
 
     context "after loading the dashboard authorizes the server" do
       before do

--- a/spec/requests/spam_protection_config_spec.rb
+++ b/spec/requests/spam_protection_config_spec.rb
@@ -3,18 +3,11 @@
 require "rails_helper"
 
 RSpec.describe "Spam protection config", type: :request do
-  include_context "discord auth"
+  include_context "plugin config request"
 
-  let(:guild) { Bot::Discord::Guild.new(id: 900_000_001, name: "Dev Refuge", owner: true, permissions: 0, icon: nil, member_count: 5) }
-  let(:config) { ServerConfiguration.find_by(discord_id: guild.id) }
-  let(:turbo) { {headers: {"Accept" => "text/vnd.turbo-stream.html"}} }
+  let(:plugin_path) { server_spam_protection_path(guild.id) }
 
-  context "when signed out" do
-    it "redirects to the sign-in page" do
-      get server_spam_protection_path(900_000_001)
-      expect(response).to redirect_to(root_path)
-    end
-  end
+  it_behaves_like "a config page that requires sign-in"
 
   context "when signed in" do
     let!(:moderation_plugin) { create(:plugin, key: "moderation", name: "Server Shield") }
@@ -29,16 +22,7 @@ RSpec.describe "Spam protection config", type: :request do
       allow(Bot::Discord::UserGuilds).to receive(:call).and_return([guild])
     end
 
-    context "when the user no longer manages the server" do
-      before do
-        allow(Bot::Discord::UserGuilds).to receive(:call).and_return([])
-      end
-
-      it "redirects to the picker" do
-        get server_spam_protection_path(guild.id)
-        expect(response).to redirect_to(servers_path)
-      end
-    end
+    it_behaves_like "a config page that requires a manageable server"
 
     context "after loading the dashboard authorizes the server" do
       before { get server_path(guild.id) }

--- a/spec/requests/welcomes_config_spec.rb
+++ b/spec/requests/welcomes_config_spec.rb
@@ -3,18 +3,11 @@
 require "rails_helper"
 
 RSpec.describe "Welcomes config", type: :request do
-  include_context "discord auth"
+  include_context "plugin config request"
 
-  let(:guild) { Bot::Discord::Guild.new(id: 900_000_001, name: "Dev Refuge", owner: true, permissions: 0, icon: nil, member_count: 5) }
-  let(:config) { ServerConfiguration.find_by(discord_id: guild.id) }
-  let(:turbo) { {headers: {"Accept" => "text/vnd.turbo-stream.html"}} }
+  let(:plugin_path) { server_welcomes_path(guild.id) }
 
-  context "when signed out" do
-    it "redirects to the sign-in page" do
-      get server_welcomes_path(900_000_001)
-      expect(response).to redirect_to(root_path)
-    end
-  end
+  it_behaves_like "a config page that requires sign-in"
 
   context "when signed in" do
     let!(:welcomes) { create(:plugin, key: "welcomes", name: "Welcomes") }
@@ -26,13 +19,7 @@ RSpec.describe "Welcomes config", type: :request do
       allow(Bot::Discord::UserGuilds).to receive(:call).and_return([guild])
     end
 
-    context "when the user no longer manages the server" do
-      it "redirects to the picker" do
-        allow(Bot::Discord::UserGuilds).to receive(:call).and_return([])
-        get server_welcomes_path(guild.id)
-        expect(response).to redirect_to(servers_path)
-      end
-    end
+    it_behaves_like "a config page that requires a manageable server"
 
     context "after loading the dashboard authorizes the server" do
       before do

--- a/spec/support/plugin_config_request.rb
+++ b/spec/support/plugin_config_request.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.shared_context "plugin config request" do
+  include_context "discord auth"
+
+  let(:guild) { Bot::Discord::Guild.new(id: 900_000_001, name: "Dev Refuge", owner: true, permissions: 0, icon: nil, member_count: 5) }
+  let(:config) { ServerConfiguration.find_by(discord_id: guild.id) }
+  let(:turbo) { {headers: {"Accept" => "text/vnd.turbo-stream.html"}} }
+end
+
+RSpec.shared_examples "a config page that requires sign-in" do
+  context "when signed out" do
+    it "redirects to the sign-in page" do
+      get plugin_path
+      expect(response).to redirect_to(root_path)
+    end
+  end
+end
+
+RSpec.shared_examples "a config page that requires a manageable server" do
+  context "when the user no longer manages the server" do
+    before do
+      allow(Bot::Discord::UserGuilds).to receive(:call).and_return([])
+    end
+
+    it "redirects to the picker" do
+      get plugin_path
+      expect(response).to redirect_to(servers_path)
+    end
+  end
+end


### PR DESCRIPTION
Fourth of four independent cleanup PRs from a bloat audit. Test-only; no app code changes.

## The problem

Eight `spec/requests/*_config_spec.rb` files each opened with the same ~19 lines: an identical `Bot::Discord::Guild` literal, identical `config` and `turbo` lets, and the same two guard cases — *signed out redirects home*, *losing access to the server redirects to the picker*.

That contract is the same for every config page, but it was written out eight times, so it could drift eight different ways. It already had: `welcomes_config_spec.rb` stubbed inside the `it` while the other seven used a `before`.

## The change

One `spec/support/plugin_config_request.rb` holding a shared context (the three lets) and two shared example groups, driven by a per-file `let(:plugin_path)`.

    include_context "plugin config request"

    let(:plugin_path) { server_logging_path(guild.id) }

    it_behaves_like "a config page that requires sign-in"
    # …and inside "when signed in":
    it_behaves_like "a config page that requires a manageable server"

**Scope was kept deliberately tight.** Only the duplicated setup and those two guard cases move. Every plugin-specific `let!` factory, every `before` that creates settings, and every GET/PATCH example is untouched — shared examples that swallow *behavioural* assertions are the thing you can't decode at 3am, so they stay in their own files.

Net −94 lines (−157 in the specs, +31 in the new support file, +32 in call sites).

## Left alone on purpose

- `spec/requests/servers/twilight_struggle_spec.rb` — doesn't share the shape.
- `logging_config_spec.rb` has three `redirect_to(servers_path)` assertions; only the one matching the shared guard was converted. The two "when the user is demoted afterward" cases (a page load and a save attempt) are logging-specific and stay.
- Many examples inline their `get`/`patch` instead of using a named `subject`, against the house rule. Converting those is a much bigger job and is not in this PR.

## Verification

`bundle exec rspec` **2990 examples / 0 failures — the same count as before the refactor**, which is the check that matters here: no example was silently dropped. `standardrb` clean · `rake active_record_doctor` clean · `undercover --compare origin/main` clean.