### PR TITLE
Fold the Channels ops into ServerChannels

### DIFF
--- a/app/bot/events/channel_cleanup.rb
+++ b/app/bot/events/channel_cleanup.rb
@@ -9,7 +9,7 @@ module Bot
     def handle
       return unless server_configuration
 
-      Ops::ServerConfiguration::Channels::HandleDeletion.call(
+      Ops::ServerConfiguration::ServerChannels::HandleDeletion.call(
         server_configuration:,
         channel_id: event.id,
         bot: event.bot

--- a/app/bot/guild_metadata.rb
+++ b/app/bot/guild_metadata.rb
@@ -18,7 +18,7 @@ module Bot
         roles: roles(server),
         bot_role_position: bot_role_position(server, bot)
       )
-      Ops::ServerConfiguration::Channels::Reconcile.call(server_configuration: config, bot:)
+      Ops::ServerConfiguration::ServerChannels::Reconcile.call(server_configuration: config, bot:)
       ServerOnboarder.notify(bot, server, config)
       config
     end

--- a/app/operations/server_configuration/server_channels/handle_deletion.rb
+++ b/app/operations/server_configuration/server_channels/handle_deletion.rb
@@ -2,7 +2,7 @@
 
 module Ops
   module ServerConfiguration
-    module Channels
+    module ServerChannels
       class HandleDeletion < ApplicationOperation
         self.transactional = false
 

--- a/app/operations/server_configuration/server_channels/reconcile.rb
+++ b/app/operations/server_configuration/server_channels/reconcile.rb
@@ -2,7 +2,7 @@
 
 module Ops
   module ServerConfiguration
-    module Channels
+    module ServerChannels
       class Reconcile < ApplicationOperation
         self.transactional = false
 

--- a/spec/bot/events/channel_cleanup_spec.rb
+++ b/spec/bot/events/channel_cleanup_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Bot::ChannelCleanup do
   let(:server) { double("server", id: 1) }
   let(:event) { double("event", server:, id: 555, bot:) }
 
-  let(:op) { Ops::ServerConfiguration::Channels::HandleDeletion }
+  let(:op) { Ops::ServerConfiguration::ServerChannels::HandleDeletion }
 
   context "for a guild channel of a configured server" do
     let!(:config) { create(:server_configuration, discord_id: 1) }

--- a/spec/bot/guild_metadata_spec.rb
+++ b/spec/bot/guild_metadata_spec.rb
@@ -79,14 +79,14 @@ RSpec.describe Bot::GuildMetadata do
     it "ensures the config, then syncs channels and roles, then reconciles deletions" do
       expect(Ops::ServerConfiguration::ServerChannels::Sync).to receive(:call).with(server_configuration: config, channels: [])
       expect(Ops::ServerConfiguration::ServerRoles::Sync).to receive(:call).with(server_configuration: config, roles: [], bot_role_position: 7)
-      expect(Ops::ServerConfiguration::Channels::Reconcile).to receive(:call).with(server_configuration: config, bot:)
+      expect(Ops::ServerConfiguration::ServerChannels::Reconcile).to receive(:call).with(server_configuration: config, bot:)
       sync
     end
 
     it "syncs the server's display metadata" do
       allow(Ops::ServerConfiguration::ServerChannels::Sync).to receive(:call)
       allow(Ops::ServerConfiguration::ServerRoles::Sync).to receive(:call)
-      allow(Ops::ServerConfiguration::Channels::Reconcile).to receive(:call)
+      allow(Ops::ServerConfiguration::ServerChannels::Reconcile).to receive(:call)
       expect(Ops::ServerConfiguration::Metadata::Sync).to receive(:call).with(
         server_configuration: config,
         name: "Dev Refuge",
@@ -99,7 +99,7 @@ RSpec.describe Bot::GuildMetadata do
     it "onboards the server" do
       allow(Ops::ServerConfiguration::ServerChannels::Sync).to receive(:call)
       allow(Ops::ServerConfiguration::ServerRoles::Sync).to receive(:call)
-      allow(Ops::ServerConfiguration::Channels::Reconcile).to receive(:call)
+      allow(Ops::ServerConfiguration::ServerChannels::Reconcile).to receive(:call)
       expect(Bot::ServerOnboarder).to receive(:notify).with(bot, server, config)
       sync
     end
@@ -107,7 +107,7 @@ RSpec.describe Bot::GuildMetadata do
     it "returns the config" do
       allow(Ops::ServerConfiguration::ServerChannels::Sync).to receive(:call)
       allow(Ops::ServerConfiguration::ServerRoles::Sync).to receive(:call)
-      allow(Ops::ServerConfiguration::Channels::Reconcile).to receive(:call)
+      allow(Ops::ServerConfiguration::ServerChannels::Reconcile).to receive(:call)
       expect(sync).to eq(config)
     end
   end

--- a/spec/operations/server_configuration/server_channels/handle_deletion_spec.rb
+++ b/spec/operations/server_configuration/server_channels/handle_deletion_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Ops::ServerConfiguration::Channels::HandleDeletion do
+RSpec.describe Ops::ServerConfiguration::ServerChannels::HandleDeletion do
   subject(:result) { described_class.call(server_configuration: server, channel_id:, bot:) }
 
   let(:server) { create(:server_configuration, discord_id: 1) }

--- a/spec/operations/server_configuration/server_channels/reconcile_spec.rb
+++ b/spec/operations/server_configuration/server_channels/reconcile_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Ops::ServerConfiguration::Channels::Reconcile do
+RSpec.describe Ops::ServerConfiguration::ServerChannels::Reconcile do
   subject(:result) { described_class.call(server_configuration: server, bot:) }
 
   let(:server) { create(:server_configuration, discord_id: 1) }


### PR DESCRIPTION
Navigability item 1b. Namespace only — no logic changes.

`Ops::ServerConfiguration::Channels::*` and `Ops::ServerConfiguration::ServerChannels::*` both existed for the same table. Your ruling: ops are named after the model they mutate, so `ServerChannels` wins.

The confusion was visible at the call site — `app/bot/guild_metadata.rb` reached across both namespaces on adjacent lines:

```ruby
Ops::ServerConfiguration::ServerChannels::Sync.call(server_configuration: config, channels: channels(server))
Ops::ServerConfiguration::Channels::Reconcile.call(server_configuration: config, bot:)
```

`Channels::Reconcile` and `Channels::HandleDeletion` move into `ServerChannels`, taking their specs with them. The `Channels/` directory is gone. `Reconcile`'s bare `HandleDeletion.call` still resolves — they're still siblings.

## `HandleDeletion` deliberately keeps its name

This is item 1c and it needs your call, because **the rename you suggested isn't available**: `Ops::ServerConfiguration::ServerChannels::Destroy` already exists and does something different. Details and a latent bug are in my session notes — worth reading before deciding.

## Verification

```
$ bin/rails runner 'puts defined?(Ops::ServerConfiguration::Channels).inspect'
nil
```

`bundle exec rspec` 2990 examples / 0 failures · `standardrb` clean · `rake active_record_doctor` clean · `undercover --compare origin/main` clean.