### PR TITLE
Extract the repeated field and config-section markup into components

### DIFF
--- a/app/components/config_sections.rb
+++ b/app/components/config_sections.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Components::ConfigSections < Components::Base
+  def initialize(key:, enable_error: nil, data: {})
+    @key = key
+    @enable_error = enable_error
+    @data = data
+  end
+
+  def view_template(&block)
+    div(id: "#{@key}-config", class: "flex flex-col gap-5", data: @data) do
+      enable_error_callout
+      yield
+    end
+  end
+
+  private
+
+  def enable_error_callout
+    return unless @enable_error
+
+    render Components::Callout.new(variant: :danger) { @enable_error }
+  end
+end

--- a/app/components/config_sections.rb
+++ b/app/components/config_sections.rb
@@ -7,7 +7,7 @@ class Components::ConfigSections < Components::Base
     @data = data
   end
 
-  def view_template(&block)
+  def view_template
     div(id: "#{@key}-config", class: "flex flex-col gap-5", data: @data) do
       enable_error_callout
       yield

--- a/app/components/field_help.rb
+++ b/app/components/field_help.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Components::FieldHelp < Components::Base
+  def view_template(&block)
+    p(class: "mt-1.5 text-xs text-text-muted", &block)
+  end
+end

--- a/app/components/field_label.rb
+++ b/app/components/field_label.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Components::FieldLabel < Components::Base
+  def view_template(&block)
+    label(class: "mb-1.5 block text-sm font-semibold", &block)
+  end
+end

--- a/app/components/lfg/config_form.rb
+++ b/app/components/lfg/config_form.rb
@@ -8,8 +8,7 @@ class Components::Lfg::ConfigForm < Components::Base
   end
 
   def view_template
-    div(id: "lfg-config", class: "flex flex-col gap-5", data: {controller: "pingable-roles"}) do
-      enable_error_callout
+    render Components::ConfigSections.new(key: "lfg", enable_error: @enable_error, data: {controller: "pingable-roles"}) do
       render Components::Lfg::SetupGuideCard.new
       render Components::Lfg::DefaultsCard.new(settings: @settings, role_options:, channels:)
       render Components::Lfg::PingableRolesCard.new(settings: @settings, context: card_context)
@@ -17,12 +16,6 @@ class Components::Lfg::ConfigForm < Components::Base
   end
 
   private
-
-  def enable_error_callout
-    return unless @enable_error
-
-    render Components::Callout.new(variant: :danger) { @enable_error }
-  end
 
   def card_context
     @card_context ||= Components::Lfg::PingableRoleFormContext.new(role_options:, channels:)

--- a/app/components/lfg/min_days_field.rb
+++ b/app/components/lfg/min_days_field.rb
@@ -12,7 +12,7 @@ class Components::Lfg::MinDaysField < Components::Base
 
   def view_template
     div do
-      label(class: "mb-1.5 block text-sm font-semibold") { @label }
+      render Components::FieldLabel.new { @label }
       render Components::NumberStepper.new(
         name: @name,
         value: @value,
@@ -22,7 +22,7 @@ class Components::Lfg::MinDaysField < Components::Base
         placeholder: @placeholder,
         input_class: "w-28"
       )
-      p(class: "mt-1.5 text-xs text-text-muted") { @help }
+      render Components::FieldHelp.new { @help }
     end
   end
 end

--- a/app/components/lfg/pingable_role_card.rb
+++ b/app/components/lfg/pingable_role_card.rb
@@ -62,7 +62,7 @@ class Components::Lfg::PingableRoleCard < Components::Base
 
   def role_field
     div do
