### PR TITLE
Recognise a closed tournament whatever its capitalisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project follows [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+- A Twilight Struggle tournament sent to us with the status `Closed` is treated as closed. The check compared against the exact lowercase text `closed`, so a site that capitalises its status names left every finished tournament in the active part of the subscription list, with no closed badge and no way to tidy it away. The comparison now ignores capitalisation and surrounding spaces. `Registration Closed` still counts as open, and the API reference says so. ([#275](https://github.com/badBlackShark/shrkbot/pull/275))
+
 ## [3.8.1] - 2026-08-19
 
 ### Fixed

--- a/app/models/twilight_struggle/tournament.rb
+++ b/app/models/twilight_struggle/tournament.rb
@@ -20,7 +20,7 @@ module TwilightStruggle
     validate :parent_chain_must_not_cycle
 
     def closed_upstream?
-      status == CLOSED_STATUS
+      status.present? && status.strip.casecmp?(CLOSED_STATUS)
     end
 
     def chain

--- a/config/api/twilight-struggle/v1/docs/tournaments.md
+++ b/config/api/twilight-struggle/v1/docs/tournaments.md
@@ -7,6 +7,18 @@ tournament. A server that subscribes to a parent receives the results of every
 tournament below it, and configuration (channel, message templates) is inherited
 down the chain unless a level overrides it.
 
+### Status
+
+`status` is free text. We store it and give it back unchanged. One value changes
+what shrkbot does. When you send `closed`, in any capitalisation and with or
+without surrounding spaces, the tournament moves into the archived part of a
+server's subscription list on the dashboard and carries a closed badge there.
+
+That is the whole effect. A closed tournament still accepts games and still posts
+their results to any subscribed channel, and a server's configuration for it is
+untouched. Every other value is inert, so `Registration Closed` is not a closed
+tournament.
+
 ### Organisers
 
 An organiser whose Discord ID we hold can reach the Twilight Struggle plugin on

--- a/config/api/twilight-struggle/v1/tournaments.yaml
+++ b/config/api/twilight-struggle/v1/tournaments.yaml
@@ -71,7 +71,13 @@ components:
           example: "otsl"
         status:
           type: string
-          description: Free text. We store it; nothing in shrkbot interprets it.
+          description: >-
+            Free text, stored and shown back to you exactly as you send it. One
+            value changes what we do. When the status is `closed`, in any
+            capitalisation and ignoring surrounding spaces, the tournament moves
+            to the archived part of a server's subscription list and carries a
+            closed badge there. Every other value is inert, `Registration Closed`
+            included.
           example: "closed"
         admins:
           type: array

--- a/spec/models/twilight_struggle/tournament_spec.rb
+++ b/spec/models/twilight_struggle/tournament_spec.rb
@@ -72,6 +72,28 @@ RSpec.describe TwilightStruggle::Tournament do
     end
   end
 
+  describe "#closed_upstream?" do
+    subject(:closed_upstream) { tournament.closed_upstream? }
+
+    let(:tournament) { build(:twilight_struggle_tournament, status:) }
+
+    ["closed", "Closed", "CLOSED", "  Closed  "].each do |value|
+      context "when the status is #{value.inspect}" do
+        let(:status) { value }
+
+        it { is_expected.to be true }
+      end
+    end
+
+    ["Registration Closed", "Ongoing", "", nil].each do |value|
+      context "when the status is #{value.inspect}" do
+        let(:status) { value }
+
+        it { is_expected.to be false }
+      end
+    end
+  end
+
   describe "#chain" do
     let(:grandparent) { create(:twilight_struggle_tournament) }
     let(:parent) { create(:twilight_struggle_tournament, parent: grandparent) }


### PR DESCRIPTION
Closing a tournament on the Twilight Struggle site did nothing here. `closed_upstream?` compared the status against the exact lowercase text `closed`, and the site sends the status name from its own table, which reads `Closed`. So a finished tournament stayed in the active part of the subscription list, with no badge and no way to tidy it away.

The comparison now ignores capitalisation and surrounding spaces. It stays an exact match rather than a substring one, because the same site has a `Registration Closed` status that must count as open.

`tournaments.yaml` told integrators that "nothing in shrkbot interprets" the status. That stopped being true when `closed_upstream?` started reading it, so the OpenAPI description and `docs/tournaments.md` now say which value acts and what it does. `docs/tournaments.md` also says what closing does not do. A closed tournament still accepts games and still posts results.

`closed_upstream?` had no spec of its own. It has eight, which takes the suite from 3000 examples to 3008. Two mutation checks back them. Restoring `==` fails the three capitalised cases and nothing else, and a substring match fails `Registration Closed` alone.

Checked against a running site and bot. A tournament closed through the site's own UI flipped `closed_upstream?` from false to true, and moving it to `Registration Closed` put it back to false.
