### PR TITLE
Cut release 3.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ refactors, tooling, and CI changes are omitted; see the git history for those.
 
 This project follows [Semantic Versioning](https://semver.org).
 
-## [Unreleased]
+## [3.8.2] - 2026-08-20
 
 ### Fixed
-- A Twilight Struggle tournament sent to us with the status `Closed` is treated as closed. The check compared against the exact lowercase text `closed`, so a site that capitalises its status names left every finished tournament in the active part of the subscription list, with no closed badge and no way to tidy it away. The comparison now ignores capitalisation and surrounding spaces. `Registration Closed` still counts as open, and the API reference says so. ([#275](https://github.com/badBlackShark/shrkbot/pull/275))
+- A Twilight Struggle tournament sent with the status `Closed` is treated as closed. The check compared against the exact lowercase text `closed`. A site that capitalises its status names left every finished tournament in the active part of the subscription list. It carried no closed badge, and there was no way to tidy it away. The check now ignores capitalisation and surrounding spaces. `Registration Closed` still counts as open, and the API reference says so. ([#275](https://github.com/badBlackShark/shrkbot/pull/275))
 
 ## [3.8.1] - 2026-08-19
 


### PR DESCRIPTION
3.8.2 is a patch. One user-facing change landed since 3.8.1: the Twilight Struggle tournament status fix (#275), which was already written into the changelog under `[Unreleased]`. This promotes that section to `## [3.8.2] - 2026-08-20`.

The other merge since 3.8.1 (#274, build the production image on release candidates) is CI only, so it gets no entry.

Three edits to the bullet, all from `docs/voice.md`: "sent to us" became "sent", because shrkbot is one developer and never "we"; the 45-word middle sentence became two, under the 25-word descriptive limit; and "comparison" became "check", so one term names one thing.

Changelog only, so there is nothing to run. The release body is this section verbatim, tagged after merge.