### PR TITLE
Let the plugin marquee be scrolled by hand

### DIFF
--- a/app/assets/tailwind/utilities.css
+++ b/app/assets/tailwind/utilities.css
@@ -117,8 +117,14 @@ details:has(.dropdown-menu.is-closing) .dropdown-chevron { transform: rotate(0de
 [data-theme="dark"] .theme-morph .theme-moon { opacity: 0; transform: rotate(90deg) scale(0.4); }
 
 .plugin-marquee {
-  overflow: hidden;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
   mask-image: linear-gradient(to right, transparent, black 8%, black 92%, transparent);
+}
+
+.plugin-marquee::-webkit-scrollbar {
+  display: none;
 }
 
 .plugin-marquee-track {
@@ -139,8 +145,12 @@ details:has(.dropdown-menu.is-closing) .dropdown-chevron { transform: rotate(0de
 
 @media (prefers-reduced-motion: reduce) {
   .plugin-marquee {
-    overflow-x: auto;
+    scrollbar-width: auto;
     mask-image: none;
+  }
+
+  .plugin-marquee::-webkit-scrollbar {
+    display: block;
   }
 
   .plugin-marquee-track {

--- a/app/javascript/controllers/marquee_controller.js
+++ b/app/javascript/controllers/marquee_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  scroll(event) {
+    event.preventDefault()
+
+    const loop = this.element.scrollWidth / 2
+    const next = this.element.scrollLeft + event.deltaY + event.deltaX
+
+    this.element.scrollLeft = ((next % loop) + loop) % loop
+  }
+}

--- a/app/views/home.rb
+++ b/app/views/home.rb
@@ -74,7 +74,13 @@ class Views::Home < Views::Base
   def plugin_showcase
     section(class: "mx-auto max-w-4xl px-6 pb-20") do
       p(class: "mb-5 text-[11px] font-semibold uppercase tracking-widest text-eyebrow") { t(".plugins_eyebrow") }
-      div(class: "plugin-marquee") do
+      div(
+        class: "plugin-marquee",
+        data: {
+          controller: "marquee",
+          action: "wheel->marquee#scroll:!passive"
+        }
+      ) do
         div(class: "plugin-marquee-track") do
           plugin_cards
           plugin_cards(decorative: true)


### PR DESCRIPTION
A user reported that the plugin marquee on the landing page cannot be sped up. Hover paused it, and nothing moved it.

`.plugin-marquee` becomes `overflow-x: auto` with a hidden scrollbar, and a Stimulus controller maps a wheel over it to `scrollLeft`. The offset wraps at half the track width, where the duplicated card row repeats, so the scroll has no end. Hover still pauses the animation.

Warning: while the pointer is over the banner, the wheel no longer scrolls the page. The handler always consumes the event, because the wrap means the banner is never at an end. I chose that trade deliberately; say so if you want the capture limited to horizontal wheel deltas.

Touch gets horizontal drag for free from `overflow-x: auto`, which the old `overflow: hidden` blocked. The drag does not wrap, so a long drag reaches the end of the duplicated row.

Under `prefers-reduced-motion` the scrollbar stays visible, because no animation runs there to show that the row moves.

Deliberately not done: no wrap for touch drag and no keyboard access to the region. Both are recorded in `BUILD_PLAN.md`.

Gates: `rspec` 2992 examples, 0 failures. `standardrb`, `active_record_doctor`, `undercover --compare origin/main` all clean.
