### PR TITLE
Move LoggingSetting to Logging::Settings

### DIFF
--- a/app/bot/activity_log.rb
+++ b/app/bot/activity_log.rb
@@ -7,7 +7,7 @@ module Bot
     module_function
 
     def post(server_configuration, bot:, title:, body:, meta:, image: nil, components: [], allowed_mentions: SUPPRESS_MENTIONS, subject: nil)
-      channel_id = server_configuration.logging_setting.channel_id
+      channel_id = server_configuration.logging_settings.channel_id
       return unless channel_id
 
       deliver(bot, channel_id, entry(title, body, meta, image:, components:), allowed_mentions:, attachments: image && [image], subject:)
@@ -16,7 +16,7 @@ module Bot
     def enabled?(server_configuration, action)
       return false unless server_configuration.plugins.enabled.exists?(key: :logging)
 
-      server_configuration.logging_setting.action_enabled?(action)
+      server_configuration.logging_settings.action_enabled?(action)
     end
 
     def entry(title, body, meta, image: nil, components: [])

--- a/app/components/logging/config_form.rb
+++ b/app/components/logging/config_form.rb
@@ -3,7 +3,7 @@
 class Components::Logging::ConfigForm < Components::Base
   def initialize(server_configuration:, enable_error: nil)
     @config = server_configuration
-    @settings = server_configuration.logging_setting
+    @settings = server_configuration.logging_settings
     @enable_error = enable_error
   end
 

--- a/app/models/logging/settings.rb
+++ b/app/models/logging/settings.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Logging
+  class Settings < ApplicationRecord
+    self.table_name = "logging_settings"
+
+    belongs_to :server_configuration
+
+    def action_enabled?(action)
+      enabled_actions[action.to_s] == true
+    end
+  end
+end

--- a/app/models/logging_setting.rb
+++ b/app/models/logging_setting.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-class LoggingSetting < ApplicationRecord
-  belongs_to :server_configuration
-
-  def action_enabled?(action)
-    enabled_actions[action.to_s] == true
-  end
-end

