### PR TITLE
Drop the logging copy nothing renders

### DIFF
--- a/config/locales/operations.en.yml
+++ b/config/locales/operations.en.yml
@@ -2,9 +2,6 @@
 en:
   operations:
     logging:
-      channel_public_warning: This channel is visible to @everyone; mod-action logs
-        would be public.
-      channel_required: A channel is required.
       moderation_dependency: can't be turned off or lose its channel while Server
         Shield is enabled
     moderation:


### PR DESCRIPTION
`i18n` has failed on `main` since #258. Two `operations.logging` keys have no caller:

```
$ bundle exec i18n-tasks unused
| en | operations.logging.channel_public_warning | This channel is visible to @everyone; mod-action logs would be public. |
| en | operations.logging.channel_required       | A channel is required.                                                 |
```

Both belonged to the uncalled draft operation that #258 discarded when `Ops::Logging::Settings::Update` took over the real behaviour, so neither is the live string. The public-channel warning users see is `web.en.yml`'s `channel.visible_warning`, rendered by `Components::Logging::ConfigForm` and toggled by the `channel-warning` Stimulus controller. The blank-channel guard was never on the surviving path either. The operation that shipped blocks only losing the channel while Server Shield is enabled, which is `moderation_dependency`.

With both keys deleted, `i18n-tasks missing`, `unused` and `check-normalized` pass. `rspec` reports 2987 examples, 0 failures. `standardrb` is clean.

`audit_ruby_deps` also fails on `main`. #267 fixes that one.