### PR TITLE
Stop chowning the storage directory that no longer exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ This project follows [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+## [3.8.1] - 2026-08-19
+
+### Fixed
+- The production image does not build in 3.8.0. That release dropped Active Storage, which removed the `storage` directory from the repository, but the Dockerfile still changed that directory's owner, so the build stopped with `chown: cannot access 'storage': No such file or directory`. This affects self-hosting only; the hosted bot is unaffected. ([#273](https://github.com/badBlackShark/shrkbot/pull/273))
+
 ## [3.8.0] - 2026-08-19
 
 ### Added

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -38,7 +38,7 @@ COPY --from=build /rails /rails
 
 RUN groupadd --system --gid 1000 rails && \
     useradd rails --uid 1000 --gid 1000 --create-home --shell /bin/bash && \
-    chown -R rails:rails db log storage tmp
+    chown -R rails:rails db log tmp
 USER 1000:1000
 
 ENTRYPOINT ["/rails/bin/docker-entrypoint"]


### PR DESCRIPTION
`Dockerfile.prod` fails at the final `chown`:

```
chown: cannot access 'storage': No such file or directory
```

b13c61e (#252) dropped Active Storage, which took `storage/.keep` with it. That was the only thing keeping the directory in the build context, and nothing in the build stage recreates it. It is absent from a fresh clone, not only from my sandbox:

```
$ git ls-tree origin/main storage
(no output)
```

`db`, `log` and `tmp` all survive: `log/.keep` and `tmp/.keep` are tracked, and `assets:precompile` writes into `tmp` before this line runs. `storage` is the only remaining reference in the repository:

```
$ grep -rn 'storage' --include='Dockerfile*' .
Dockerfile.prod:41:    chown -R rails:rails db log storage tmp
```

Also here: a 3.8.1 changelog entry. The break shipped in 3.8.0, and a self-hoster cannot build that tag, so it is user-facing rather than tooling.

I cannot verify the build here: there is no docker in the sandbox. The deploy is the check.

Deliberately not done: `main` has not built since #252 merged, because no gate builds the image. A `docker build -f Dockerfile.prod` step in CI is the fix and is its own change. Recorded in `BUILD_PLAN.md`.