### PR TITLE
Call the logging settings association by its current name

### DIFF
--- a/spec/requests/logging_config_spec.rb
+++ b/spec/requests/logging_config_spec.rb
@@ -79,9 +79,9 @@ RSpec.describe "Logging config", type: :request do
 
         context "when the plugin is enabled but its channel is gone" do
           before do
-            config.logging_setting.update!(channel_id: 200)
+            config.logging_settings.update!(channel_id: 200)
             create(:plugin_activation, server_configuration: config, plugin: logging, enabled: true)
-            config.logging_setting.update_column(:channel_id, nil)
+            config.logging_settings.update_column(:channel_id, nil)
             get server_path(guild.id)
           end
 


### PR DESCRIPTION
CI on `main` is red. One example fails:

```
1) Logging config ... warns that the configured channel was deleted
   Failure/Error: config.logging_setting.update!(channel_id: 200)
   NoMethodError:
     undefined method 'logging_setting' for an instance of ServerConfiguration
2988 examples, 1 failure
```

`8473e9f` renamed the association to `logging_settings` and updated every caller. `cf1b83c` branched off before that commit and added two fresh calls to `config.logging_setting`. Git found no textual conflict, both branches passed CI on their own bases, and the merge broke the suite. This renames the two calls.

Gates on this branch: 2988 examples, 0 failures. standardrb, active_record_doctor and undercover are clean.
