### PR TITLE
Put all nine plugin config pages on one base

### DIFF
--- a/app/views/servers/image_scanning/show.rb
+++ b/app/views/servers/image_scanning/show.rb
@@ -3,16 +3,12 @@
 class Views::Servers::ImageScanning::Show < Views::Servers::Moderation::SubPluginShow
   private
 
-  def active_key
+  def plugin_key
     :image_scanning
   end
 
   def icon
     "scan"
-  end
-
-  def enable_field
-    "image_scanning[enabled]"
   end
 
   def form

--- a/app/views/servers/lfg/show.rb
+++ b/app/views/servers/lfg/show.rb
@@ -1,27 +1,17 @@
 # frozen_string_literal: true
 
-class Views::Servers::Lfg::Show < Views::Base
-  def initialize(server_configuration:, user:, enabled:)
-    @config = server_configuration
-    @user = user
-    @enabled = enabled
+class Views::Servers::Lfg::Show < Views::Servers::PluginConfigShow
+  private
+
+  def plugin_key
+    :lfg
   end
 
-  def view_template
-    render Components::PluginShell.new(user: @user, server_configuration: @config, active_key: :lfg) do
-      render Components::ConfigPage.new(
-        header: Components::ConfigPageHeader.new(
-          icon: "game-controller",
-          title: t(".title"),
-          description: t(".description")
-        ),
-        server_configuration: @config,
-        url: PluginPaths.for(@config, :lfg),
-        toggle: {field: "lfg[enabled]", enabled: @enabled},
-        gate: {type: :enable, message: t(".gate_message")}
-      ) do
-        render Components::Lfg::ConfigForm.new(server_configuration: @config)
-      end
-    end
+  def icon
+    "game-controller"
+  end
+
+  def body
+    render Components::Lfg::ConfigForm.new(server_configuration: @config)
   end
 end

--- a/app/views/servers/logging/show.rb
+++ b/app/views/servers/logging/show.rb
@@ -11,7 +11,7 @@ class Views::Servers::Logging::Show < Views::Servers::PluginConfigShow
     "scroll"
   end
 
-  def form
+  def body
     render Components::Logging::ConfigForm.new(server_configuration: @config)
   end
 end

--- a/app/views/servers/moderation/show.rb
+++ b/app/views/servers/moderation/show.rb
@@ -1,42 +1,38 @@
 # frozen_string_literal: true
 
-class Views::Servers::Moderation::Show < Views::Base
+class Views::Servers::Moderation::Show < Views::Servers::PluginConfigShow
   include Phlex::Rails::Helpers::FormWith
 
   def initialize(server_configuration:, user:, context:)
-    @config = server_configuration
-    @user = user
+    super(server_configuration:, user:)
     @context = context
   end
 
-  def view_template
-    render Components::PluginShell.new(
-      user: @user,
-      server_configuration: @config,
-      active_key: :moderation
-    ) do
-      render Components::ConfigPage.new(
-        header: Components::ConfigPageHeader.new(
-          icon: "shield",
-          title: t(".title"),
-          description: t(".description")
-        ),
-        server_configuration: @config,
-        url: PluginPaths.for(@config, :moderation),
-        gate: shell_gate,
-        toggle: shell_toggle
-      ) do
-        logging_subline
-        render Components::Moderation::OverviewForm.new(
-          server_configuration: @config,
-          context: @context
-        )
-      end
-      sub_plugin_toggle_forms
-    end
+  private
+
+  def plugin_key
+    :moderation
   end
 
-  private
+  def icon
+    "shield"
+  end
+
+  def enabled?
+    @context.group_enabled?
+  end
+
+  def body
+    logging_subline
+    render Components::Moderation::OverviewForm.new(
+      server_configuration: @config,
+      context: @context
+    )
+  end
+
+  def after_config_page
+    sub_plugin_toggle_forms
+  end
 
   def sub_plugin_toggle_forms
     PluginCatalog.sub_plugin_keys(:moderation).each do |key|
@@ -50,7 +46,7 @@ class Views::Servers::Moderation::Show < Views::Base
     end
   end
 
