### PR TITLE
Give the labelled-setting row one implementation

### DIFF
--- a/app/components/moderation/account_age_card.rb
+++ b/app/components/moderation/account_age_card.rb
@@ -7,11 +7,7 @@ class Components::Moderation::AccountAgeCard < Components::Base
 
   def view_template
     render Components::Card.new do
-      div(class: "flex items-center justify-between gap-4") do
-        div(class: "max-w-md") do
-          label(class: "text-sm font-semibold") { t(".label") }
-          render Components::FieldHelp.new { t(".help") }
-        end
+      render Components::SettingRow.new(label: t(".label"), help: t(".help")) do
         render Components::NumberStepper.new(
           name: "moderation[new_account_age_days]",
           value: @new_account_age_days,

--- a/app/components/moderation/staff_ping_card.rb
+++ b/app/components/moderation/staff_ping_card.rb
@@ -7,11 +7,7 @@ class Components::Moderation::StaffPingCard < Components::Base
 
   def view_template
     render Components::Card.new do
-      div(class: "flex items-center justify-between gap-4") do
-        div(class: "max-w-md") do
-          label(class: "text-sm font-semibold") { t(".label") }
-          render Components::FieldHelp.new { t(".help") }
-        end
+      render Components::SettingRow.new(label: t(".label"), help: t(".help")) do
         render Components::Toggle.new(
           name: "moderation[ping_staff]",
           checked: @ping_staff,

--- a/app/components/setting_row.rb
+++ b/app/components/setting_row.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Components::SettingRow < Components::Base
+  def initialize(label:, help: nil)
+    @label = label
+    @help = help
+  end
+
+  def view_template
+    div(class: "flex items-center gap-4") do
+      div(class: "flex-1") do
+        p(class: "text-sm font-semibold") { @label }
+        p(class: "mt-0.5 text-sm text-text-secondary") { @help } if @help
+      end
+      yield
+    end
+  end
+end

--- a/app/components/toggle_row.rb
+++ b/app/components/toggle_row.rb
@@ -9,11 +9,7 @@ class Components::ToggleRow < Components::Base
   end
 
   def view_template
-    div(class: "flex items-center gap-4") do
-      div(class: "flex-1") do
-        p(class: "text-sm font-semibold") { @label }
-        p(class: "mt-0.5 text-sm text-text-secondary") { @help } if @help
-      end
+    render Components::SettingRow.new(label: @label, help: @help) do
       render Components::Toggle.new(name: @name, checked: @checked, label: @label)
     end
   end

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -216,6 +216,13 @@ duplicated class strings:
 - **`Components::ConfigSections`** — the config-page section stack: renders the
   `<key>-config` div Turbo targets, the vertical `gap-5` rhythm, and the
   danger callout every plugin form was repeating (`enable_error:`).
+- **`Components::SettingRow`** — one labelled setting: `label:` + optional
+  `help:` on the left, the control yielded as a block on the right. The *only*
+  row treatment — `ToggleRow` is this plus a `Toggle`, and the Server Shield
+  cards are this plus a stepper or a toggle. The visible label is a `<p>`, not a
+  `<label>`: the accessible name belongs on the control (`Components::Toggle`
+  carries its own `aria-label`), and a second `<label>` with no `for` only
+  duplicates it.
 
 `Components::Icon` wraps Phosphor; names not in Phosphor (the `megaphone-slash`
 sub-plugin glyph) are served from its `CUSTOM_GLYPHS` map of inline SVGs.

--- a/spec/components/setting_row_spec.rb
+++ b/spec/components/setting_row_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::SettingRow do
+  subject(:html) do
+    described_class.new(label: "Ping staff on detection", help:).call { "CONTROL" }
+  end
+
+  let(:help) { "Mentions your staff role when Shield acts." }
+
+  it "renders the label" do
+    expect(html).to include("Ping staff on detection")
+  end
+
+  it "renders the help text" do
+    expect(html).to include("Mentions your staff role when Shield acts.")
+  end
+
+  it "renders the yielded control" do
+    expect(html).to include("CONTROL")
+  end
+
+  it "labels the setting with a paragraph, leaving the accessible name to the control" do
+    expect(html).not_to include("<label")
+  end
+
+  context "without help text" do
+    let(:help) { nil }
+
+    it "renders only the label" do
+      expect(html).to include("Ping staff on detection")
+      expect(html).not_to include("text-text-secondary")
+    end
+  end
+end


### PR DESCRIPTION
Navigability item 1e — you picked ToggleRow's help-text treatment.

> **Stacked on [#255](https://github.com/badBlackShark/shrkbot/pull/255)** — base is `refactor/extract-field-components`. This replaces the `FieldHelp` usage that PR introduced in the two Server Shield cards, so it only makes sense on top of it.

## The problem

Two treatments of "label, help text, control on the right", with no way to tell which was the house style:

| | layout | label | help |
|---|---|---|---|
| `ToggleRow` (5 sites) | `flex items-center gap-4` + `flex-1` | `<p>` | `text-sm text-text-secondary` |
| Server Shield cards (2 sites) | `+ justify-between` + `max-w-md` | `<label>` | `text-xs text-text-muted` |

## The change

`Components::SettingRow` is now the only one, and **yields its control** so it isn't toggle-specific:

```ruby
render Components::SettingRow.new(label: t(".label"), help: t(".help")) do
  render Components::NumberStepper.new(...)   # or a Toggle, or anything
end
```

`ToggleRow` becomes `SettingRow` + `Toggle`. `AccountAgeCard` and `StaffPingCard` become `SettingRow` + their control. Per your pick, ToggleRow's treatment wins, so **the two Server Shield rows are what changes visually** — help text goes from 12px muted to 14px secondary. The five toggle rows are untouched.

## The a11y wart this removes

The Server Shield cards rendered `<label class="text-sm font-semibold">` with **no `for` and wrapping no control** — meaningless to a screen reader. Worse, on `StaffPingCard` the `Toggle` beside it already carries that same text as its `aria-label`, so it was announced twice and associated with nothing.

`SettingRow` uses `<p>` and leaves the accessible name to the control, which is what `ToggleRow` was already doing correctly.

## Flagged, not fixed

`Components::NumberStepper` has **no accessible name at all** — no `label:`, no `aria-label`, just a bare `input`. That's unchanged by this PR (the old `<label>` wasn't associated with it either, so nothing regressed), but it's a real gap. It belongs in the deferred a11y pass rather than smuggled in here.

## Verification

`bundle exec rspec` **3002 examples / 0 failures** (2997 + 5 new `SettingRow` examples) · `standardrb` clean · `rake active_record_doctor` clean · `undercover --compare origin/main` clean.

The existing `ToggleRow` / `ToggleCard` / moderation component specs are untouched and still pass, which is the check that the five unchanged rows really are unchanged.

`docs/design/design-system.md` records it as the only row treatment, with the `<p>`-not-`<label>` reasoning.

> Two pages change appearance, so this one wants your eyes — no browser here.