### PR TITLE
Write the refactor series' rules into docs

### DIFF
--- a/docs/architecture/operations-layer.md
+++ b/docs/architecture/operations-layer.md
@@ -17,6 +17,30 @@ and the web app, so a given mutation is written once and called from both.
 - Operations run inside the caller's connection context (web request, or the bot's
   `with_connection` wrapper) and wrap their writes in a transaction.
 
+## Naming
+
+The namespace is how you find an operation, so it follows rules rather than taste.
+
+- **The verb is CRUD**: `Create`, `Update`, `Destroy` (plus the domain verbs that
+  genuinely aren't CRUD — `Sync`, `Reconcile`, `Ensure`). A bespoke verb like
+  `Configure` reads as a *different* thing from the CRUD name, which is how three
+  plugins ended up with the real behaviour in `Ops::<Plugin>::Configure` and an
+  uncalled draft under `Ops::<Plugin>::Settings::Update`.
+- **One namespace per table.** `Ops::ServerConfiguration::Channels` and
+  `::ServerChannels` both wrote `server_channels`; the op is named for the model it
+  mutates, so `ServerChannels` won and the other directory went away.
+- **Model-named domains are singular**, matching the constant they mirror:
+  `Ops::User`, `Ops::Notification`, `Ops::BotSetting`, `Ops::ServerConfiguration`.
+  The plural was accidentally hiding the shadowing trap below.
+- **Plugin-named domains keep the plugin's own spelling** — `Ops::Roles`,
+  `Ops::Welcomes`, `Ops::Reminders`, `Ops::Logging` match `app/plugins/<name>/` and
+  are not model names.
+- **A resource segment carries the plurality the resource actually has.**
+  `Ops::Roles::Messages` posts several; `Ops::Lfg::Message` posts one. That is
+  meaning, not inconsistency.
+- **Two verbs for one job is a naming bug**, even when both are CRUD-shaped —
+  `Ops::Notification::Read` (one) beside `MarkRead` (many) is on the backlog.
+
 ## The shadowing trap
 
 Namespacing an operation under a module named after a model **shadows that model

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -187,6 +187,17 @@ warning or a limitation before the thing it applies to.
 pretending to explain, fake-strong verbs, binary contrasts, colon reveals,
 summary-recap endings, decorative em dashes.
 
+**A refactor body owes two things, and they come first in the budget.** One: the
+invariant and the check that proves it - example counts with the delta accounted
+for, or the constant that no longer resolves. Two: a "deliberately not done"
+line naming what you found, left, and recorded, so the omissions read as
+decisions. When one PR is based on another, name the base branch in line one.
+
+Everything else is what gets cut to fit. Before/after tables, a tour of the old
+code, and a recap of the reasoning are the first to go: the diff carries them.
+The budget is not waived for a large refactor. A long body means the change
+should have been more than one PR.
+
 **Show, do not claim.** Paste the failing command, the error line, the test
 counts, the measured numbers. A reviewer should be able to check every claim
 without trusting the author.


### PR DESCRIPTION
#252-#266 settled rules that only ever lived in PR descriptions. Two docs, no code.

**`operations-layer.md` § Naming** carries the #258/#259/#260 rulings: CRUD verbs
over bespoke ones, one namespace per table, singular model-named domains,
plugin-named domains matching `app/plugins/`, and resource-segment plurality that
means what it says rather than an inconsistency to fix.

**`voice.md` § PR descriptions** now states that a refactor body owes the invariant
with its proving check and a line naming what was deliberately left, and that both
come first inside the 15-line budget instead of justifying an overrun. Every body
in the series broke that budget.

Deliberately not done: the rest of the extraction went into `CLAUDE.md` and
`.claude/agents/convention-reviewer.md`, both gitignored, so neither is reviewable here.

Verification: `spec/docs_toc_spec.rb` passes; `standardrb`, `rake active_record_doctor`
and `undercover --compare origin/main` are clean. No `.rb` or locale file changed.