-  def shell_gate
+  def gate
     if !@context.logging_ready?
       {
         type: :prereq,
@@ -68,21 +64,10 @@ class Views::Servers::Moderation::Show < Views::Base
     end
   end
 
-  def shell_toggle
-    if !@context.logging_ready?
-      {
-        field: "moderation[enabled]",
-        enabled: @context.group_enabled?,
-        locked: true,
-        reason: t(".toggle_locked_reason")
-      }
-    else
-      {
-        field: "moderation[enabled]",
-        enabled: @context.group_enabled?,
-        locked: false
-      }
-    end
+  def toggle
+    return super if @context.logging_ready?
+
+    super.merge(locked: true, reason: t(".toggle_locked_reason"))
   end
 
   def logging_subline

--- a/app/views/servers/moderation/sub_plugin_show.rb
+++ b/app/views/servers/moderation/sub_plugin_show.rb
@@ -1,48 +1,26 @@
 # frozen_string_literal: true
 
-class Views::Servers::Moderation::SubPluginShow < Views::Base
+class Views::Servers::Moderation::SubPluginShow < Views::Servers::PluginConfigShow
   def initialize(server_configuration:, user:, context:)
-    @config = server_configuration
-    @user = user
+    super(server_configuration:, user:)
     @context = context
-  end
-
-  def view_template
-    render Components::PluginShell.new(
-      user: @user,
-      server_configuration: @config,
-      active_key:
-    ) do
-      render Components::ConfigPage.new(
-        header: Components::ConfigPageHeader.new(
-          icon:,
-          title: t(".title"),
-          description: t(".description")
-        ),
-        server_configuration: @config,
-        url:,
-        gate: shell_gate,
-        toggle: shell_toggle,
-        parent_crumb: {label: PluginCatalog.find(:moderation).name, href: moderation_path}
-      ) do
-        group_subline
-        no_role_callout
-        render form
-      end
-    end
   end
 
   private
 
-  def url
-    PluginPaths.for(@config, active_key)
+  def enabled?
+    @context.plugin_enabled?
+  end
+
+  def parent_crumb
+    {label: PluginCatalog.find(:moderation).name, href: moderation_path}
   end
 
   def moderation_path
     PluginPaths.for(@config, :moderation)
   end
 
-  def shell_gate
+  def gate
     return if @context.group_enabled?
 
     {
@@ -55,13 +33,8 @@ class Views::Servers::Moderation::SubPluginShow < Views::Base
     }
   end
 
-  def shell_toggle
-    {
-      field: enable_field,
-      enabled: @context.plugin_enabled?,
-      locked: toggle_locked?,
-      reason: toggle_reason
-    }
+  def toggle
+    super.merge(locked: toggle_locked?, reason: toggle_reason)
   end
 
   def toggle_locked?
@@ -72,6 +45,12 @@ class Views::Servers::Moderation::SubPluginShow < Views::Base
     return t(".group_locked_reason") unless @context.group_enabled?
 
     t(".role_locked_reason") unless @context.staff_role_present?
+  end
+
+  def body
+    group_subline
+    no_role_callout
+    render form
   end
 
   def group_subline

--- a/app/views/servers/plugin_config_show.rb
+++ b/app/views/servers/plugin_config_show.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Views::Servers::PluginConfigShow < Views::Base
-  def initialize(server_configuration:, user:, enabled:)
+  def initialize(server_configuration:, user:, enabled: false)
     @config = server_configuration
     @user = user
     @enabled = enabled
@@ -10,29 +10,63 @@ class Views::Servers::PluginConfigShow < Views::Base
   def view_template
     render Components::PluginShell.new(user: @user, server_configuration: @config, active_key: plugin_key) do
       render Components::ConfigPage.new(
-        header: Components::ConfigPageHeader.new(
-          icon:,
-          title: t(".title"),
-          description: t(".description")
-        ),
+        header:,
         server_configuration: @config,
         url:,
-        toggle: {field: "#{plugin_key}[enabled]", enabled: @enabled},
-        gate: {type: :enable, message: t(".gate_message")},
-        channel_lost: @enabled && channel_setting.channel_id.nil?
+        toggle:,
+        gate:,
+        channel_lost: channel_lost?,
+        parent_crumb:
       ) do
-        form
+        body
       end
+      after_config_page
     end
   end
 
   private
 
+  def header
+    Components::ConfigPageHeader.new(
+      icon:,
+      title: t(".title"),
+      description: t(".description"),
+      badge:
+    )
+  end
+
   def url
     PluginPaths.for(@config, plugin_key)
   end
 
-  def channel_setting
-    @config.public_send(PluginCatalog.find(plugin_key).channel_setting)
+  def toggle
+    {field: "#{plugin_key}[enabled]", enabled: enabled?}
+  end
+
+  def gate
+    {type: :enable, message: t(".gate_message")}
+  end
+
+  def enabled?
+    @enabled
+  end
+
+  def badge
+    nil
+  end
+
+  def parent_crumb
+    nil
+  end
+
+  def after_config_page
+    nil
+  end
+
+  def channel_lost?
+    definition = PluginCatalog.find(plugin_key)
+    return false unless definition&.channel_backed?
+
+    enabled? && @config.public_send(definition.channel_setting).channel_id.nil?
   end
 end

--- a/app/views/servers/reminders/show.rb
+++ b/app/views/servers/reminders/show.rb
@@ -1,25 +1,29 @@
 # frozen_string_literal: true
 
-class Views::Servers::Reminders::Show < Views::Base
-  def initialize(server_configuration:, user:)
-    @config = server_configuration
-    @user = user
+class Views::Servers::Reminders::Show < Views::Servers::PluginConfigShow
+  private
+
+  def plugin_key
+    :reminders
   end
 
-  def view_template
-    render Components::PluginShell.new(user: @user, server_configuration: @config, active_key: :reminders) do
-      render Components::ConfigPage.new(
-        header: Components::ConfigPageHeader.new(
-          icon: "bell-ringing",
-          title: t(".title"),
-          description: t(".description"),
-          badge: t(".badge")
-        ),
-        server_configuration: @config,
-        url: PluginPaths.for(@config, :reminders)
-      ) do
-        render Components::Reminders::ConfigForm.new(server_configuration: @config)
-      end
-    end
+  def icon
+    "bell-ringing"
+  end
+
+  def badge
+    t(".badge")
+  end
+
+  def toggle
+    nil
+  end
+
+  def gate
+    nil
+  end
+
+  def body
+    render Components::Reminders::ConfigForm.new(server_configuration: @config)
   end
 end

--- a/app/views/servers/roles/show.rb
+++ b/app/views/servers/roles/show.rb
@@ -11,7 +11,7 @@ class Views::Servers::Roles::Show < Views::Servers::PluginConfigShow
     "users-three"
   end
 
-  def form
+  def body
     render Components::Roles::ConfigForm.new(server_configuration: @config)
   end
 end

--- a/app/views/servers/spam_protection/show.rb
+++ b/app/views/servers/spam_protection/show.rb
@@ -3,16 +3,12 @@
 class Views::Servers::SpamProtection::Show < Views::Servers::Moderation::SubPluginShow
   private
 
-  def active_key
+  def plugin_key
     :spam_protection
   end
 
   def icon
     "megaphone-slash"
-  end
-
-  def enable_field
-    "spam_protection[enabled]"
   end
 
   def form

--- a/app/views/servers/twilight_struggle/show.rb
+++ b/app/views/servers/twilight_struggle/show.rb
@@ -1,31 +1,35 @@
 # frozen_string_literal: true
 
-class Views::Servers::TwilightStruggle::Show < Views::Base
+class Views::Servers::TwilightStruggle::Show < Views::Servers::PluginConfigShow
   def initialize(server_configuration:, user:, enabled:, subscriptions:, archived:, toggleable:)
-    @config = server_configuration
-    @user = user
-    @enabled = enabled
+    super(server_configuration:, user:, enabled:)
     @subscriptions = subscriptions
     @archived = archived
     @toggleable = toggleable
   end
 
-  def view_template
-    render Components::PluginShell.new(user: @user, server_configuration: @config, active_key: :twilight_struggle) do
-      render Components::ConfigPage.new(
-        header: Components::ConfigPageHeader.new(icon: "trophy", title: t(".title"), description: t(".description")),
-        server_configuration: @config,
-        url: server_twilight_struggle_path(@config.discord_id),
-        toggle: {field: "twilight_struggle[enabled]", enabled: @enabled, locked: !@toggleable, reason: t(".toggle_admin_only")},
-        gate: {type: :enable, message: t(".gate_message")}
-      ) do
-        render Components::TwilightStruggle::ArchiveFilter.new(server_configuration: @config, archived: @archived)
-        @subscriptions.empty? ? empty : list
-      end
-    end
+  private
+
+  def plugin_key
+    :twilight_struggle
   end
 
-  private
+  def icon
+    "trophy"
+  end
+
+  def url
+    server_twilight_struggle_path(@config.discord_id)
+  end
+
+  def toggle
+    {field: "twilight_struggle[enabled]", enabled: @enabled, locked: !@toggleable, reason: t(".toggle_admin_only")}
+  end
+
+  def body
+    render Components::TwilightStruggle::ArchiveFilter.new(server_configuration: @config, archived: @archived)
+    @subscriptions.empty? ? empty : list
+  end
 
   def empty
     render Components::EmptyState.new(title: t(".empty_title"), body: empty_body) { nil }

--- a/app/views/servers/twilight_struggle/show.rb
+++ b/app/views/servers/twilight_struggle/show.rb
@@ -18,10 +18,6 @@ class Views::Servers::TwilightStruggle::Show < Views::Servers::PluginConfigShow
     "trophy"
   end
 
-  def url
-    server_twilight_struggle_path(@config.discord_id)
-  end
-
   def toggle
     {field: "twilight_struggle[enabled]", enabled: @enabled, locked: !@toggleable, reason: t(".toggle_admin_only")}
   end

--- a/app/views/servers/welcomes/show.rb
+++ b/app/views/servers/welcomes/show.rb
@@ -11,7 +11,7 @@ class Views::Servers::Welcomes::Show < Views::Servers::PluginConfigShow
     "hand-waving"
   end
 
-  def form
+  def body
     render Components::Welcomes::ConfigForm.new(server_configuration: @config)
   end
 end

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -37,6 +37,18 @@ ignore_unused:
   - views.servers.logging.show.*
   - views.servers.roles.show.*
   - views.servers.welcomes.show.*
+  - views.servers.lfg.show.title
+  - views.servers.lfg.show.description
+  - views.servers.lfg.show.gate_message
+  - views.servers.reminders.show.title
+  - views.servers.reminders.show.description
+  - views.servers.reminders.show.badge
+  - views.servers.moderation.show.title
+  - views.servers.moderation.show.description
+  - views.servers.moderation.show.gate_message
+  - views.servers.twilight_struggle.show.title
+  - views.servers.twilight_struggle.show.description
+  - views.servers.twilight_struggle.show.gate_message
   # 2. Admin::SettingsController#update
   - admin.settings.dms_enabled
   - admin.settings.dms_disabled

--- a/spec/requests/logging_config_spec.rb
+++ b/spec/requests/logging_config_spec.rb
@@ -92,6 +92,20 @@ RSpec.describe "Logging config", type: :request do
             expect(response.body).to include("Member gained a role")
           end
         end
+
+        context "when the plugin is enabled but its channel is gone" do
+          before do
+            config.logging_setting.update!(channel_id: 200)
+            create(:plugin_activation, server_configuration: config, plugin: logging, enabled: true)
+            config.logging_setting.update_column(:channel_id, nil)
+            get server_path(guild.id)
+          end
+
+          it "warns that the configured channel was deleted" do
+            get server_logging_path(guild.id)
+            expect(response.body).to include("was deleted").and include("Choose a new channel")
+          end
+        end
       end
 
       describe "PATCH /servers/:server_id/logging" do


### PR DESCRIPTION
Navigability item 1d — you picked "parameterise until all 9 fit".

> **Stacked on [#256](https://github.com/badBlackShark/shrkbot/pull/256)** — base is `chore/trustworthy-i18n-unused-report`. Both edit `config/i18n-tasks.yml`, and this PR's changes are only correct on top of that one's.

## Before

| base | pages |
|---|---|
| `PluginConfigShow` | logging, roles, welcomes |
| `Moderation::SubPluginShow` | image_scanning, spam_protection |
| `Views::Base` (hand-rolled) | lfg, reminders, moderation, twilight_struggle |

`PluginConfigShow` hardcoded a standard toggle, an enable gate and no badge — so it fit only the three most rigid pages, and `SubPluginShow` was a second copy of its entire structure sitting next to it.

## After

One base, a hook per axis that genuinely varies, each defaulting to what the majority wants. Most pages override only `plugin_key`, `icon` and `body`:

```ruby
class Views::Servers::Lfg::Show < Views::Servers::PluginConfigShow
  private

  def plugin_key
    :lfg
  end

  def icon
    "game-controller"
  end

  def body
    render Components::Lfg::ConfigForm.new(server_configuration: @config)
  end
end
```

`SubPluginShow` becomes a subclass instead of a parallel copy, which retires two hooks as redundant: **`active_key`** was the base's `plugin_key` under a second name, and **`enable_field`** only ever returned `"#{plugin_key}[enabled]"` — verified against both sub-plugins before deleting.

`channel_lost?` is now derived from `PluginCatalog#channel_backed?`, so it's correctly `false` for lfg, reminders, moderation and twilight_struggle without any of them saying so.

## Two things the coverage gate caught

**`Moderation::Show#enabled?` had zero hits.** Its `toggle` override restated `field:` and `enabled:` by hand in both branches, bypassing the hook. Both moderation toggles now build on `super`, which removes the duplication and makes the hook live. The redundant `locked: false` went too — `ConfigPage` only checks truthiness.

**The channel-lost banner had no end-to-end test at all.** Now it does. Reaching that state needs care: `PluginActivation` refuses to enable a plugin without a channel, so the only way in is the way reality gets there — enable with a channel, then have the channel deleted underneath you, which is exactly what `ReleaseFromPlugins` does.

## Deliberate corrections during review

- **No `AbstractMethodError` stubs on the base.** My brief asked for them, which contradicts a standing decision: unreachable raises can't satisfy undercover, and a missing hook already fails loudly as `NoMethodError`. Removed — the previous base had none either.
- **No `&.` on the settings lookup.** It was added as "strictly safer", but `Ops::ServerConfiguration::Ensure` always creates the settings row, so the nil branch is unreachable and left the branch gate at 1/2. Matches the old code and `CLAUDE.md`'s rule against over-defending nil-that-never-happens.
- **`TwilightStruggle::Show` uses the shared `url`.** It briefly kept an override, because the base's `PluginPaths.for` *raises* for a bespoke plugin under a preview config. Per your call that bespoke plugins shouldn't be previewable, that raise is the defined and correct behaviour, so the override is gone. It's unreachable either way: the `/preview` scope has no `twilight_struggle` resource, preview seeding never creates a bespoke grant, and `PluginCatalog.visible_for` hides ungranted bespoke plugins from the sidebar.

## i18n

Twelve **exact** keys added to `ignore_unused` for the four newly-converted views, since their `t(".title")` lookups now resolve from the base. No wildcard for moderation — its `prereq_gate_*`, `toggle_locked_reason` and `logging_subline_*` calls stay in its own file and must keep being checked.

## Verification

`bundle exec rspec` **2991 examples / 0 failures** (2990 + the new channel-lost case) · `standardrb` clean · `rake active_record_doctor` clean · `undercover --compare origin/main` clean · `i18n-tasks` unused/missing/check-normalized all clean.

Request specs for all nine pages were left untouched and still pass — that's the evidence the HTML didn't move. Visual spot-check is still yours; no browser here.