### PR TITLE
Bump mail to 2.9.1 for GHSA-mvxr-6m87-mv2q

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,7 +261,7 @@ GEM
     loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    mail (2.9.0)
+    mail (2.9.1)
       logger
       mini_mime (>= 0.1.1)
       net-imap
@@ -732,7 +732,7 @@ CHECKSUMS
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   loofah (2.25.2) sha256=2007f746959ac65552456e04b433e83deb22759ab38c838b4445c70e43425918
-  mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
+  mail (2.9.1) sha256=06574eca475253d6c18145dd70af80d0eb970182d55053497c5f4d797ea160e8
   marcel (1.2.1) sha256=1678e9360e32f9eafa917c80029e2f6d10b2715c66a4b87b6d0da9b9cd1f859f
   mime-types (3.7.0) sha256=dcebf61c246f08e15a4de34e386ebe8233791e868564a470c3fe77c00eed5e56
   mime-types-data (3.2026.0414) sha256=461c4c655373a44bd6c5fe54bcf5b7776026ea96e808144b1ec465c4b99148cc


### PR DESCRIPTION
`audit_ruby_deps` fails on `main`. It runs only on `main` and on the nightly schedule, so no PR check catches this:

```
$ bin/bundler-audit
Name: mail
Version: 2.9.0
GHSA: GHSA-mvxr-6m87-mv2q
Criticality: Medium
Title: Email address spoofing via malformed RFC 2047 encoded-words in mail
Solution: update to '>= 2.9.1'
```

Malformed encoded-words decode so that a sender can fake the visible address. 2.9.1 fixes the decoder.

The update is conservative, so the lockfile moves `mail` from 2.9.0 to 2.9.1 and nothing else. Upstream ships two changes in the release: the Q- and B-encoding decode fix ([#1664](https://github.com/mikel/mail/pull/1664)) and a CI matrix addition. Nothing in the app uses ActionMailer, so `mail` is present only because the Rails stack depends on it.

`bin/bundler-audit` now reports no vulnerabilities. `rspec` reports 2987 examples, 0 failures. `standardrb` is clean.

The `i18n` check on this PR is red because this branch starts from `main`, which is red. #266 fixes it. Merge #266 first and this one goes green on the next run.