--- a/app/models/plugin_catalog.rb
+++ b/app/models/plugin_catalog.rb
@@ -43,10 +43,10 @@ class PluginCatalog
   end
 
   DEFINITIONS = [
-    Definition.new(key: :logging, name: "Logging", description: "Writes moderation actions to a log channel.", channel_setting: :logging_setting),
+    Definition.new(key: :logging, name: "Logging", description: "Writes moderation actions to a log channel.", channel_setting: :logging_settings),
     Definition.new(key: :roles, name: "Roles", description: "Self-assignable roles.", channel_setting: :role_setting),
     Definition.new(key: :welcomes, name: "Welcomes", description: "Join and leave messages.", channel_setting: :welcome_settings),
-    Definition.new(key: :moderation, name: "Server Shield", description: "Your server's aegis: automated moderation beyond Discord's AutoMod.", requires_plugin: :logging, prerequisite: ->(c) { c.logging_setting&.channel_id.present? }),
+    Definition.new(key: :moderation, name: "Server Shield", description: "Your server's aegis: automated moderation beyond Discord's AutoMod.", requires_plugin: :logging, prerequisite: ->(c) { c.logging_settings&.channel_id.present? }),
     Definition.new(key: :spam_protection, name: "Cross-Channel Spam Guard", description: "Detects the same message blasted across multiple channels within seconds and purges it before it spreads. Matching is fingerprint-based — message content is never stored.", parent: :moderation, prerequisite: ->(c) { c.moderation_settings&.staff_role_id.present? }),
     Definition.new(key: :image_scanning, name: "Scam Image Detection", description: "Reads the text inside posted images and checks it against known scam patterns and previously confirmed scam images. Staff confirm or dismiss every catch, and the bot remembers.", parent: :moderation, prerequisite: ->(c) { c.moderation_settings&.staff_role_id.present? }),
     Definition.new(key: :lfg, name: "Looking for Game", description: "Let members find people to play with both on the fly and scheduled in the future. Only shrkbot will ping, allowing you to turn off generally available role pings."),

--- a/app/models/server_configuration.rb
+++ b/app/models/server_configuration.rb
@@ -5,7 +5,7 @@ class ServerConfiguration < ApplicationRecord
   has_many :plugins, through: :plugin_activations
   has_many :bespoke_plugin_grants, dependent: :delete_all
 
-  has_one :logging_setting, dependent: :delete
+  has_one :logging_settings, class_name: "Logging::Settings", dependent: :delete
   has_one :role_setting, class_name: "Roles::Settings", dependent: :destroy
   has_one :welcome_settings, class_name: "Welcomes::Settings", dependent: :delete
   has_one :moderation_settings, class_name: "Moderation::Settings", dependent: :delete

--- a/app/operations/logging/configure.rb
+++ b/app/operations/logging/configure.rb
@@ -8,7 +8,7 @@ module Ops
       receives :server_configuration, :channel_id, :enabled_actions, :enabled
 
       def call
-        settings = server_configuration.logging_setting
+        settings = server_configuration.logging_settings
         settings.assign_attributes(channel_id:, enabled_actions:)
         activation = staged_activation
 

--- a/app/operations/logging/settings/update.rb
+++ b/app/operations/logging/settings/update.rb
@@ -9,7 +9,7 @@ module Ops
         def call
           return failure(I18n.t("operations.logging.channel_required")) if channel_id.blank?
 
-          setting = server_configuration.logging_setting
+          setting = server_configuration.logging_settings
           setting.update!(channel_id:)
           ok(setting, warnings: visibility_warnings)
         end

--- a/app/operations/moderation/configure.rb
+++ b/app/operations/moderation/configure.rb
@@ -27,7 +27,7 @@ module Ops
 
       def logging_ready?
         server_configuration.plugins.enabled.exists?(key: :logging) &&
-          server_configuration.logging_setting&.channel_id.present?
+          server_configuration.logging_settings&.channel_id.present?
       end
 
       def sub_plugin_enabled?

--- a/app/operations/server_configuration/ensure.rb
+++ b/app/operations/server_configuration/ensure.rb
@@ -29,7 +29,7 @@ module Ops
       end
 
       def ensure_settings(config)
-        config.logging_setting || config.create_logging_setting!
+        config.logging_settings || config.create_logging_settings!
         config.role_setting || config.create_role_setting!
         config.welcome_settings || config.create_welcome_settings!
         config.moderation_settings || config.create_moderation_settings!

--- a/app/presenters/moderation/overview_context.rb
+++ b/app/presenters/moderation/overview_context.rb
@@ -19,7 +19,7 @@ module Moderation
 
     def logging_ready?
       enabled_keys.include?(:logging) &&
-        @config.logging_setting&.channel_id.present?
+        @config.logging_settings&.channel_id.present?
     end
 
     def staff_role_id
@@ -67,9 +67,9 @@ module Moderation
     end
 
     def logging_channel_name
-      return unless @config.logging_setting&.channel_id
+      return unless @config.logging_settings&.channel_id
 
-      @config.server_channels.find_by(discord_id: @config.logging_setting.channel_id)&.name
+      @config.server_channels.find_by(discord_id: @config.logging_settings.channel_id)&.name
     end
 
     private

--- a/config/initializers/web_debug.rb
+++ b/config/initializers/web_debug.rb
@@ -32,7 +32,7 @@ if ENV["WEB_DEBUG"] && Rails.env.development?
       end
       PluginActivation.find_or_create_by!(server_configuration: config, plugin:)
     end
-    config.create_logging_setting!(channel_id: 111) unless config.logging_setting
+    config.create_logging_settings!(channel_id: 111) unless config.logging_settings
     config.create_moderation_settings! unless config.moderation_settings
     config.create_spam_protection_settings! unless config.spam_protection_settings
     config.create_image_scanning_settings! unless config.image_scanning_settings

--- a/config/preview_data.yml
+++ b/config/preview_data.yml
@@ -88,7 +88,7 @@ roles:
 
 plugins:
   - plugin: logging
-    settings_association: logging_setting
+    settings_association: logging_settings
     enabled: true
     settings:
       channel_id: 105

--- a/spec/bot/activity_log_spec.rb
+++ b/spec/bot/activity_log_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Bot::ActivityLog do
 
   before do
     create(
-      :logging_setting,
+      :logging_settings,
       server_configuration: server_config,
       channel_id: 555,
       enabled_actions: {"roles.role_gained" => true}
@@ -134,7 +134,7 @@ RSpec.describe Bot::ActivityLog do
 
     context "when no logging channel is set" do
       before do
-        server_config.logging_setting.update!(channel_id: nil)
+        server_config.logging_settings.update!(channel_id: nil)
       end
 
       it "writes nothing" do

--- a/spec/bot/registration/guild_command_set_spec.rb
+++ b/spec/bot/registration/guild_command_set_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Bot::GuildCommandSet do
       end
 
       before do
-        create(:logging_setting, server_configuration: server)
+        create(:logging_settings, server_configuration: server)
         create(:plugin_activation, server_configuration: server, plugin: logging_plugin, enabled: true)
         create(:moderation_settings, server_configuration: server, staff_role_id: 888)
         create(:plugin_activation, server_configuration: server, plugin: moderation_plugin, enabled: true)

--- a/spec/components/logging/config_form_spec.rb
+++ b/spec/components/logging/config_form_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Components::Logging::ConfigForm do
   let(:config) { create(:server_configuration) }
 
   before do
-    create(:logging_setting, server_configuration: config)
+    create(:logging_settings, server_configuration: config)
   end
 
   it "renders the channel card with the required marker" do

--- a/spec/components/plugin_sidebar_spec.rb
+++ b/spec/components/plugin_sidebar_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Components::PluginSidebar do
       let!(:logging_plugin) { create(:plugin, key: "logging", name: "Logging") }
 
       before do
-        config.create_logging_setting!(channel_id: 111)
+        config.create_logging_settings!(channel_id: 111)
         config.create_moderation_settings!(staff_role_id: 555)
         config.create_spam_protection_settings!
         config.create_image_scanning_settings!
@@ -102,7 +102,7 @@ RSpec.describe Components::PluginSidebar do
       let!(:logging_plugin) { create(:plugin, key: "logging", name: "Logging") }
 
       before do
-        config.create_logging_setting!(channel_id: 111)
+        config.create_logging_settings!(channel_id: 111)
         config.create_moderation_settings!(staff_role_id: 555)
         config.create_spam_protection_settings!
         config.create_image_scanning_settings!

--- a/spec/factories/logging_settings.rb
+++ b/spec/factories/logging_settings.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :logging_setting do
+  factory :logging_settings, class: "Logging::Settings" do
     association :server_configuration
     sequence(:channel_id) { |n| 200_000 + n }
   end

--- a/spec/models/logging/settings_spec.rb
+++ b/spec/models/logging/settings_spec.rb
@@ -2,8 +2,8 @@
 
 require "rails_helper"
 
-RSpec.describe LoggingSetting do
-  subject(:setting) { build(:logging_setting, enabled_actions: actions) }
+RSpec.describe Logging::Settings do
+  subject(:setting) { build(:logging_settings, enabled_actions: actions) }
 
   describe "#action_enabled?" do
     context "when the action is toggled on" do

--- a/spec/models/moderation/image_scanning/settings_spec.rb
+++ b/spec/models/moderation/image_scanning/settings_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe Moderation::ImageScanning::Settings do
       let!(:moderation_plugin) { create(:plugin, key: "moderation", name: "Server Shield") }
 
       before do
-        server.create_logging_setting!(channel_id: 999)
+        server.create_logging_settings!(channel_id: 999)
         create(:plugin_activation, server_configuration: server, plugin: logging_plugin, enabled: true)
         create(:plugin_activation, server_configuration: server, plugin: moderation_plugin, enabled: true)
       end
@@ -203,7 +203,7 @@ RSpec.describe Moderation::ImageScanning::Settings do
       let!(:scan_plugin) { create(:plugin, key: "image_scanning", name: "Scam Image Detection") }
 
       before do
-        server.create_logging_setting!(channel_id: 999)
+        server.create_logging_settings!(channel_id: 999)
         create(:plugin_activation, server_configuration: server, plugin: logging_plugin, enabled: true)
         create(:plugin_activation, server_configuration: server, plugin: moderation_plugin, enabled: true)
         create(:plugin_activation, server_configuration: server, plugin: scan_plugin, enabled: false).update_column(:enabled, true)

--- a/spec/models/moderation/spam_protection/settings_spec.rb
+++ b/spec/models/moderation/spam_protection/settings_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe Moderation::SpamProtection::Settings do
       let!(:moderation_plugin) { create(:plugin, key: "moderation", name: "Server Shield") }
 
       before do
-        server.create_logging_setting!(channel_id: 999)
+        server.create_logging_settings!(channel_id: 999)
         create(:plugin_activation, server_configuration: server, plugin: logging_plugin, enabled: true)
         create(:plugin_activation, server_configuration: server, plugin: moderation_plugin, enabled: true)
       end
@@ -183,7 +183,7 @@ RSpec.describe Moderation::SpamProtection::Settings do
       let!(:spam_plugin) { create(:plugin, key: "spam_protection", name: "Cross-Channel Spam Guard") }
 
       before do
-        server.create_logging_setting!(channel_id: 999)
+        server.create_logging_settings!(channel_id: 999)
         create(:plugin_activation, server_configuration: server, plugin: logging_plugin, enabled: true)
         create(:plugin_activation, server_configuration: server, plugin: moderation_plugin, enabled: true)
         create(:plugin_activation, server_configuration: server, plugin: spam_plugin, enabled: false).update_column(:enabled, true)

--- a/spec/models/plugin_catalog_spec.rb
+++ b/spec/models/plugin_catalog_spec.rb
@@ -133,16 +133,16 @@ RSpec.describe PluginCatalog do
     end
 
     context "when channel-backed" do
-      subject(:check) { definition(channel_setting: :logging_setting).prerequisites_met?(config) }
+      subject(:check) { definition(channel_setting: :logging_settings).prerequisites_met?(config) }
 
       context "without a channel" do
-        let(:config) { double(logging_setting: nil) }
+        let(:config) { double(logging_settings: nil) }
 
         it { is_expected.to be(false) }
       end
 
       context "with a channel" do
-        let(:config) { double(logging_setting: double(channel_id: 5)) }
+        let(:config) { double(logging_settings: double(channel_id: 5)) }
 
         it { is_expected.to be(true) }
       end
@@ -217,7 +217,7 @@ RSpec.describe PluginCatalog do
     let!(:moderation_plugin) { create(:plugin, key: "moderation", name: "Server Shield") }
 
     before do
-      config.create_logging_setting!
+      config.create_logging_settings!
       config.create_moderation_settings!
       config.create_spam_protection_settings!
       config.create_image_scanning_settings!
@@ -228,7 +228,7 @@ RSpec.describe PluginCatalog do
 
       context "when logging is enabled and channel is set" do
         before do
-          config.logging_setting.update!(channel_id: 111)
+          config.logging_settings.update!(channel_id: 111)
           create(:plugin_activation, server_configuration: config, plugin: logging_plugin, enabled: false)
             .update_column(:enabled, true)
         end
@@ -245,9 +245,9 @@ RSpec.describe PluginCatalog do
         it { is_expected.to be(false) }
       end
 
-      context "when logging is enabled but logging_setting is absent" do
+      context "when logging is enabled but logging_settings is absent" do
         before do
-          config.logging_setting.destroy!
+          config.logging_settings.destroy!
           create(:plugin_activation, server_configuration: config, plugin: logging_plugin, enabled: false)
             .update_column(:enabled, true)
         end
@@ -339,7 +339,7 @@ RSpec.describe PluginCatalog do
         let(:config) do
           double(
             enabled_plugin_keys: enabled_keys,
-            logging_setting: double(channel_id: nil)
+            logging_settings: double(channel_id: nil)
           )
         end
 
@@ -350,7 +350,7 @@ RSpec.describe PluginCatalog do
         let(:config) do
           double(
             enabled_plugin_keys: enabled_keys,
-            logging_setting: double(channel_id: 999)
+            logging_settings: double(channel_id: 999)
           )
         end
 

--- a/spec/models/server_configuration_spec.rb
+++ b/spec/models/server_configuration_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ServerConfiguration do
     let(:roles) { create(:plugin, key: "roles", name: "Roles") }
 
     before do
-      server.create_logging_setting!(channel_id: 999)
+      server.create_logging_settings!(channel_id: 999)
       create(:plugin_activation, server_configuration: server, plugin: logging, enabled: true)
       create(:plugin_activation, server_configuration: server, plugin: roles, enabled: false)
     end
@@ -39,7 +39,7 @@ RSpec.describe ServerConfiguration do
     let(:roles) { create(:plugin, key: "roles", name: "Roles") }
 
     before do
-      server.create_logging_setting!(channel_id: 999)
+      server.create_logging_settings!(channel_id: 999)
       create(:plugin_activation, server_configuration: server, plugin: logging, enabled: true)
       create(:plugin_activation, server_configuration: server, plugin: roles, enabled: false)
     end

--- a/spec/operations/logging/configure_spec.rb
+++ b/spec/operations/logging/configure_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Ops::Logging::Configure do
 
   let(:config) { create(:server_configuration) }
   let!(:plugin) { create(:plugin, key: "logging", name: "Logging") }
-  let!(:settings) { config.create_logging_setting! }
+  let!(:settings) { config.create_logging_settings! }
   let(:channel_id) { 200 }
   let(:enabled_actions) { {"roles.role_gained" => true, "roles.role_lost" => false} }
   let(:enabled) { "1" }
@@ -22,9 +22,9 @@ RSpec.describe Ops::Logging::Configure do
   context "with a channel, enabling the plugin" do
     it "saves the channel, event toggles, and enables the plugin" do
       expect(result).to be_success
-      expect(config.logging_setting.reload.channel_id).to eq(200)
-      expect(config.logging_setting.action_enabled?("roles.role_gained")).to be(true)
-      expect(config.logging_setting.action_enabled?("roles.role_lost")).to be(false)
+      expect(config.logging_settings.reload.channel_id).to eq(200)
+      expect(config.logging_settings.action_enabled?("roles.role_gained")).to be(true)
+      expect(config.logging_settings.action_enabled?("roles.role_lost")).to be(false)
       expect(config.plugin_activations.find_by(plugin:).enabled).to be(true)
     end
   end
@@ -45,7 +45,7 @@ RSpec.describe Ops::Logging::Configure do
 
     it "stores the toggles and leaves the plugin disabled" do
       expect(result).to be_success
-      expect(config.logging_setting.reload.action_enabled?("roles.role_gained")).to be(true)
+      expect(config.logging_settings.reload.action_enabled?("roles.role_gained")).to be(true)
       expect(config.plugin_activations.find_by(plugin:)&.enabled).to be_falsey
     end
   end
@@ -54,7 +54,7 @@ RSpec.describe Ops::Logging::Configure do
     let!(:moderation_plugin) { create(:plugin, key: "moderation", name: "Server Shield") }
 
     before do
-      config.logging_setting.update!(channel_id: 200)
+      config.logging_settings.update!(channel_id: 200)
       create(:plugin_activation, server_configuration: config, plugin:, enabled: true)
       create(:plugin_activation, server_configuration: config, plugin: moderation_plugin, enabled: true)
     end

--- a/spec/operations/logging/settings/update_spec.rb
+++ b/spec/operations/logging/settings/update_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Ops::Logging::Settings::Update do
   subject(:result) { described_class.call(server_configuration: server, channel_id:) }
 
   let(:server) { create(:server_configuration, discord_id: 1) }
-  let!(:setting) { server.create_logging_setting! }
+  let!(:setting) { server.create_logging_settings! }
   let(:channel_id) { 555 }
 
   context "with a channel" do

--- a/spec/operations/moderation/configure_spec.rb
+++ b/spec/operations/moderation/configure_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Ops::Moderation::Configure do
     let!(:logging_plugin) { create(:plugin, key: "logging", name: "Logging") }
 
     before do
-      config.create_logging_setting!(channel_id: nil)
+      config.create_logging_settings!(channel_id: nil)
       create(:plugin_activation, server_configuration: config, plugin: logging_plugin, enabled: false).update_column(:enabled, true)
     end
 
@@ -64,7 +64,7 @@ RSpec.describe Ops::Moderation::Configure do
     let!(:logging_plugin) { create(:plugin, key: "logging", name: "Logging") }
 
     before do
-      config.create_logging_setting!(channel_id: 999)
+      config.create_logging_settings!(channel_id: 999)
       create(:plugin_activation, server_configuration: config, plugin: logging_plugin, enabled: true)
     end
 

--- a/spec/operations/moderation/image_scanning/configure_spec.rb
+++ b/spec/operations/moderation/image_scanning/configure_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Ops::Moderation::ImageScanning::Configure do
   def setup_moderation_group_enabled
     logging_plugin = create(:plugin, key: "logging", name: "Logging")
     moderation_plugin = create(:plugin, key: "moderation", name: "Server Shield")
-    config.create_logging_setting!(channel_id: 999)
+    config.create_logging_settings!(channel_id: 999)
     config.create_moderation_settings!.tap { |s| s.update!(staff_role_id: 777_888_999) }
     create(:plugin_activation, server_configuration: config, plugin: logging_plugin, enabled: true)
     create(:plugin_activation, server_configuration: config, plugin: moderation_plugin, enabled: true)
@@ -67,7 +67,7 @@ RSpec.describe Ops::Moderation::ImageScanning::Configure do
     before do
       logging_plugin = create(:plugin, key: "logging", name: "Logging")
       moderation_plugin = create(:plugin, key: "moderation", name: "Server Shield")
-      config.create_logging_setting!(channel_id: 999)
+      config.create_logging_settings!(channel_id: 999)
       config.create_moderation_settings!
       create(:plugin_activation, server_configuration: config, plugin: logging_plugin, enabled: true)
       create(:plugin_activation, server_configuration: config, plugin: moderation_plugin, enabled: true)

--- a/spec/operations/moderation/spam_protection/configure_spec.rb
+++ b/spec/operations/moderation/spam_protection/configure_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Ops::Moderation::SpamProtection::Configure do
   def setup_moderation_group_enabled
     logging_plugin = create(:plugin, key: "logging", name: "Logging")
     moderation_plugin = create(:plugin, key: "moderation", name: "Server Shield")
-    config.create_logging_setting!(channel_id: 999)
+    config.create_logging_settings!(channel_id: 999)
     config.create_moderation_settings!.tap { |s| s.update!(staff_role_id: 777_888_999) }
     create(:plugin_activation, server_configuration: config, plugin: logging_plugin, enabled: true)
     create(:plugin_activation, server_configuration: config, plugin: moderation_plugin, enabled: true)
@@ -60,7 +60,7 @@ RSpec.describe Ops::Moderation::SpamProtection::Configure do
     before do
       logging_plugin = create(:plugin, key: "logging", name: "Logging")
       moderation_plugin = create(:plugin, key: "moderation", name: "Server Shield")
-      config.create_logging_setting!(channel_id: 999)
+      config.create_logging_settings!(channel_id: 999)
       config.create_moderation_settings!
       create(:plugin_activation, server_configuration: config, plugin: logging_plugin, enabled: true)
       create(:plugin_activation, server_configuration: config, plugin: moderation_plugin, enabled: true)

--- a/spec/operations/server_configuration/ensure_spec.rb
+++ b/spec/operations/server_configuration/ensure_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Ops::ServerConfiguration::Ensure do
   it "creates the plugin settings rows so they always exist" do
     config = result.value
 
-    expect(config.logging_setting).to be_present
+    expect(config.logging_settings).to be_present
     expect(config.role_setting).to be_present
     expect(config.welcome_settings).to be_present
     expect(config.moderation_settings).to be_present

--- a/spec/operations/server_configuration/plugins/toggle_spec.rb
+++ b/spec/operations/server_configuration/plugins/toggle_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Ops::ServerConfiguration::Plugins::Toggle do
     let(:enabled) { true }
 
     before do
-      server.create_logging_setting!(channel_id: 999)
+      server.create_logging_settings!(channel_id: 999)
     end
 
     it "succeeds" do
@@ -114,7 +114,7 @@ RSpec.describe Ops::ServerConfiguration::Plugins::Toggle do
     let(:enabled) { false }
 
     before do
-      server.create_logging_setting!(channel_id: 999)
+      server.create_logging_settings!(channel_id: 999)
       create(:plugin_activation, server_configuration: server, plugin: logging, enabled: true)
     end
 
@@ -135,7 +135,7 @@ RSpec.describe Ops::ServerConfiguration::Plugins::Toggle do
       let(:plugin) { logging }
       let(:enabled) { true }
 
-      before { server.create_logging_setting!(channel_id: 999) }
+      before { server.create_logging_settings!(channel_id: 999) }
 
       it "publishes sync_commands" do
         result
@@ -148,7 +148,7 @@ RSpec.describe Ops::ServerConfiguration::Plugins::Toggle do
       let(:enabled) { false }
 
       before do
-        server.create_logging_setting!(channel_id: 999)
+        server.create_logging_settings!(channel_id: 999)
         create(:plugin_activation, server_configuration: server, plugin: logging, enabled: true)
       end
 
@@ -206,7 +206,7 @@ RSpec.describe Ops::ServerConfiguration::Plugins::Toggle do
     before do
       allow(Bot::ConfigBus).to receive(:post_roles)
       allow(Bot::ConfigBus).to receive(:remove_roles_menu)
-      server.create_logging_setting!(channel_id: 999)
+      server.create_logging_settings!(channel_id: 999)
     end
 
     it "publishes neither post_roles nor remove_roles_menu" do

--- a/spec/plugins/moderation/events/spam_guard_spec.rb
+++ b/spec/plugins/moderation/events/spam_guard_spec.rb
@@ -19,13 +19,13 @@ RSpec.describe Moderation::SpamGuard do
   let(:bot) { double("bot") }
   let(:event) { double("event", from_bot?: false, server:, author:, message:, channel:, bot:) }
 
-  let(:logging_setting) { double("logging_setting", channel_id: log_channel_id) }
+  let(:logging_settings) { double("logging_settings", channel_id: log_channel_id) }
   let(:ping_staff) { true }
   let(:moderation_settings) { double("moderation_settings", staff_role_id:, ping_staff:) }
   let(:config) do
     double(
       "server_configuration",
-      logging_setting:,
+      logging_settings:,
       moderation_settings:
     )
   end
@@ -409,7 +409,7 @@ RSpec.describe Moderation::SpamGuard do
 
   context "when the log channel is unset" do
     let(:action) { "notify_only" }
-    let(:logging_setting) { double("logging_setting", channel_id: nil) }
+    let(:logging_settings) { double("logging_settings", channel_id: nil) }
 
     it "does not attempt to notify" do
       expect(Bot::Discord::Components).not_to receive(:send_to)

--- a/spec/plugins/moderation/image_scanning/verdict_executor_spec.rb
+++ b/spec/plugins/moderation/image_scanning/verdict_executor_spec.rb
@@ -19,13 +19,13 @@ RSpec.describe Moderation::ImageScanning::VerdictExecutor do
   let(:message_channel) { double("message_channel", delete_message: nil) }
   let(:bot) { double("bot", channel: message_channel) }
 
-  let(:logging_setting) { double("logging_setting", channel_id: channel_id) }
+  let(:logging_settings) { double("logging_settings", channel_id: channel_id) }
   let(:ping_staff) { true }
   let(:moderation_settings) { double("moderation_settings", staff_role_id:, ping_staff:) }
   let(:server_configuration) do
     double(
       "server_configuration",
-      logging_setting:,
+      logging_settings:,
       moderation_settings:
     )
   end

--- a/spec/presenters/moderation/overview_context_spec.rb
+++ b/spec/presenters/moderation/overview_context_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Moderation::OverviewContext do
   let!(:moderation_plugin) { create(:plugin, key: "moderation", name: "Server Shield") }
 
   before do
-    config.create_logging_setting!
+    config.create_logging_settings!
     config.create_moderation_settings!
     config.create_spam_protection_settings!
     config.create_image_scanning_settings!
@@ -19,7 +19,7 @@ RSpec.describe Moderation::OverviewContext do
   describe "#logging_ready?" do
     context "when logging plugin is enabled and channel is set" do
       before do
-        config.logging_setting.update!(channel_id: 111)
+        config.logging_settings.update!(channel_id: 111)
         create(:plugin_activation, server_configuration: config, plugin: logging_plugin, enabled: false)
           .update_column(:enabled, true)
       end
@@ -40,9 +40,9 @@ RSpec.describe Moderation::OverviewContext do
       it { expect(context.logging_ready?).to be(false) }
     end
 
-    context "when logging plugin is enabled but logging_setting has no channel_id" do
+    context "when logging plugin is enabled but logging_settings has no channel_id" do
       before do
-        config.logging_setting.update!(channel_id: nil)
+        config.logging_settings.update!(channel_id: nil)
         create(:plugin_activation, server_configuration: config, plugin: logging_plugin, enabled: false)
           .update_column(:enabled, true)
       end
@@ -50,9 +50,9 @@ RSpec.describe Moderation::OverviewContext do
       it { expect(context.logging_ready?).to be(false) }
     end
 
-    context "when logging plugin is enabled but logging_setting is absent" do
+    context "when logging plugin is enabled but logging_settings is absent" do
       before do
-        config.logging_setting.destroy!
+        config.logging_settings.destroy!
         create(:plugin_activation, server_configuration: config, plugin: logging_plugin, enabled: false)
           .update_column(:enabled, true)
       end
@@ -155,31 +155,31 @@ RSpec.describe Moderation::OverviewContext do
   end
 
   describe "#logging_channel_name" do
-    context "when logging_setting is absent" do
-      before { config.logging_setting.destroy! }
+    context "when logging_settings is absent" do
+      before { config.logging_settings.destroy! }
 
       it "returns nil" do
         expect(described_class.new(config.reload).logging_channel_name).to be_nil
       end
     end
 
-    context "when logging_setting has no channel_id" do
+    context "when logging_settings has no channel_id" do
       it "returns nil" do
         expect(context.logging_channel_name).to be_nil
       end
     end
 
-    context "when logging_setting has a channel_id but no matching server_channel" do
-      before { config.logging_setting.update!(channel_id: 777) }
+    context "when logging_settings has a channel_id but no matching server_channel" do
+      before { config.logging_settings.update!(channel_id: 777) }
 
       it "returns nil" do
         expect(context.logging_channel_name).to be_nil
       end
     end
 
-    context "when logging_setting has a channel_id with a matching server_channel" do
+    context "when logging_settings has a channel_id with a matching server_channel" do
       before do
-        config.logging_setting.update!(channel_id: 888)
+        config.logging_settings.update!(channel_id: 888)
         create(:server_channel, server_configuration: config, discord_id: 888, name: "mod-log")
       end
 

--- a/spec/requests/logging_config_spec.rb
+++ b/spec/requests/logging_config_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Logging config", type: :request do
     before do
       post "/auth/discord/callback"
       create(:server_configuration, discord_id: guild.id)
-      config.create_logging_setting!
+      config.create_logging_settings!
       allow(Bot::Discord::UserGuilds).to receive(:call).and_return([guild])
     end
 
@@ -81,7 +81,7 @@ RSpec.describe "Logging config", type: :request do
 
         context "when the plugin is already enabled" do
           before do
-            config.logging_setting.update!(channel_id: 200)
+            config.logging_settings.update!(channel_id: 200)
             create(:plugin_activation, server_configuration: config, plugin: logging, enabled: true)
             get server_path(guild.id)
           end
@@ -104,8 +104,8 @@ RSpec.describe "Logging config", type: :request do
             params: {logging: {channel_id: 200, enabled: "1", actions: {"roles.role_gained" => "1", "roles.role_lost" => "0"}}},
             **turbo
           expect(response.media_type).to eq("text/vnd.turbo-stream.html")
-          expect(config.logging_setting.reload.channel_id).to eq(200)
-          expect(config.logging_setting.action_enabled?("roles.role_gained")).to be(true)
+          expect(config.logging_settings.reload.channel_id).to eq(200)
+          expect(config.logging_settings.action_enabled?("roles.role_gained")).to be(true)
           expect(config.plugins.enabled.exists?(key: :logging)).to be(true)
           expect(response.body).to include("saved")
           expect(response.body).to include('target="plugin-sidebar"')

--- a/spec/requests/moderation_config_spec.rb
+++ b/spec/requests/moderation_config_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Moderation config", type: :request do
       post "/auth/discord/callback"
       create(:server_configuration, discord_id: guild.id)
       config.create_moderation_settings!
-      config.create_logging_setting!
+      config.create_logging_settings!
       config.create_spam_protection_settings!
       config.create_image_scanning_settings!
       allow(Bot::Discord::UserGuilds).to receive(:call).and_return([guild])
@@ -50,7 +50,7 @@ RSpec.describe "Moderation config", type: :request do
       describe "GET /servers/:server_id/moderation" do
         context "when logging is ready and group is enabled" do
           before do
-            config.logging_setting.update!(channel_id: 111)
+            config.logging_settings.update!(channel_id: 111)
             create(:plugin_activation, server_configuration: config, plugin: logging_plugin, enabled: false)
               .update_column(:enabled, true)
             create(:plugin_activation, server_configuration: config, plugin: moderation_plugin, enabled: false)
@@ -100,7 +100,7 @@ RSpec.describe "Moderation config", type: :request do
 
         context "when group is disabled but logging is ready" do
           before do
-            config.logging_setting.update!(channel_id: 111)
+            config.logging_settings.update!(channel_id: 111)
             create(:plugin_activation, server_configuration: config, plugin: logging_plugin, enabled: false)
               .update_column(:enabled, true)
           end
@@ -124,7 +124,7 @@ RSpec.describe "Moderation config", type: :request do
 
       describe "PATCH /servers/:server_id/moderation" do
         before do
-          config.logging_setting.update!(channel_id: 111)
+          config.logging_settings.update!(channel_id: 111)
           create(:plugin_activation, server_configuration: config, plugin: logging_plugin, enabled: false)
             .update_column(:enabled, true)
           create(:plugin_activation, server_configuration: config, plugin: moderation_plugin, enabled: false)

--- a/spec/requests/server_dashboard_spec.rb
+++ b/spec/requests/server_dashboard_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "Server dashboard", type: :request do
 
           welcomes
 
-          config.create_logging_setting!(channel_id: 9)
+          config.create_logging_settings!(channel_id: 9)
           logging
         end
 

--- a/spec/requests/server_picker_spec.rb
+++ b/spec/requests/server_picker_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "Server picker", type: :request do
       context "with enabled plugins" do
         before do
           config = ServerConfiguration.find_by(discord_id: present_guild.id)
-          config.create_logging_setting!(channel_id: 999)
+          config.create_logging_settings!(channel_id: 999)
           logging = create(:plugin, key: "logging", name: "Logging")
           create(:plugin_activation, server_configuration: config, plugin: logging, enabled: true)
         end


### PR DESCRIPTION
Prep PR for the ops CRUD-naming work, from the navigability audit (item 3.1).

## Why

Every plugin's settings model is `<Plugin>::Settings` with an explicit `self.table_name`:

| | |
|---|---|
| `Lfg::Settings` | `lfg_settings` |
| `Welcomes::Settings` | `welcome_settings` |
| `Roles::Settings` | `role_settings` |
| `Moderation::Settings` | `moderation_settings` |
| `Moderation::SpamProtection::Settings` | `spam_protection_settings` |
| `Moderation::ImageScanning::Settings` | `image_scanning_settings` |
| **`LoggingSetting`** | *(inferred)* |

Logging was the only one flat and singular — so it was also the only one whose file path you couldn't guess from the plugin name.

## No migration

Because `self.table_name` was already explicit on every sibling, `Logging::Settings` just declares `"logging_settings"` and the table is untouched. `db/schema.rb` and `db/migrate/` are not modified. Migration files that mention `logging_settings` are referring to the table and were already correct.

## What moved

- `app/models/logging_setting.rb` → `app/models/logging/settings.rb`
- `has_one :logging_setting` → `has_one :logging_settings, class_name: "Logging::Settings"`. Plural matches `welcome_settings` / `moderation_settings` / `lfg_settings` and your rule that "one setting for a set of settings doesn't feel right".
- ~45 reader call sites, 16 `create_logging_setting!` → `create_logging_settings!` writers, and both `PluginCatalog` references (the `channel_setting:` and the moderation `prerequisite` lambda).
- `config/preview_data.yml`'s `settings_association: logging_setting`, which is read via `public_send` in `Ops::ServerConfiguration::Previews::ApplyPlugin`.
- `spec/models/logging_setting_spec.rb` → `spec/models/logging/settings_spec.rb`; factory `:logging_setting` → `:logging_settings, class: "Logging::Settings"`.

No spec examples were deleted — that spec only exercises `action_enabled?` on the model itself, so all of it earns its place.

## Deliberately not in this PR

`has_one :role_setting` is the **second** singular outlier. It's held back because the ops CRUD-naming PR rewrites the same files, and doing both at once would collide. It's recorded as a follow-up: association name only, the `role_setting_id` FK column stays.

## Verification

```
$ bin/rails runner 'puts Logging::Settings.table_name'
logging_settings
```

`bundle exec rspec` 2990 examples / 0 failures · `standardrb` clean · `rake active_record_doctor` clean · `undercover --compare origin/main` clean.

A `grep` for `logging_setting\b` across `app/ spec/ config/ lib/` returns nothing.