-      label(class: "mb-1.5 block text-sm font-semibold") { t(".role.label") }
+      render Components::FieldLabel.new { t(".role.label") }
       render Components::TomSelect.new(
         name: field(:role_id),
         options: @context.role_options,
@@ -98,7 +98,7 @@ class Components::Lfg::PingableRoleCard < Components::Base
 
   def channel_field
     div do
-      label(class: "mb-1.5 block text-sm font-semibold") { t(".channel.label") }
+      render Components::FieldLabel.new { t(".channel.label") }
       render Components::ChannelSelect.new(
         name: "#{field(:allowed_channel_ids)}[]",
         options: @context.channels,
@@ -106,7 +106,7 @@ class Components::Lfg::PingableRoleCard < Components::Base
         placeholder: t(".channel.placeholder"),
         multiple: true
       )
-      p(class: "mt-1.5 text-xs text-text-muted") { t(".channel.help") }
+      render Components::FieldHelp.new { t(".channel.help") }
     end
   end
 

--- a/app/components/lfg/role_gate_field.rb
+++ b/app/components/lfg/role_gate_field.rb
@@ -12,14 +12,14 @@ class Components::Lfg::RoleGateField < Components::Base
 
   def view_template
     div do
-      label(class: "mb-1.5 block text-sm font-semibold") { @label }
+      render Components::FieldLabel.new { @label }
       render Components::RoleSelect.new(
         name: @name,
         options: @options,
         selected: @selected,
         placeholder: @placeholder
       )
-      p(class: "mt-1.5 text-xs text-text-muted") { @help }
+      render Components::FieldHelp.new { @help }
     end
   end
 end

--- a/app/components/logging/config_form.rb
+++ b/app/components/logging/config_form.rb
@@ -8,20 +8,13 @@ class Components::Logging::ConfigForm < Components::Base
   end
 
   def view_template
-    div(id: "logging-config", class: "flex flex-col gap-5") do
-      enable_error_callout
+    render Components::ConfigSections.new(key: "logging", enable_error: @enable_error) do
       channel_card
       events_card
     end
   end
 
   private
-
-  def enable_error_callout
-    return unless @enable_error
-
-    render Components::Callout.new(variant: :danger) { @enable_error }
-  end
 
   def channel_card
     render Components::ChannelCard.new(

--- a/app/components/moderation/account_age_card.rb
+++ b/app/components/moderation/account_age_card.rb
@@ -10,7 +10,7 @@ class Components::Moderation::AccountAgeCard < Components::Base
       div(class: "flex items-center justify-between gap-4") do
         div(class: "max-w-md") do
           label(class: "text-sm font-semibold") { t(".label") }
-          p(class: "mt-1.5 text-xs text-text-muted") { t(".help") }
+          render Components::FieldHelp.new { t(".help") }
         end
         render Components::NumberStepper.new(
           name: "moderation[new_account_age_days]",

--- a/app/components/moderation/image_scanning_form.rb
+++ b/app/components/moderation/image_scanning_form.rb
@@ -7,8 +7,7 @@ class Components::Moderation::ImageScanningForm < Components::Base
   end
 
   def view_template
-    div(id: "image_scanning-config", class: "flex flex-col gap-5") do
-      enable_error_callout
+    render Components::ConfigSections.new(key: "image_scanning", enable_error: @enable_error) do
       consent_callout
       report_scam_callout
       sensitivity_card
@@ -19,12 +18,6 @@ class Components::Moderation::ImageScanningForm < Components::Base
   end
 
   private
-
-  def enable_error_callout
-    return unless @enable_error
-
-    render Components::Callout.new(variant: :danger) { @enable_error }
-  end
 
   def consent_callout
     render Components::Callout.new(variant: :warning) do
@@ -46,7 +39,7 @@ class Components::Moderation::ImageScanningForm < Components::Base
 
   def sensitivity_card
     render Components::Card.new do
-      label(class: "block text-sm font-semibold mb-1.5") { t(".detection.sensitivity.label") }
+      render Components::FieldLabel.new { t(".detection.sensitivity.label") }
       render Components::RadioCardGroup.new(
         name: "image_scanning[sensitivity]",
         value: @settings.sensitivity,
@@ -83,7 +76,7 @@ class Components::Moderation::ImageScanningForm < Components::Base
 
   def keywords_field
     div do
-      label(class: "block text-sm font-semibold mb-1.5") { t(".custom_keywords.keywords_label") }
+      render Components::FieldLabel.new { t(".custom_keywords.keywords_label") }
       render Components::TomSelect.new(
         name: "image_scanning[custom_keywords][]",
         options: keyword_options,
@@ -91,7 +84,7 @@ class Components::Moderation::ImageScanningForm < Components::Base
         multiple: true,
         controller_data: {tom_select_create_value: true}
       )
-      p(class: "text-xs text-text-muted mt-1.5") { t(".custom_keywords.keywords_help") }
+      render Components::FieldHelp.new { t(".custom_keywords.keywords_help") }
     end
   end
 
@@ -100,7 +93,7 @@ class Components::Moderation::ImageScanningForm < Components::Base
     max = keyword_count.positive? ? keyword_count : nil
 
     div do
-      label(class: "block text-sm font-semibold mb-1.5") { t(".custom_keywords.min_hits_label") }
+      render Components::FieldLabel.new { t(".custom_keywords.min_hits_label") }
       div(class: "flex items-start gap-2.5") do
         render Components::NumberStepper.new(
           name: "image_scanning[custom_keyword_min_hits]",
@@ -113,7 +106,7 @@ class Components::Moderation::ImageScanningForm < Components::Base
           t(".custom_keywords.min_hits_suffix")
         end
       end
-      p(class: "text-xs text-text-muted mt-1.5") { t(".custom_keywords.min_hits_help") }
+      render Components::FieldHelp.new { t(".custom_keywords.min_hits_help") }
     end
   end
 
@@ -129,7 +122,7 @@ class Components::Moderation::ImageScanningForm < Components::Base
 
   def action_field
     div do
-      label(class: "block text-sm font-semibold mb-1.5") { t(".response.action.label") }
+      render Components::FieldLabel.new { t(".response.action.label") }
       render Components::SegmentedControl.new(
         name: "image_scanning[action]",
         value: @settings.action,
@@ -138,13 +131,13 @@ class Components::Moderation::ImageScanningForm < Components::Base
           {value: "none", label: t(".response.action.flag_only")}
         ]
       )
-      p(class: "text-xs text-text-muted mt-1.5") { t(".response.action.help") }
+      render Components::FieldHelp.new { t(".response.action.help") }
     end
   end
 
   def punishment_field
     div do
-      label(class: "block text-sm font-semibold mb-1.5") { t(".response.punishment.label") }
+      render Components::FieldLabel.new { t(".response.punishment.label") }
       render Components::Moderation::PunishmentControl.new(
         name: "image_scanning[punishment]",
         value: @settings.punishment,
@@ -155,14 +148,14 @@ class Components::Moderation::ImageScanningForm < Components::Base
 
   def confirmed_punishment_field
     div do
-      label(class: "block text-sm font-semibold mb-1.5") { t(".response.confirmed_punishment.label") }
+      render Components::FieldLabel.new { t(".response.confirmed_punishment.label") }
       render Components::Moderation::PunishmentControl.new(
         name: "image_scanning[confirmed_punishment]",
         value: @settings.confirmed_punishment,
         timeout_seconds: @settings.confirmed_timeout_seconds,
         none_label: t(".response.confirmed_punishment.inherit")
       )
-      p(class: "text-xs text-text-muted mt-1.5") { t(".response.confirmed_punishment.help") }
+      render Components::FieldHelp.new { t(".response.confirmed_punishment.help") }
     end
   end
 

--- a/app/components/moderation/overview_form.rb
+++ b/app/components/moderation/overview_form.rb
@@ -8,8 +8,7 @@ class Components::Moderation::OverviewForm < Components::Base
   end
 
   def view_template
-    div(id: "moderation-config", class: "flex flex-col gap-5") do
-      enable_error_callout
+    render Components::ConfigSections.new(key: "moderation", enable_error: @enable_error) do
       render Components::Moderation::StaffRoleCard.new(
         server_configuration: @config,
         staff_role_id: @context.staff_role_id,
@@ -27,13 +26,5 @@ class Components::Moderation::OverviewForm < Components::Base
       )
       render Components::Moderation::MatchingExplainer.new
     end
-  end
-
-  private
-
-  def enable_error_callout
-    return unless @enable_error
-
-    render Components::Callout.new(variant: :danger) { @enable_error }
   end
 end

--- a/app/components/moderation/punishment_control.rb
+++ b/app/components/moderation/punishment_control.rb
@@ -54,7 +54,7 @@ class Components::Moderation::PunishmentControl < Components::Base
         options: duration_options,
         selected: @timeout_seconds
       )
-      p(class: "text-xs text-text-muted mt-1.5") do
+      render Components::FieldHelp.new do
         t("components.moderation.punishment_control.duration_help")
       end
     end

--- a/app/components/moderation/spam_protection_form.rb
+++ b/app/components/moderation/spam_protection_form.rb
@@ -7,20 +7,13 @@ class Components::Moderation::SpamProtectionForm < Components::Base
   end
 
   def view_template
-    div(id: "spam_protection-config", class: "flex flex-col gap-5") do
-      enable_error_callout
+    render Components::ConfigSections.new(key: "spam_protection", enable_error: @enable_error) do
       detection_card
       response_card
     end
   end
 
   private
-
-  def enable_error_callout
-    return unless @enable_error
-
-    render Components::Callout.new(variant: :danger) { @enable_error }
-  end
 
   def detection_card
     render Components::Card.new do
@@ -34,7 +27,7 @@ class Components::Moderation::SpamProtectionForm < Components::Base
 
   def trigger_threshold_field
     div do
-      label(class: "block text-sm font-semibold mb-1.5") do
+      render Components::FieldLabel.new do
         t(".detection.trigger_threshold.label")
       end
       div(class: "flex items-start gap-2.5 flex-wrap") do
@@ -63,7 +56,7 @@ class Components::Moderation::SpamProtectionForm < Components::Base
 
   def match_strictness_field
     div do
-      label(class: "block text-sm font-semibold mb-1.5") { t(".detection.match_strictness.label") }
+      render Components::FieldLabel.new { t(".detection.match_strictness.label") }
       render Components::RangeSlider.new(
         name: "spam_protection[similarity]",
         value: @settings.similarity,
@@ -73,7 +66,7 @@ class Components::Moderation::SpamProtectionForm < Components::Base
         min: 75,
         max: 100
       )
-      p(class: "text-xs text-text-muted mt-1.5") { t(".detection.match_strictness.help") }
+      render Components::FieldHelp.new { t(".detection.match_strictness.help") }
       p(class: "text-xs text-text-muted mt-1") { t(".detection.match_strictness.recommended") }
     end
   end
@@ -105,7 +98,7 @@ class Components::Moderation::SpamProtectionForm < Components::Base
 
   def action_field
     div do
-      label(class: "block text-sm font-semibold mb-1.5") { t(".response.action.label") }
+      render Components::FieldLabel.new { t(".response.action.label") }
       render Components::SegmentedControl.new(
         name: "spam_protection[action]",
         value: @settings.action,
@@ -114,13 +107,13 @@ class Components::Moderation::SpamProtectionForm < Components::Base
           {value: "notify_only", label: t(".response.action.notify_only")}
         ]
       )
-      p(class: "text-xs text-text-muted mt-1.5") { t(".response.action.help") }
+      render Components::FieldHelp.new { t(".response.action.help") }
     end
   end
 
   def punishment_field
     div do
-      label(class: "block text-sm font-semibold mb-1.5") { t(".response.punishment.label") }
+      render Components::FieldLabel.new { t(".response.punishment.label") }
       render Components::Moderation::PunishmentControl.new(
         name: "spam_protection[punishment]",
         value: @settings.punishment,

--- a/app/components/moderation/staff_ping_card.rb
+++ b/app/components/moderation/staff_ping_card.rb
@@ -10,7 +10,7 @@ class Components::Moderation::StaffPingCard < Components::Base
       div(class: "flex items-center justify-between gap-4") do
         div(class: "max-w-md") do
           label(class: "text-sm font-semibold") { t(".label") }
-          p(class: "mt-1.5 text-xs text-text-muted") { t(".help") }
+          render Components::FieldHelp.new { t(".help") }
         end
         render Components::Toggle.new(
           name: "moderation[ping_staff]",

--- a/app/components/moderation/staff_role_card.rb
+++ b/app/components/moderation/staff_role_card.rb
@@ -13,7 +13,7 @@ class Components::Moderation::StaffRoleCard < Components::Base
 
   def view_template
     render Components::Card.new do
-      label(class: "block text-sm font-semibold mb-1.5") do
+      render Components::FieldLabel.new do
         plain t(".label")
         span(class: "ml-1 text-xs font-semibold text-danger") { "*" }
       end
@@ -29,7 +29,7 @@ class Components::Moderation::StaffRoleCard < Components::Base
         }
       )
       missing_warning if @missing
-      p(class: "mt-1.5 text-xs text-text-muted") { t(".help") } unless @missing
+      render Components::FieldHelp.new { t(".help") } unless @missing
       warning_callout(t(".permission_warning_bold"), t(".permission_warning_body")) if @permission_warning
       warning_callout(t(".staff_permission_warning_bold"), t(".staff_permission_warning_body")) if @staff_permission_warning
     end

--- a/app/components/reminders/config_form.rb
+++ b/app/components/reminders/config_form.rb
@@ -6,7 +6,7 @@ class Components::Reminders::ConfigForm < Components::Base
   end
 
   def view_template
-    div(id: "reminders-config", class: "flex flex-col gap-5") do
+    render Components::ConfigSections.new(key: "reminders") do
       force_dm_card
       command_callout
     end

--- a/app/components/roles/config_form.rb
+++ b/app/components/roles/config_form.rb
@@ -7,7 +7,7 @@ class Components::Roles::ConfigForm < Components::Base
   end
 
   def view_template
-    div(id: "roles-config", class: "flex flex-col gap-5", data: {controller: "role-sets"}) do
+    render Components::ConfigSections.new(key: "roles", data: {controller: "role-sets"}) do
       bot_at_bottom_callout
       default_channel_card
       role_sets_section

--- a/app/components/roles/role_set_card.rb
+++ b/app/components/roles/role_set_card.rb
@@ -87,7 +87,7 @@ class Components::Roles::RoleSetCard < Components::Base
   def top_fields
     div(class: "grid gap-5 sm:grid-cols-2") do
       div do
-        label(class: "mb-1.5 block text-sm font-semibold") { t(".name.label") }
+        render Components::FieldLabel.new { t(".name.label") }
         input(
           type: "text",
           name: field(:name),
@@ -99,7 +99,7 @@ class Components::Roles::RoleSetCard < Components::Base
         )
       end
       div do
-        label(class: "mb-1.5 block text-sm font-semibold") { t(".selection.label") }
+        render Components::FieldLabel.new { t(".selection.label") }
         render Components::SegmentedControl.new(
           name: field(:selection_mode),
           value: @data.selection_mode,
@@ -114,7 +114,7 @@ class Components::Roles::RoleSetCard < Components::Base
 
   def channel_override_field
     div do
-      label(class: "mb-1.5 block text-sm font-semibold") do
+      render Components::FieldLabel.new do
         plain t(".channel.label")
         span(class: "font-normal text-text-muted") { " #{t(".channel.optional")}" }
       end
@@ -130,7 +130,7 @@ class Components::Roles::RoleSetCard < Components::Base
 
   def roles_field
     div do
-      label(class: "mb-1.5 block text-sm font-semibold") { t(".roles.label") }
+      render Components::FieldLabel.new { t(".roles.label") }
       render Components::RoleSelect.new(
         name: "#{field(:role_ids)}[]",
         options: @context.role_options,

--- a/app/components/twilight_struggle/config_form.rb
+++ b/app/components/twilight_struggle/config_form.rb
@@ -8,7 +8,7 @@ class Components::TwilightStruggle::ConfigForm < Components::Base
   end
 
   def view_template
-    div(id: "twilight_struggle-config", class: "flex flex-col gap-5", data: {controller: "twilight-struggle-preview", action: "input->twilight-struggle-preview#render"}) do
+    render Components::ConfigSections.new(key: "twilight_struggle", data: {controller: "twilight-struggle-preview", action: "input->twilight-struggle-preview#render"}) do
       channel_card
       render Components::TwilightStruggle::PingCard.new(destination: @destination, inherited:)
       render Components::TwilightStruggle::TokenHelpCard.new

--- a/app/components/welcomes/config_form.rb
+++ b/app/components/welcomes/config_form.rb
@@ -13,8 +13,7 @@ class Components::Welcomes::ConfigForm < Components::Base
   end
 
   def view_template
-    div(id: "welcomes-config", class: "flex flex-col gap-5", data: {controller: "welcome-preview"}) do
-      enable_error_callout
+    render Components::ConfigSections.new(key: "welcomes", enable_error: @enable_error, data: {controller: "welcome-preview"}) do
       channel_card
       message_cards
       placeholder_help
@@ -23,12 +22,6 @@ class Components::Welcomes::ConfigForm < Components::Base
   end
 
   private
-
-  def enable_error_callout
-    return unless @enable_error
-
-    render Components::Callout.new(variant: :danger) { @enable_error }
-  end
 
   def channel_card
     render Components::ChannelCard.new(

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -210,6 +210,12 @@ duplicated class strings:
 - **`Components::RadioCardGroup`** — stacked radio options as bordered cards with a
   title + one-line description; native radios, so selection is reactive with no JS.
 - **`Components::PrereqGate`** / **`Components::SidebarGroup`** — see *Plugin groups*.
+- **`Components::FieldLabel`** / **`Components::FieldHelp`** — the shared label
+  and help-text styling for a form field (`<label>` and `<p>` respectively); no
+  parameters, block content only.
+- **`Components::ConfigSections`** — the config-page section stack: renders the
+  `<key>-config` div Turbo targets, the vertical `gap-5` rhythm, and the
+  danger callout every plugin form was repeating (`enable_error:`).
 
 `Components::Icon` wraps Phosphor; names not in Phosphor (the `megaphone-slash`
 sub-plugin glyph) are served from its `CUSTOM_GLYPHS` map of inline SVGs.

--- a/spec/components/config_sections_spec.rb
+++ b/spec/components/config_sections_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::ConfigSections do
+  subject(:html) do
+    described_class.new(key:, enable_error:, data:).call { "Section body" }
+  end
+
+  let(:key) { "welcomes" }
+  let(:enable_error) { nil }
+  let(:data) { {} }
+
+  it "wraps the content in a div with the key-derived id" do
+    expect(html).to include('id="welcomes-config"')
+  end
+
+  it "renders the yielded block content" do
+    expect(html).to include("Section body")
+  end
+
+  it "does not render a danger callout" do
+    expect(html).not_to include("bg-danger-soft")
+  end
+
+  context "with data attributes" do
+    let(:data) { {controller: "welcome-preview"} }
+
+    it "renders the data attributes" do
+      expect(html).to include('data-controller="welcome-preview"')
+    end
+  end
+
+  context "with an enable_error" do
+    let(:enable_error) { "Something went wrong." }
+
+    it "renders a danger callout with the error" do
+      expect(html).to include("bg-danger-soft").and include("Something went wrong.")
+    end
+  end
+end

--- a/spec/components/field_help_spec.rb
+++ b/spec/components/field_help_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::FieldHelp do
+  subject(:html) { described_class.new.call { "Pick a channel." } }
+
+  it "renders the block content inside a p carrying the shared classes" do
+    expect(html).to include("<p").and include('class="mt-1.5 text-xs text-text-muted"').and include("Pick a channel.")
+  end
+end

--- a/spec/components/field_label_spec.rb
+++ b/spec/components/field_label_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::FieldLabel do
+  subject(:html) { described_class.new.call { "Channel" } }
+
+  it "renders the block content inside a label carrying the shared classes" do
+    expect(html).to include("<label").and include('class="mb-1.5 block text-sm font-semibold"').and include("Channel")
+  end
+end


### PR DESCRIPTION
Third of four independent cleanup PRs from a bloat audit. Pure view refactor — rendered HTML is unchanged.

## `FieldLabel` / `FieldHelp`

Form-field labels and help text were raw class strings at 32 call sites — and in **two different orderings of the same styles**:

| | count |
|---|---|
| `"block text-sm font-semibold mb-1.5"` | 11 |
| `"mb-1.5 block text-sm font-semibold"` | 8 |
| `"text-xs text-text-muted mt-1.5"` | 7 |
| `"mt-1.5 text-xs text-text-muted"` | 6 |

Two actual styles, four spellings. The split runs along authorship — `lfg/*` and `roles/*` wrote one order, `moderation/*` the other — so grepping for either spelling found roughly half the sites, which is how it stayed unnoticed.

Now `render Components::FieldLabel.new { … }` and `render Components::FieldHelp.new { … }`. No parameters, block content only.

## `ConfigSections`

Every plugin config form opened with its own copy of

```ruby
div(id: "<key>-config", class: "flex flex-col gap-5", data: …) do
  enable_error_callout
  …
end
```

and six of the nine carried a byte-identical private `enable_error_callout`. One component now owns the Turbo target id, the vertical rhythm, and the error callout.

## Deliberately left alone

- **`FieldLabel` takes no parameters and emits no `for:`.** Not one call site passes one today. The missing `for:` is a pre-existing accessibility gap; adding the plumbing speculatively is a different PR.
- **Near-miss class strings stay as they are** — `"text-xs text-text-muted mt-1"` (`mt-1`, not `mt-1.5`), `"text-xs text-text-muted mt-1.5 max-w-md"`, `"block text-xs font-semibold mb-1.5"` (`text-xs`), and the toggle-row `label(class: "text-sm font-semibold")` in `staff_ping_card.rb` / `account_age_card.rb`, which aren't field labels. Only exact matches were converted.

## Verification

`bundle exec rspec` **2997 examples / 0 failures** — 2990 before, plus 7 from the three new component specs. The nine config-form component specs and the config request specs were untouched and still pass, which is what proves the markup didn't move.

`standardrb` clean · `rake active_record_doctor` clean · `undercover --compare origin/main` clean.

`docs/design/design-system.md` § Core components documents all three.

> No browser in my sandbox, so the visual check is yours to run — though nothing should have moved a pixel.