### PR TITLE
Seed the web debug harness through the ensure operation

### DIFF
--- a/config/initializers/web_debug.rb
+++ b/config/initializers/web_debug.rb
@@ -25,17 +25,14 @@ if ENV["WEB_DEBUG"] && Rails.env.development?
   end
 
   Rails.application.config.after_initialize do
-    config = ServerConfiguration.find_or_create_by!(discord_id: 900_000_001)
-    %w[logging moderation spam_protection image_scanning].each do |key|
-      plugin = Plugin.find_or_create_by!(key:) do |record|
-        record.name = key.humanize
+    PluginCatalog.all.each do |definition|
+      Plugin.find_or_create_by!(key: definition.key) do |record|
+        record.name = definition.name
+        record.description = definition.description
       end
-      PluginActivation.find_or_create_by!(server_configuration: config, plugin:)
     end
-    config.create_logging_settings!(channel_id: 111) unless config.logging_settings
-    config.create_moderation_settings! unless config.moderation_settings
-    config.create_spam_protection_settings! unless config.spam_protection_settings
-    config.create_image_scanning_settings! unless config.image_scanning_settings
+    config = Ops::ServerConfiguration::Ensure.call(discord_id: 900_000_001).value
+    config.logging_settings.update!(channel_id: 111) unless config.logging_settings.channel_id
     unless config.server_roles.exists?(discord_id: 500)
       config.server_roles.create!(discord_id: 500, name: "Moderator", color: 0xE67E22, position: 1)
     end

--- a/docs/running/web-debug-harness.md
+++ b/docs/running/web-debug-harness.md
@@ -18,9 +18,9 @@ production. On boot it:
 - puts OmniAuth in test mode with a mock Discord identity (uid `12345`),
 - stubs `Bot::Discord::UserGuilds.call` to return one fixture guild
   (`Dev Refuge`, id `900000001`, owner),
-- idempotently seeds that guild: server configuration, the four plugin rows +
-  activations (all disabled), settings rows, a `Moderator` role (id 500) and a
-  `#mod-log` channel (id 111).
+- idempotently seeds that guild via `Ops::ServerConfiguration::Ensure` — a plugin
+  row per `PluginCatalog` definition, activations (all disabled) and every settings
+  row — plus a `Moderator` role (id 500) and a `#mod-log` channel (id 111).
 
 The seed never toggles state back — flip things in the UI or via `bin/rails runner`.
 


### PR DESCRIPTION
`/servers/:id/welcomes`, `/roles` and `/lfg` return 500 under `bin/web-debug`:
`NoMethodError (undefined method 'channel_id' for nil)` at
`app/components/welcomes/config_form.rb:30`. The initializer seeded four plugins
and four settings rows by hand, and the three later plugins never reached it.

`Ops::ServerConfiguration::Ensure` already creates every row for a real guild, so
the harness calls it instead. The fixture guild now matches production and the seed
cannot drift when the next plugin lands.

I swept all 29 GET pages that work without a Discord network. Zero 500s after the
change. The remaining non-200s are authorization redirects: `/` to `/servers`,
`/admin/*` for a non-admin user, `/servers/:id/twilight_struggle` without a grant.

Deliberately not done: `Servers::RolesController#preload_role_sets` passes
`[role_setting]` to the preloader with no nil guard. `Ensure` guarantees the row.