### PR TITLE
Make the unused-locale-key report trustworthy, then gate on it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,9 +121,14 @@ jobs:
         with:
           bundler-cache: true
 
-      # `unused` is intentionally omitted: it can't see dynamic `t("#{...}")` calls.
       - name: Check for missing locale keys
         run: bundle exec i18n-tasks missing
+
+      # Every key the scanner can't trace is listed in i18n-tasks.yml's
+      # ignore_unused with the indirection that hides it. A new failure here is
+      # either a genuinely dead key or a new indirection to add to that list.
+      - name: Check for unused locale keys
+        run: bundle exec i18n-tasks unused
 
       - name: Check locale files are normalized
         run: bundle exec i18n-tasks check-normalized

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -20,9 +20,32 @@ ignore_missing:
   - views.servers.moderation.sub_plugin_show.*
   - views.servers.plugin_config_show.*
 
+# Every entry here is a key that IS used, by an indirection the static scanner
+# cannot follow. Keep this list exact — a wildcard wide enough to cover a real
+# dead key makes the whole report worthless. Four mechanisms, in order:
+#
+# 1. The abstract show views resolve `t(".key")` against the subclass scope, so
+#    the scanner attributes the lookup to the base class instead.
+# 2. A ternary inside the `t()` call.
+# 3. Key strings held in a constant and looked up by symbol.
+# 4. The key chosen by a ternary before the `t()` call.
 ignore_unused:
+  # 1. Views::Servers::Moderation::SubPluginShow subclasses
   - views.servers.spam_protection.show.*
   - views.servers.image_scanning.show.*
+  # 1. Views::Servers::PluginConfigShow subclasses
+  - views.servers.logging.show.*
+  - views.servers.roles.show.*
+  - views.servers.welcomes.show.*
+  # 2. Admin::SettingsController#update
+  - admin.settings.dms_enabled
+  - admin.settings.dms_disabled
+  # 3. AssignableRoleOptions::REASON_KEYS
+  - assignable_roles.managed
+  - assignable_roles.above_bot
+  # 4. Servers::PluginsController#feedback
+  - servers.plugin_enabled
+  - servers.plugin_disabled
 
 search:
   paths:


### PR DESCRIPTION
From the navigability audit, item 4. Config only — no app code touched.

`bundle exec i18n-tasks unused` reported 15 keys. **All 15 were false positives**, from four distinct indirections the static scanner can't follow:

| # | Mechanism | Keys |
|---|---|---|
| 1 | `t(".title")` in an abstract show view resolves against the **subclass** scope at runtime, so the scanner attributes it to the base class | 9 |
| 2 | a ternary *inside* the `t()` call — `t(result.value ? "…dms_enabled" : "…dms_disabled")` | 2 |
| 3 | key strings held in a constant and looked up by symbol — `AssignableRoleOptions::REASON_KEYS` | 2 |
| 4 | the key chosen by a ternary *before* the call — `PluginsController#feedback` | 2 |

Mechanism 1 was already half-handled: `ignore_unused` carried the two `SubPluginShow` subclasses but not the three `PluginConfigShow` ones. Someone hit this, fixed half, and stopped — which left the report at 15 findings, all noise, so it was unrunnable and stayed unrun.

All four are now listed, each with the reason it's there. Entries name **exact keys** rather than wide globs, deliberately: a wildcard broad enough to swallow a real dead key would make the report worthless again.

The report is now clean, so `unused` joins `missing` in the CI i18n job. The comment claiming it was "intentionally omitted" is gone — it was true, but only because of the half-finished config it described.

A future failure here means one of two things, both worth knowing: a genuinely dead key, or a new indirection to add to the list.

## Verification

`i18n-tasks unused` ✓ · `i18n-tasks missing` ✓ · `i18n-tasks check-normalized` ✓ · `standardrb` clean · workflow YAML parses.

## Note

This does **not** delete any key. You were right to refuse that — the report was lying, and this PR is why.