### PR TITLE
Build the production image on release candidates

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -9,6 +9,7 @@ on:
       - CHANGELOG.md
       - Dockerfile.prod
       - .dockerignore
+      - .github/workflows/release-image.yml
 
 permissions:
   contents: read

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,0 +1,27 @@
+name: Release image
+
+on:
+  pull_request:
+    # Only release candidates and changes to the image itself. A full image
+    # build on every PR costs more CI time than it catches; a break only has
+    # to be caught before it ships.
+    paths:
+      - CHANGELOG.md
+      - Dockerfile.prod
+      - .dockerignore
+
+permissions:
+  contents: read
+
+jobs:
+  build_production_image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Build the production image
+        run: docker build --file Dockerfile.prod --tag shrkbot:${{ github.sha }} .

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -33,6 +33,8 @@ bounds, the numbers that made the bug bite. The prose is held to website
 standard, because the release page is public and read by people who never see
 the repository. So: full sentences, no shorthand, no internal class or constant
 names, and one bullet that reads on its own without the diff beside it.
+The GitHub release title takes the same ` - ` joiner as every other surface.
+Releases up to 3.8.1 used an em dash and are left as a record.
 
 ## Rules for every surface
 


### PR DESCRIPTION
#273 was a one-line Dockerfile break that sat on `main` for two weeks and surfaced as a failed `kamal deploy`. Nothing builds the image, so nothing could have caught it.

This builds `Dockerfile.prod` on any PR that touches `CHANGELOG.md`, `Dockerfile.prod` or `.dockerignore`. A changelog entry is what makes a PR a release candidate, so no label or flag has to be remembered, and both release PRs so far (#272, #273) would have run it. The other two paths catch a break in the PR that causes it rather than at the next release.

Build only. No push, no registry credentials, no secrets: the Dockerfile needs none, and `assets:precompile` already runs under `SECRET_KEY_BASE_DUMMY=1`.

Deliberately not done: no build cache. The job runs a few times per month, so a cold build is cheaper than the configuration. Add one if the runtime starts to bite.

Also here, one line in `docs/voice.md`: a release title takes the ` - ` joiner like every other surface. 3.8.0 and 3.8.1 shipped with an em dash and are left as they are.

I cannot run this here; there is no docker in the sandbox. The check itself is the verification, on this PR.